### PR TITLE
feat(kit): real Cookies impl with secure defaults

### DIFF
--- a/packages/sveltego/exports/kit/cookies.go
+++ b/packages/sveltego/exports/kit/cookies.go
@@ -5,70 +5,129 @@ import (
 	"time"
 )
 
-// Cookies is the request/response cookie jar surface. The full
-// implementation lands with issue #28 in v0.2; for MVP this exists so
-// codegen output and user route code referencing kit.Cookies compiles.
-// All methods are stubs returning zero values.
-type Cookies struct{}
-
-// Get returns the cookie value for name, or "" if absent. MVP stub:
-// always returns "".
-func (c *Cookies) Get(_ string) string {
-	return ""
-}
-
-// Set queues a Set-Cookie header. MVP stub: no-op.
-func (c *Cookies) Set(_, _ string, _ ...CookieOption) {}
-
-// Delete queues a Set-Cookie clear for name. MVP stub: no-op.
-func (c *Cookies) Delete(_ string) {}
-
-// CookieOption configures Set behavior. MVP stub: option constructors
-// produce functions that mutate cookieOpts but the jar does not yet
-// consume those values.
-type CookieOption func(*cookieOpts)
-
-type cookieOpts struct {
+// CookieOpts configures a Set-Cookie. Zero values mean "use defaults":
+// Path defaults to "/", SameSite to Lax, Secure follows the request
+// scheme (true for HTTPS), HttpOnly is true unless explicitly false via
+// SetExposed or by passing a non-nil pointer to false.
+type CookieOpts struct {
 	Path     string
 	Domain   string
-	MaxAge   int
-	Secure   bool
-	HTTPOnly bool
-	SameSite http.SameSite
+	MaxAge   time.Duration
 	Expires  time.Time
+	HttpOnly *bool
+	Secure   *bool
+	SameSite http.SameSite
 }
 
-// Path sets the Path attribute. MVP stub: stored but unused.
-func Path(p string) CookieOption {
-	return func(o *cookieOpts) { o.Path = p }
+// Cookies is the request/response cookie jar threaded through LoadCtx
+// and RenderCtx. Reads pull from the incoming request; writes accumulate
+// in an outgoing queue flushed to the response by Apply before the
+// pipeline calls WriteHeader.
+type Cookies struct {
+	in    map[string]string
+	out   []*http.Cookie
+	https bool
 }
 
-// Domain sets the Domain attribute. MVP stub: stored but unused.
-func Domain(d string) CookieOption {
-	return func(o *cookieOpts) { o.Domain = d }
+// NewCookies builds a Cookies jar seeded with the request's incoming
+// cookies. Secure defaults are inferred from r.TLS. A nil request is
+// tolerated and yields an empty jar with Secure defaulting to false.
+func NewCookies(r *http.Request) *Cookies {
+	c := &Cookies{in: map[string]string{}}
+	if r == nil {
+		return c
+	}
+	c.https = r.TLS != nil
+	for _, ck := range r.Cookies() {
+		c.in[ck.Name] = ck.Value
+	}
+	return c
 }
 
-// MaxAge sets the Max-Age attribute in seconds. MVP stub: stored but unused.
-func MaxAge(seconds int) CookieOption {
-	return func(o *cookieOpts) { o.MaxAge = seconds }
+// Get returns the incoming cookie value for name and ok=true if
+// present. Outgoing Sets do not affect Get.
+func (c *Cookies) Get(name string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	v, ok := c.in[name]
+	return v, ok
 }
 
-// Secure sets the Secure flag. MVP stub: stored but unused.
-func Secure() CookieOption {
-	return func(o *cookieOpts) { o.Secure = true }
+// Set queues a Set-Cookie for name=value with secure defaults applied
+// (HttpOnly=true, SameSite=Lax, Path="/", Secure=request-scheme).
+func (c *Cookies) Set(name, value string, opts CookieOpts) {
+	if c == nil {
+		return
+	}
+	c.out = append(c.out, c.build(name, value, opts, true))
 }
 
-// HTTPOnly sets the HttpOnly flag. MVP stub: stored but unused.
-func HTTPOnly() CookieOption {
-	return func(o *cookieOpts) { o.HTTPOnly = true }
+// SetExposed queues a Set-Cookie like Set but defaults HttpOnly to
+// false so client-side JS can read it. Caller can still explicitly set
+// HttpOnly=true in opts to override.
+func (c *Cookies) SetExposed(name, value string, opts CookieOpts) {
+	if c == nil {
+		return
+	}
+	c.out = append(c.out, c.build(name, value, opts, false))
 }
 
-// SameSite sets the SameSite attribute. MVP stub: stored but unused.
-func SameSite(s http.SameSite) CookieOption {
-	return func(o *cookieOpts) { o.SameSite = s }
+// Delete queues a Set-Cookie that clears name on the client by emitting
+// MaxAge=-1 and Expires=epoch. Path/Domain in opts must match the path
+// the cookie was originally set at; Path defaults to "/".
+func (c *Cookies) Delete(name string, opts CookieOpts) {
+	if c == nil {
+		return
+	}
+	if opts.Path == "" {
+		opts.Path = "/"
+	}
+	c.out = append(c.out, &http.Cookie{
+		Name:    name,
+		Value:   "",
+		Path:    opts.Path,
+		Domain:  opts.Domain,
+		MaxAge:  -1,
+		Expires: time.Unix(0, 0),
+	})
 }
 
-// Expires sets the Expires attribute. MVP stub: stored but unused.
-func Expires(t time.Time) CookieOption {
-	return func(o *cookieOpts) { o.Expires = t }
+// Apply writes every queued Set-Cookie header to w. Safe to call before
+// WriteHeader; emits one header per cookie.
+func (c *Cookies) Apply(w http.ResponseWriter) {
+	if c == nil || w == nil {
+		return
+	}
+	for _, ck := range c.out {
+		http.SetCookie(w, ck)
+	}
+}
+
+func (c *Cookies) build(name, value string, opts CookieOpts, httpOnlyDefault bool) *http.Cookie {
+	if opts.Path == "" {
+		opts.Path = "/"
+	}
+	if opts.SameSite == 0 {
+		opts.SameSite = http.SameSiteLaxMode
+	}
+	secure := c.https
+	if opts.Secure != nil {
+		secure = *opts.Secure
+	}
+	httpOnly := httpOnlyDefault
+	if opts.HttpOnly != nil {
+		httpOnly = *opts.HttpOnly
+	}
+	return &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     opts.Path,
+		Domain:   opts.Domain,
+		MaxAge:   int(opts.MaxAge.Seconds()),
+		Expires:  opts.Expires,
+		Secure:   secure,
+		HttpOnly: httpOnly,
+		SameSite: opts.SameSite,
+	}
 }

--- a/packages/sveltego/exports/kit/cookies_test.go
+++ b/packages/sveltego/exports/kit/cookies_test.go
@@ -1,0 +1,218 @@
+package kit_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+func ptrBool(b bool) *bool { return &b }
+
+func TestCookies_Get_ReadsIncoming(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "abc"})
+	c := kit.NewCookies(req)
+
+	v, ok := c.Get("session")
+	if !ok || v != "abc" {
+		t.Errorf("Get(session) = (%q,%v), want (abc,true)", v, ok)
+	}
+	if _, ok := c.Get("missing"); ok {
+		t.Error("Get(missing) ok=true, want false")
+	}
+}
+
+func TestCookies_Set_DefaultsApplied(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := kit.NewCookies(req)
+	c.Set("k", "v", kit.CookieOpts{})
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+	got := rw.Header().Get("Set-Cookie")
+
+	wants := []string{"k=v", "Path=/", "HttpOnly", "SameSite=Lax"}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("Set-Cookie %q missing %q", got, w)
+		}
+	}
+	if strings.Contains(got, "Secure") {
+		t.Errorf("Set-Cookie %q should not have Secure for plain HTTP", got)
+	}
+}
+
+func TestCookies_Set_SecureFromTLS(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+	c := kit.NewCookies(req)
+	c.Set("k", "v", kit.CookieOpts{})
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+	got := rw.Header().Get("Set-Cookie")
+
+	if !strings.Contains(got, "Secure") {
+		t.Errorf("Set-Cookie %q missing Secure on HTTPS", got)
+	}
+}
+
+func TestCookies_Set_ExplicitOptsWin(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+	c := kit.NewCookies(req)
+	c.Set("k", "v", kit.CookieOpts{
+		Path:     "/admin",
+		Domain:   "example.com",
+		MaxAge:   2 * time.Hour,
+		HttpOnly: ptrBool(false),
+		Secure:   ptrBool(false),
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+	got := rw.Header().Get("Set-Cookie")
+
+	wants := []string{"k=v", "Path=/admin", "Domain=example.com", "Max-Age=7200", "SameSite=Strict"}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("Set-Cookie %q missing %q", got, w)
+		}
+	}
+	if strings.Contains(got, "HttpOnly") {
+		t.Errorf("Set-Cookie %q has HttpOnly when explicitly disabled", got)
+	}
+	if strings.Contains(got, "Secure") {
+		t.Errorf("Set-Cookie %q has Secure when explicitly disabled", got)
+	}
+}
+
+func TestCookies_SetExposed_DefaultNoHttpOnly(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := kit.NewCookies(req)
+	c.SetExposed("ui-pref", "dark", kit.CookieOpts{})
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+	got := rw.Header().Get("Set-Cookie")
+
+	if strings.Contains(got, "HttpOnly") {
+		t.Errorf("SetExposed Set-Cookie %q should not have HttpOnly", got)
+	}
+}
+
+func TestCookies_SetExposed_HttpOnlyOverride(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := kit.NewCookies(req)
+	c.SetExposed("k", "v", kit.CookieOpts{HttpOnly: ptrBool(true)})
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+	got := rw.Header().Get("Set-Cookie")
+
+	if !strings.Contains(got, "HttpOnly") {
+		t.Errorf("SetExposed with HttpOnly=true missing HttpOnly: %q", got)
+	}
+}
+
+func TestCookies_Multiple_SeparateHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := kit.NewCookies(req)
+	c.Set("a", "1", kit.CookieOpts{})
+	c.Set("b", "2", kit.CookieOpts{})
+	c.Set("c", "3", kit.CookieOpts{})
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+
+	hdrs := rw.Header().Values("Set-Cookie")
+	if len(hdrs) != 3 {
+		t.Fatalf("Set-Cookie count = %d, want 3", len(hdrs))
+	}
+	for i, name := range []string{"a=1", "b=2", "c=3"} {
+		if !strings.Contains(hdrs[i], name) {
+			t.Errorf("hdr[%d] %q missing %q", i, hdrs[i], name)
+		}
+	}
+}
+
+func TestCookies_Delete_EmitsExpired(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := kit.NewCookies(req)
+	c.Delete("session", kit.CookieOpts{})
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+	got := rw.Header().Get("Set-Cookie")
+
+	wants := []string{"session=", "Path=/", "Max-Age=0"}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("Delete Set-Cookie %q missing %q", got, w)
+		}
+	}
+}
+
+func TestCookies_Delete_RoundTrip(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "abc"})
+	c := kit.NewCookies(req)
+
+	if v, ok := c.Get("session"); !ok || v != "abc" {
+		t.Fatalf("seed Get = (%q,%v)", v, ok)
+	}
+	c.Delete("session", kit.CookieOpts{Path: "/admin", Domain: "example.com"})
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+	got := rw.Header().Get("Set-Cookie")
+
+	if !strings.Contains(got, "Path=/admin") {
+		t.Errorf("Delete didn't honor opts.Path: %q", got)
+	}
+	if !strings.Contains(got, "Domain=example.com") {
+		t.Errorf("Delete didn't honor opts.Domain: %q", got)
+	}
+}
+
+func TestCookies_Apply_NoCookiesNoHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := kit.NewCookies(req)
+
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+
+	if hdrs := rw.Header().Values("Set-Cookie"); len(hdrs) != 0 {
+		t.Errorf("Set-Cookie count = %d, want 0", len(hdrs))
+	}
+}
+
+func TestCookies_NilSafe(t *testing.T) {
+	var c *kit.Cookies
+	if v, ok := c.Get("x"); ok || v != "" {
+		t.Errorf("nil Get = (%q,%v)", v, ok)
+	}
+	c.Set("x", "y", kit.CookieOpts{})
+	c.SetExposed("x", "y", kit.CookieOpts{})
+	c.Delete("x", kit.CookieOpts{})
+	c.Apply(httptest.NewRecorder())
+}
+
+func TestCookies_NewCookies_NilRequest(t *testing.T) {
+	c := kit.NewCookies(nil)
+	if c == nil {
+		t.Fatal("NewCookies(nil) = nil, want non-nil")
+	}
+	if _, ok := c.Get("anything"); ok {
+		t.Error("nil-request jar should have no incoming cookies")
+	}
+	c.Set("k", "v", kit.CookieOpts{})
+	rw := httptest.NewRecorder()
+	c.Apply(rw)
+	if rw.Header().Get("Set-Cookie") == "" {
+		t.Error("Set still queues when request was nil")
+	}
+}

