### PR TITLE
feat(kit): env accessors with PUBLIC_ prefix enforcement

### DIFF
--- a/packages/sveltego/exports/kit/env/doc.go
+++ b/packages/sveltego/exports/kit/env/doc.go
@@ -1,0 +1,18 @@
+// Package env mirrors SvelteKit's $env/static/* and $env/dynamic/*
+// namespaces with four runtime accessors: StaticPrivate, StaticPublic,
+// DynamicPrivate, and DynamicPublic. Public accessors enforce a
+// PUBLIC_ key prefix so leaks into client bundles are detectable;
+// private accessors carry no prefix constraint and must never appear
+// in client-side code.
+//
+// The Static* accessors panic on missing keys and are intended for
+// values whose absence should fail process startup (DATABASE_URL,
+// PUBLIC_API_URL). The Dynamic* accessors return "" on missing keys
+// for runtime-toggleable settings.
+//
+// Build-time substitution of Static* calls into literal strings, and
+// the codegen guard that rejects private env references in
+// +page.svelte client bundles, are deferred to the v0.3 Vite
+// client-bundle work. Until then Static* and Dynamic* differ only in
+// missing-key behaviour.
+package env

--- a/packages/sveltego/exports/kit/env/env.go
+++ b/packages/sveltego/exports/kit/env/env.go
@@ -1,0 +1,53 @@
+package env
+
+import (
+	"os"
+	"strings"
+)
+
+const publicPrefix = "PUBLIC_"
+
+// StaticPrivate returns the value of key from the process environment
+// and panics when key is unset. Use for required server-only secrets
+// (DATABASE_URL, SESSION_KEY) whose absence should fail startup.
+func StaticPrivate(key string) string {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		panic("env: required key " + quote(key) + " is unset")
+	}
+	return v
+}
+
+// StaticPublic returns the value of key from the process environment
+// and panics when key is unset or lacks the PUBLIC_ prefix. The
+// prefix is enforced so accidental private values cannot reach the
+// client bundle.
+func StaticPublic(key string) string {
+	if !strings.HasPrefix(key, publicPrefix) {
+		panic("env: StaticPublic key " + quote(key) + " must have PUBLIC_ prefix")
+	}
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		panic("env: required key " + quote(key) + " is unset")
+	}
+	return v
+}
+
+// DynamicPrivate returns the value of key from the process
+// environment, or "" when unset. Use for runtime-toggleable
+// server-only settings.
+func DynamicPrivate(key string) string {
+	return os.Getenv(key)
+}
+
+// DynamicPublic returns the value of key from the process
+// environment, or "" when unset. Panics when key lacks the PUBLIC_
+// prefix.
+func DynamicPublic(key string) string {
+	if !strings.HasPrefix(key, publicPrefix) {
+		panic("env: DynamicPublic key " + quote(key) + " must have PUBLIC_ prefix")
+	}
+	return os.Getenv(key)
+}
+
+func quote(s string) string { return `"` + s + `"` }

--- a/packages/sveltego/exports/kit/env/env_test.go
+++ b/packages/sveltego/exports/kit/env/env_test.go
@@ -1,0 +1,103 @@
+package env
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStaticPrivate(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		t.Setenv("SVELTEGO_TEST_DB_URL", "postgres://localhost/x")
+		if got := StaticPrivate("SVELTEGO_TEST_DB_URL"); got != "postgres://localhost/x" {
+			t.Fatalf("StaticPrivate = %q, want postgres://localhost/x", got)
+		}
+	})
+
+	t.Run("empty value still present", func(t *testing.T) {
+		t.Setenv("SVELTEGO_TEST_EMPTY", "")
+		if got := StaticPrivate("SVELTEGO_TEST_EMPTY"); got != "" {
+			t.Fatalf("StaticPrivate = %q, want empty", got)
+		}
+	})
+
+	t.Run("missing panics", func(t *testing.T) {
+		assertPanics(t, "required key", func() {
+			StaticPrivate("SVELTEGO_TEST_DEFINITELY_UNSET_KEY")
+		})
+	})
+}
+
+func TestStaticPublic(t *testing.T) {
+	t.Run("present with prefix", func(t *testing.T) {
+		t.Setenv("PUBLIC_API_URL", "https://api.example.com")
+		if got := StaticPublic("PUBLIC_API_URL"); got != "https://api.example.com" {
+			t.Fatalf("StaticPublic = %q, want https://api.example.com", got)
+		}
+	})
+
+	t.Run("missing prefix panics", func(t *testing.T) {
+		assertPanics(t, "PUBLIC_ prefix", func() {
+			StaticPublic("SECRET_KEY")
+		})
+	})
+
+	t.Run("missing value panics", func(t *testing.T) {
+		assertPanics(t, "required key", func() {
+			StaticPublic("PUBLIC_SVELTEGO_TEST_UNSET")
+		})
+	})
+}
+
+func TestDynamicPrivate(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		t.Setenv("SVELTEGO_TEST_DYN_PRIV", "v1")
+		if got := DynamicPrivate("SVELTEGO_TEST_DYN_PRIV"); got != "v1" {
+			t.Fatalf("DynamicPrivate = %q, want v1", got)
+		}
+	})
+
+	t.Run("missing returns empty", func(t *testing.T) {
+		if got := DynamicPrivate("SVELTEGO_TEST_DEFINITELY_UNSET_KEY"); got != "" {
+			t.Fatalf("DynamicPrivate = %q, want empty", got)
+		}
+	})
+}
+
+func TestDynamicPublic(t *testing.T) {
+	t.Run("present with prefix", func(t *testing.T) {
+		t.Setenv("PUBLIC_FEATURE_FLAG", "on")
+		if got := DynamicPublic("PUBLIC_FEATURE_FLAG"); got != "on" {
+			t.Fatalf("DynamicPublic = %q, want on", got)
+		}
+	})
+
+	t.Run("missing returns empty", func(t *testing.T) {
+		if got := DynamicPublic("PUBLIC_SVELTEGO_TEST_UNSET"); got != "" {
+			t.Fatalf("DynamicPublic = %q, want empty", got)
+		}
+	})
+
+	t.Run("missing prefix panics", func(t *testing.T) {
+		assertPanics(t, "PUBLIC_ prefix", func() {
+			DynamicPublic("SECRET_KEY")
+		})
+	})
+}
+
+func assertPanics(t *testing.T, wantSubstr string, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic containing %q, got none", wantSubstr)
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic value not a string: %#v", r)
+		}
+		if !strings.Contains(msg, wantSubstr) {
+			t.Fatalf("panic = %q, want substring %q", msg, wantSubstr)
+		}
+	}()
+	fn()
+}


### PR DESCRIPTION
## Summary
- New `exports/kit/env/` package with `StaticPrivate` / `StaticPublic` / `DynamicPrivate` / `DynamicPublic`
- `PUBLIC_` prefix enforced on Public accessors via panic
- `StaticPrivate` panics on unset key; `DynamicPrivate` returns `""`
- Build-time substitution + client-bundle guard deferred to v0.3 (#34) — tracked as #117

## Test plan
- [x] `env_test.go` table tests including panic recover paths (15 subtests)
- [x] `gofumpt -l` / `goimports -l` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] `go test -race -count=1 ./...` green
- [x] `GOWORK=off go build ./...` green
- [x] playground basic smoke unchanged (root returns "Hello, sveltego!")

Refs #82 — partial. Build-time half tracked in #117.