--- a/packages/sveltego/exports/kit/ctx.go
+++ b/packages/sveltego/exports/kit/ctx.go
@@ -32,7 +32,7 @@ func NewRenderCtx(r *http.Request, w http.ResponseWriter, params map[string]stri
 	ctx := &RenderCtx{
 		Locals:  map[string]any{},
 		Params:  params,
-		Cookies: &Cookies{},
+		Cookies: NewCookies(r),
 		Request: r,
 		Writer:  w,
 	}
@@ -48,7 +48,7 @@ func NewLoadCtx(r *http.Request, params map[string]string) *LoadCtx {
 	ctx := &LoadCtx{
 		Locals:  map[string]any{},
 		Params:  params,
-		Cookies: &Cookies{},
+		Cookies: NewCookies(r),
 		Request: r,
 	}
 	if r != nil {

--- a/packages/sveltego/exports/kit/doc.go
+++ b/packages/sveltego/exports/kit/doc.go
@@ -1,6 +1,6 @@
 // Package kit is the public sveltego runtime API. Generated code and
 // user route handlers depend on this package: RenderCtx threads request
 // state through SSR templates, LoadCtx threads the same state through
-// user-written Load functions in +page.server.go, and Cookies (stub
-// until issue #28) provides the request/response cookie surface.
+// user-written Load functions in +page.server.go, and Cookies provides
+// the request/response cookie surface with secure defaults.
 package kit

--- a/packages/sveltego/exports/kit/kit_test.go
+++ b/packages/sveltego/exports/kit/kit_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/binsarjr/sveltego/exports/kit"
 )
@@ -91,57 +90,6 @@ func TestNewLoadCtx_NilRequest(t *testing.T) {
 	}
 	if ctx.Cookies == nil {
 		t.Error("Cookies = nil, want non-nil")
-	}
-}
-
-func TestCookies_GetReturnsEmpty(t *testing.T) {
-	c := &kit.Cookies{}
-	if got := c.Get("session"); got != "" {
-		t.Errorf("Get = %q, want empty", got)
-	}
-	if got := c.Get(""); got != "" {
-		t.Errorf("Get(\"\") = %q, want empty", got)
-	}
-}
-
-func TestCookies_SetNoPanic(_ *testing.T) {
-	c := &kit.Cookies{}
-	c.Set("session", "abc")
-	c.Set("session", "abc", kit.Path("/"), kit.Secure(), kit.HTTPOnly())
-}
-
-func TestCookies_DeleteNoPanic(_ *testing.T) {
-	c := &kit.Cookies{}
-	c.Delete("session")
-}
-
-func TestCookieOptions_ComposeNoPanic(_ *testing.T) {
-	c := &kit.Cookies{}
-	c.Set("k", "v",
-		kit.Path("/"),
-		kit.Domain("example.com"),
-		kit.MaxAge(3600),
-		kit.Secure(),
-		kit.HTTPOnly(),
-		kit.SameSite(http.SameSiteStrictMode),
-		kit.Expires(time.Unix(1700000000, 0)),
-	)
-}
-
-func TestCookieOptions_NonNil(t *testing.T) {
-	opts := []kit.CookieOption{
-		kit.Path("/"),
-		kit.Domain("example.com"),
-		kit.MaxAge(60),
-		kit.Secure(),
-		kit.HTTPOnly(),
-		kit.SameSite(http.SameSiteLaxMode),
-		kit.Expires(time.Now()),
-	}
-	for i, opt := range opts {
-		if opt == nil {
-			t.Errorf("option %d is nil", i)
-		}
 	}
 }
 

--- a/packages/sveltego/server/cookies_integration_test.go
+++ b/packages/sveltego/server/cookies_integration_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/render"
+	"github.com/binsarjr/sveltego/runtime/router"
+)
+
+func TestPipeline_LoadSetsCookie_AppearsInResponse(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(ctx *kit.LoadCtx) (any, error) {
+			ctx.Cookies.Set("session", "abc", kit.CookieOpts{})
+			return "ok", nil
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("<p>hi</p>")
+			return nil
+		},
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	hdrs := resp.Header.Values("Set-Cookie")
+	if len(hdrs) != 1 {
+		t.Fatalf("Set-Cookie count = %d, want 1; headers = %v", len(hdrs), hdrs)
+	}
+	got := hdrs[0]
+	for _, want := range []string{"session=abc", "Path=/", "HttpOnly", "SameSite=Lax"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Set-Cookie %q missing %q", got, want)
+		}
+	}
+}
+
+func TestPipeline_LoadSetsMultipleCookies_SeparateHeaders(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(ctx *kit.LoadCtx) (any, error) {
+			ctx.Cookies.Set("a", "1", kit.CookieOpts{})
+			ctx.Cookies.Set("b", "2", kit.CookieOpts{})
+			ctx.Cookies.SetExposed("c", "3", kit.CookieOpts{})
+			return nil, nil
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("<p>hi</p>")
+			return nil
+		},
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	hdrs := resp.Header.Values("Set-Cookie")
+	if len(hdrs) != 3 {
+		t.Fatalf("Set-Cookie count = %d, want 3; headers = %v", len(hdrs), hdrs)
+	}
+
+	combined := strings.Join(hdrs, "\n")
+	for _, want := range []string{"a=1", "b=2", "c=3"} {
+		if !strings.Contains(combined, want) {
+			t.Errorf("missing %q in headers: %v", want, hdrs)
+		}
+	}
+
+	// SetExposed must produce a cookie WITHOUT HttpOnly.
+	var exposed string
+	for _, h := range hdrs {
+		if strings.HasPrefix(h, "c=3") {
+			exposed = h
+		}
+	}
+	if exposed == "" {
+		t.Fatalf("could not find c=3 header in %v", hdrs)
+	}
+	if strings.Contains(exposed, "HttpOnly") {
+		t.Errorf("SetExposed cookie %q should not have HttpOnly", exposed)
+	}
+}
+
+func TestPipeline_LoadDeleteCookie_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(ctx *kit.LoadCtx) (any, error) {
+			if v, ok := ctx.Cookies.Get("session"); !ok || v != "abc" {
+				t.Errorf("Load Get(session) = (%q,%v), want (abc,true)", v, ok)
+			}
+			ctx.Cookies.Delete("session", kit.CookieOpts{})
+			return nil, nil
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("<p>bye</p>")
+			return nil
+		},
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "abc"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	hdrs := resp.Header.Values("Set-Cookie")
+	if len(hdrs) != 1 {
+		t.Fatalf("Set-Cookie count = %d, want 1; headers = %v", len(hdrs), hdrs)
+	}
+	got := hdrs[0]
+	for _, want := range []string{"session=", "Max-Age=0"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Delete Set-Cookie %q missing %q", got, want)
+		}
+	}
+}

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -31,7 +31,10 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var data any
+	var (
+		data    any
+		cookies *kit.Cookies
+	)
 	if route.Load != nil {
 		lctx := kit.NewLoadCtx(r, params)
 		d, err := route.Load(lctx)
@@ -40,6 +43,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		data = d
+		cookies = lctx.Cookies
 	}
 
 	buf := render.Acquire()
@@ -48,12 +52,16 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	buf.WriteString(s.shellHead)
 	buf.WriteString(s.shellMid)
 	rctx := kit.NewRenderCtx(r, w, params)
+	if cookies != nil {
+		rctx.Cookies = cookies
+	}
 	if err := route.Page(buf, rctx, data); err != nil {
 		s.handleRenderError(w, r, err)
 		return
 	}
 	buf.WriteString(s.shellTail)
 
+	rctx.Cookies.Apply(w)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- Replace MVP stub kit.Cookies with production API: `Get`/`Set`/`Delete`/`SetExposed`/`Apply`
- Secure defaults: `HttpOnly=true`, `SameSite=Lax`, `Secure` auto from `r.TLS`, `Path=/`
- Pipeline calls `Cookies.Apply(w)` before `WriteHeader` so `Set-Cookie` reaches the response

## Test plan
- [x] `cookies_test.go` 12 cases pass under `-race` (defaults, explicit override, multiple cookies, Delete round-trip, Secure inferred from r.TLS, SetExposed wins HttpOnly, nil-safe)
- [x] `cookies_integration_test.go` httptest verifies `Set-Cookie` headers appear in response with correct attrs
- [x] Playground smoke unchanged (basic compile/build/serve OK)

Closes #32