### PR TITLE
feat(forms): Actions dispatch + BindForm/BindMultipart helpers

### DIFF
--- a/packages/sveltego/exports/kit/action.go
+++ b/packages/sveltego/exports/kit/action.go
@@ -1,0 +1,70 @@
+package kit
+
+// ActionFn is the signature of one entry in an [ActionMap]. It runs on
+// POST to a page route after dispatch resolves the entry from the
+// request's `?/<name>` query (or the default key when absent). The
+// returned [ActionResult] tells the pipeline how to finish the request.
+type ActionFn = func(ev *RequestEvent) ActionResult
+
+// ActionMap is the type a +page.server.go exports as `var Actions`.
+// Keys are action names (`"default"`, `"submit"`, ...); the dispatcher
+// matches the request's `?/<name>` query against them.
+type ActionMap = map[string]ActionFn
+
+// ActionResult is the sealed sum returned from an [ActionFn]. The three
+// concrete types — [ActionData], [ActionFailData], [ActionRedirectResult]
+// — are constructed via [ActionDataResult], [ActionFail], and
+// [ActionRedirect]. The unexported sealedAction method keeps user code
+// from defining additional variants.
+type ActionResult interface {
+	sealedAction()
+}
+
+// ActionData re-renders the page with Code as the response status and
+// Data merged into the page's Form field.
+type ActionData struct {
+	Code int
+	Data any
+}
+
+func (ActionData) sealedAction() {}
+
+// ActionFailData re-renders the page with Code as the response status
+// (typically 4xx) and Data merged into the page's Form field. Used to
+// surface validation errors back to the form.
+type ActionFailData struct {
+	Code int
+	Data any
+}
+
+func (ActionFailData) sealedAction() {}
+
+// ActionRedirectResult short-circuits the page render and writes a
+// redirect with Location and Code (defaulting to 303 when zero).
+type ActionRedirectResult struct {
+	Code     int
+	Location string
+}
+
+func (ActionRedirectResult) sealedAction() {}
+
+// ActionDataResult builds an [ActionData] result. Use code 200 for the
+// happy path; the page re-renders with data bound to its Form field.
+func ActionDataResult(code int, data any) ActionResult {
+	return ActionData{Code: code, Data: data}
+}
+
+// ActionFail builds an [ActionFailData] result. The page re-renders
+// with the same Form data and the response carries the failure code.
+func ActionFail(code int, data any) ActionResult {
+	return ActionFailData{Code: code, Data: data}
+}
+
+// ActionRedirect builds an [ActionRedirectResult]. Default Code is 303
+// (POST -> GET) when the caller passes 0.
+func ActionRedirect(code int, location string) ActionResult {
+	if code == 0 {
+		code = 303
+	}
+	return ActionRedirectResult{Code: code, Location: location}
+}

--- a/packages/sveltego/exports/kit/action_test.go
+++ b/packages/sveltego/exports/kit/action_test.go
@@ -1,0 +1,75 @@
+package kit_test
+
+import (
+	"testing"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+func TestActionDataResult(t *testing.T) {
+	t.Parallel()
+	got := kit.ActionDataResult(200, map[string]string{"ok": "yes"})
+	d, ok := got.(kit.ActionData)
+	if !ok {
+		t.Fatalf("type = %T, want kit.ActionData", got)
+	}
+	if d.Code != 200 {
+		t.Errorf("Code = %d, want 200", d.Code)
+	}
+	if m, ok := d.Data.(map[string]string); !ok || m["ok"] != "yes" {
+		t.Errorf("Data = %#v, want map[ok:yes]", d.Data)
+	}
+}
+
+func TestActionFail(t *testing.T) {
+	t.Parallel()
+	got := kit.ActionFail(400, "bad")
+	d, ok := got.(kit.ActionFailData)
+	if !ok {
+		t.Fatalf("type = %T, want kit.ActionFailData", got)
+	}
+	if d.Code != 400 {
+		t.Errorf("Code = %d, want 400", d.Code)
+	}
+	if d.Data != "bad" {
+		t.Errorf("Data = %v, want bad", d.Data)
+	}
+}
+
+func TestActionRedirect(t *testing.T) {
+	t.Parallel()
+	got := kit.ActionRedirect(0, "/dash")
+	r, ok := got.(kit.ActionRedirectResult)
+	if !ok {
+		t.Fatalf("type = %T, want kit.ActionRedirectResult", got)
+	}
+	if r.Code != 303 {
+		t.Errorf("Code = %d, want default 303", r.Code)
+	}
+	if r.Location != "/dash" {
+		t.Errorf("Location = %q, want /dash", r.Location)
+	}
+
+	r2 := kit.ActionRedirect(307, "/keep").(kit.ActionRedirectResult)
+	if r2.Code != 307 {
+		t.Errorf("override Code = %d, want 307", r2.Code)
+	}
+}
+
+func TestActionMap_DispatchShape(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	m := kit.ActionMap{
+		"default": func(_ *kit.RequestEvent) kit.ActionResult {
+			calls++
+			return kit.ActionDataResult(200, "hi")
+		},
+	}
+	res := m["default"](nil)
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if _, ok := res.(kit.ActionData); !ok {
+		t.Fatalf("result type = %T", res)
+	}
+}

--- a/packages/sveltego/exports/kit/bind.go
+++ b/packages/sveltego/exports/kit/bind.go
@@ -1,0 +1,232 @@
+package kit
+
+import (
+	"errors"
+	"mime/multipart"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultMaxFormMemory is the maxMemory value [RequestEvent.BindMultipart]
+// uses when the caller passes a non-positive limit. Multipart parts
+// larger than this go to disk via the stdlib temp-file path.
+const DefaultMaxFormMemory int64 = 32 << 20 // 32 MiB
+
+// BindError aggregates per-field coercion failures from [RequestEvent.BindForm]
+// and [RequestEvent.BindMultipart]. FieldErrors is keyed by the form
+// name (the `form:"..."` tag value, falling back to the lowercased
+// struct field name).
+type BindError struct {
+	FieldErrors map[string]string
+}
+
+// Error implements error. The string is stable across runs because
+// fields are sorted before joining.
+func (b *BindError) Error() string {
+	if b == nil || len(b.FieldErrors) == 0 {
+		return "bind: no field errors"
+	}
+	keys := make([]string, 0, len(b.FieldErrors))
+	for k := range b.FieldErrors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+": "+b.FieldErrors[k])
+	}
+	return "bind: " + strings.Join(parts, "; ")
+}
+
+// BindForm parses the request's url-encoded body into dst by reflecting
+// over its `form` tags. Numeric / bool / time.Time / []string fields
+// are coerced; coercion errors aggregate into a [*BindError]. dst must
+// be a non-nil pointer to a struct.
+func (e *RequestEvent) BindForm(dst any) error {
+	if e == nil || e.Request == nil {
+		return errors.New("bind: nil request")
+	}
+	if err := e.Request.ParseForm(); err != nil {
+		return err
+	}
+	return bindStruct(dst, e.Request.PostForm, nil)
+}
+
+// BindMultipart parses the request's multipart body into dst. File
+// fields receive `*multipart.FileHeader` or `[]*multipart.FileHeader`.
+// maxMemory follows net/http semantics (parts above the limit spill to
+// temp files); a non-positive value uses [DefaultMaxFormMemory].
+func (e *RequestEvent) BindMultipart(dst any, maxMemory int64) error {
+	if e == nil || e.Request == nil {
+		return errors.New("bind: nil request")
+	}
+	if maxMemory <= 0 {
+		maxMemory = DefaultMaxFormMemory
+	}
+	if err := e.Request.ParseMultipartForm(maxMemory); err != nil {
+		return err
+	}
+	form := e.Request.MultipartForm
+	var values map[string][]string
+	var files map[string][]*multipart.FileHeader
+	if form != nil {
+		values = form.Value
+		files = form.File
+	}
+	return bindStruct(dst, values, files)
+}
+
+// Files returns the multipart file map for the request, or nil when no
+// multipart form has been parsed yet. Call after [RequestEvent.BindMultipart]
+// or [http.Request.ParseMultipartForm].
+func (e *RequestEvent) Files() map[string][]*multipart.FileHeader {
+	if e == nil || e.Request == nil || e.Request.MultipartForm == nil {
+		return nil
+	}
+	return e.Request.MultipartForm.File
+}
+
+type fieldInfo struct {
+	index    int
+	formName string
+	typ      reflect.Type
+}
+
+var (
+	bindCache    sync.Map // reflect.Type -> []fieldInfo
+	timeType     = reflect.TypeOf(time.Time{})
+	fileHdrType  = reflect.TypeOf((*multipart.FileHeader)(nil))
+	fileHdrSlice = reflect.TypeOf([]*multipart.FileHeader(nil))
+)
+
+func bindStruct(dst any, values map[string][]string, files map[string][]*multipart.FileHeader) error {
+	rv := reflect.ValueOf(dst)
+	if !rv.IsValid() || rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return errors.New("bind: dst must be non-nil pointer")
+	}
+	rv = rv.Elem()
+	if rv.Kind() != reflect.Struct {
+		return errors.New("bind: dst must point to struct")
+	}
+	infos := fieldsFor(rv.Type())
+	errs := map[string]string{}
+	for _, fi := range infos {
+		fv := rv.Field(fi.index)
+		if isFileField(fi.typ) {
+			assignFiles(fv, files[fi.formName])
+			continue
+		}
+		raw := values[fi.formName]
+		if len(raw) == 0 {
+			continue
+		}
+		if err := assignField(fv, raw); err != nil {
+			errs[fi.formName] = err.Error()
+		}
+	}
+	if len(errs) > 0 {
+		return &BindError{FieldErrors: errs}
+	}
+	return nil
+}
+
+func fieldsFor(t reflect.Type) []fieldInfo {
+	if v, ok := bindCache.Load(t); ok {
+		return v.([]fieldInfo)
+	}
+	var out []fieldInfo
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		tag := sf.Tag.Get("form")
+		if tag == "-" {
+			continue
+		}
+		name := tag
+		if name == "" {
+			name = strings.ToLower(sf.Name)
+		}
+		out = append(out, fieldInfo{
+			index:    i,
+			formName: name,
+			typ:      sf.Type,
+		})
+	}
+	bindCache.Store(t, out)
+	return out
+}
+
+func isFileField(t reflect.Type) bool {
+	return t == fileHdrType || t == fileHdrSlice
+}
+
+func assignFiles(fv reflect.Value, hdrs []*multipart.FileHeader) {
+	if len(hdrs) == 0 {
+		return
+	}
+	if fv.Type() == fileHdrType {
+		fv.Set(reflect.ValueOf(hdrs[0]))
+		return
+	}
+	if fv.Type() == fileHdrSlice {
+		fv.Set(reflect.ValueOf(hdrs))
+	}
+}
+
+func assignField(fv reflect.Value, raw []string) error {
+	if fv.Type() == timeType {
+		t, err := time.Parse(time.RFC3339, raw[0])
+		if err != nil {
+			return err
+		}
+		fv.Set(reflect.ValueOf(t))
+		return nil
+	}
+	switch fv.Kind() {
+	case reflect.String:
+		fv.SetString(raw[0])
+	case reflect.Bool:
+		b, err := strconv.ParseBool(raw[0])
+		if err != nil {
+			return err
+		}
+		fv.SetBool(b)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(raw[0], 10, 64)
+		if err != nil {
+			return err
+		}
+		fv.SetInt(n)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(raw[0], 10, 64)
+		if err != nil {
+			return err
+		}
+		fv.SetUint(n)
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(raw[0], 64)
+		if err != nil {
+			return err
+		}
+		fv.SetFloat(f)
+	case reflect.Slice:
+		if fv.Type().Elem().Kind() == reflect.String {
+			out := reflect.MakeSlice(fv.Type(), len(raw), len(raw))
+			for i, s := range raw {
+				out.Index(i).SetString(s)
+			}
+			fv.Set(out)
+			return nil
+		}
+		return errors.New("unsupported slice element type")
+	default:
+		return errors.New("unsupported field type")
+	}
+	return nil
+}

--- a/packages/sveltego/exports/kit/bind_test.go
+++ b/packages/sveltego/exports/kit/bind_test.go
@@ -1,0 +1,253 @@
+package kit_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+func newPostRequest(t *testing.T, body string, contentType string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", contentType)
+	return req
+}
+
+func TestBindForm_HappyPath(t *testing.T) {
+	t.Parallel()
+	values := url.Values{
+		"email":  {"alice@example.com"},
+		"age":    {"30"},
+		"notify": {"true"},
+		"score":  {"4.5"},
+		"tags":   {"go", "kit"},
+	}
+	req := newPostRequest(t, values.Encode(), "application/x-www-form-urlencoded")
+	ev := kit.NewRequestEvent(req, nil)
+
+	type form struct {
+		Email  string   `form:"email"`
+		Age    int      `form:"age"`
+		Notify bool     `form:"notify"`
+		Score  float64  `form:"score"`
+		Tags   []string `form:"tags"`
+	}
+	var got form
+	if err := ev.BindForm(&got); err != nil {
+		t.Fatalf("BindForm: %v", err)
+	}
+	if got.Email != "alice@example.com" || got.Age != 30 || !got.Notify || got.Score != 4.5 {
+		t.Fatalf("scalar mismatch: %#v", got)
+	}
+	if !equalStringSlice(got.Tags, []string{"go", "kit"}) {
+		t.Fatalf("Tags = %v", got.Tags)
+	}
+}
+
+func TestBindForm_DefaultLowercaseTag(t *testing.T) {
+	t.Parallel()
+	values := url.Values{"name": {"jdoe"}}
+	req := newPostRequest(t, values.Encode(), "application/x-www-form-urlencoded")
+	ev := kit.NewRequestEvent(req, nil)
+
+	type form struct {
+		Name string
+	}
+	var got form
+	if err := ev.BindForm(&got); err != nil {
+		t.Fatalf("BindForm: %v", err)
+	}
+	if got.Name != "jdoe" {
+		t.Errorf("Name = %q, want jdoe", got.Name)
+	}
+}
+
+func TestBindForm_InvalidIntAggregates(t *testing.T) {
+	t.Parallel()
+	values := url.Values{"age": {"notanumber"}, "max": {"alsobad"}}
+	req := newPostRequest(t, values.Encode(), "application/x-www-form-urlencoded")
+	ev := kit.NewRequestEvent(req, nil)
+
+	type form struct {
+		Age int `form:"age"`
+		Max int `form:"max"`
+	}
+	var dst form
+	err := ev.BindForm(&dst)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var be *kit.BindError
+	if !errors.As(err, &be) {
+		t.Fatalf("expected *BindError, got %T (%v)", err, err)
+	}
+	if _, ok := be.FieldErrors["age"]; !ok {
+		t.Errorf("missing age error: %#v", be.FieldErrors)
+	}
+	if _, ok := be.FieldErrors["max"]; !ok {
+		t.Errorf("missing max error: %#v", be.FieldErrors)
+	}
+}
+
+func TestBindForm_TimeRFC3339(t *testing.T) {
+	t.Parallel()
+	values := url.Values{"when": {"2026-04-30T12:00:00Z"}, "bad": {"not-a-time"}}
+	req := newPostRequest(t, values.Encode(), "application/x-www-form-urlencoded")
+	ev := kit.NewRequestEvent(req, nil)
+
+	type form struct {
+		When time.Time `form:"when"`
+		Bad  time.Time `form:"bad"`
+	}
+	var dst form
+	err := ev.BindForm(&dst)
+	if err == nil {
+		t.Fatal("expected aggregated time error")
+	}
+	var be *kit.BindError
+	if !errors.As(err, &be) {
+		t.Fatalf("expected *BindError, got %T", err)
+	}
+	if _, ok := be.FieldErrors["bad"]; !ok {
+		t.Errorf("missing bad error: %#v", be.FieldErrors)
+	}
+	if !dst.When.Equal(time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)) {
+		t.Errorf("when = %v, want 2026-04-30T12:00:00Z", dst.When)
+	}
+}
+
+func TestBindForm_NilDstRejected(t *testing.T) {
+	t.Parallel()
+	req := newPostRequest(t, "", "application/x-www-form-urlencoded")
+	ev := kit.NewRequestEvent(req, nil)
+
+	type form struct{ Email string }
+	var nilPtr *form
+	if err := ev.BindForm(nilPtr); err == nil {
+		t.Fatal("expected error on nil pointer")
+	}
+	if err := ev.BindForm(form{}); err == nil {
+		t.Fatal("expected error on non-pointer")
+	}
+}
+
+func TestBindMultipart_FilesAndValues(t *testing.T) {
+	t.Parallel()
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	if err := w.WriteField("title", "hello"); err != nil {
+		t.Fatalf("WriteField: %v", err)
+	}
+	if err := w.WriteField("tags", "a"); err != nil {
+		t.Fatalf("WriteField: %v", err)
+	}
+	if err := w.WriteField("tags", "b"); err != nil {
+		t.Fatalf("WriteField: %v", err)
+	}
+	fw, err := w.CreateFormFile("avatar", "avatar.png")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write([]byte("PNGDATA")); err != nil {
+		t.Fatalf("file write: %v", err)
+	}
+	for _, n := range []string{"a.txt", "b.txt"} {
+		fp, err := w.CreateFormFile("photos", n)
+		if err != nil {
+			t.Fatalf("CreateFormFile: %v", err)
+		}
+		if _, err := fp.Write([]byte(n)); err != nil {
+			t.Fatalf("file write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	ev := kit.NewRequestEvent(req, nil)
+
+	type form struct {
+		Title  string                  `form:"title"`
+		Tags   []string                `form:"tags"`
+		Avatar *multipart.FileHeader   `form:"avatar"`
+		Photos []*multipart.FileHeader `form:"photos"`
+	}
+	var got form
+	if err := ev.BindMultipart(&got, 0); err != nil {
+		t.Fatalf("BindMultipart: %v", err)
+	}
+	if got.Title != "hello" {
+		t.Errorf("Title = %q", got.Title)
+	}
+	if !equalStringSlice(got.Tags, []string{"a", "b"}) {
+		t.Errorf("Tags = %v", got.Tags)
+	}
+	if got.Avatar == nil || got.Avatar.Filename != "avatar.png" {
+		t.Fatalf("Avatar = %#v", got.Avatar)
+	}
+	f, err := got.Avatar.Open()
+	if err != nil {
+		t.Fatalf("open avatar: %v", err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("read avatar: %v", err)
+	}
+	if string(data) != "PNGDATA" {
+		t.Errorf("avatar bytes = %q", data)
+	}
+	if len(got.Photos) != 2 || got.Photos[0].Filename != "a.txt" || got.Photos[1].Filename != "b.txt" {
+		t.Errorf("Photos = %#v", got.Photos)
+	}
+
+	files := ev.Files()
+	if len(files["photos"]) != 2 {
+		t.Errorf("Files()[photos] = %d, want 2", len(files["photos"]))
+	}
+}
+
+func TestBindError_String(t *testing.T) {
+	t.Parallel()
+	be := &kit.BindError{FieldErrors: map[string]string{"b": "x", "a": "y"}}
+	got := be.Error()
+	if got != "bind: a: y; b: x" {
+		t.Errorf("Error() = %q", got)
+	}
+	empty := &kit.BindError{}
+	if empty.Error() == "" {
+		t.Error("empty BindError.Error should not be empty string")
+	}
+}
+
+func TestFiles_NoMultipartParsed(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	ev := kit.NewRequestEvent(req, nil)
+	if got := ev.Files(); got != nil {
+		t.Errorf("Files() before parse = %#v, want nil", got)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/packages/sveltego/internal/codegen/actions_pagedata_test.go
+++ b/packages/sveltego/internal/codegen/actions_pagedata_test.go
@@ -1,0 +1,46 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/internal/parser"
+)
+
+// TestGenerate_HasActions_AddsFormField pins the codegen behavior
+// linking page.server.go's `var Actions = ...` to PageData.Form.
+func TestGenerate_HasActions_AddsFormField(t *testing.T) {
+	t.Parallel()
+	src := []byte("<h1>{Data.Name}</h1>")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{
+		PackageName: "page",
+		HasActions:  true,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "Form any") {
+		t.Errorf("expected `Form any` in PageData when HasActions=true:\n%s", got)
+	}
+}
+
+func TestGenerate_NoActions_NoFormField(t *testing.T) {
+	t.Parallel()
+	src := []byte("<h1>hi</h1>")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{PackageName: "page"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.Contains(string(out), "Form any") {
+		t.Errorf("unexpected Form field when HasActions=false:\n%s", out)
+	}
+}

--- a/packages/sveltego/internal/codegen/actionscan.go
+++ b/packages/sveltego/internal/codegen/actionscan.go
@@ -1,0 +1,107 @@
+package codegen
+
+import (
+	"fmt"
+	goast "go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+)
+
+// ActionScan summarizes form-action discovery in one page.server.go.
+// HasActions is true when the file declares `var Actions = ...`. Names
+// collects best-effort action keys read off a literal ActionMap
+// initializer; dynamically-keyed maps yield an empty Names slice and the
+// runtime dispatcher resolves keys at request time.
+type ActionScan struct {
+	HasActions bool
+	Names      []string
+}
+
+// scanActions reads path and reports whether it declares Actions and
+// which keys the literal initializer (when present) contains. A missing
+// or empty path returns the zero value with no error.
+func scanActions(path string) (ActionScan, error) {
+	if path == "" {
+		return ActionScan{}, nil
+	}
+	src, err := os.ReadFile(path) //nolint:gosec // path is scanner-controlled
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ActionScan{}, nil
+		}
+		return ActionScan{}, fmt.Errorf("codegen: read %s: %w", path, err)
+	}
+	stripped := stripBuildConstraint(src)
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, stripped, parser.AllErrors|parser.SkipObjectResolution)
+	if err != nil {
+		return ActionScan{}, fmt.Errorf("codegen: parse %s: %w", path, err)
+	}
+
+	var out ActionScan
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*goast.GenDecl)
+		if !ok || gd.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*goast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if name == nil || name.Name != "Actions" {
+					continue
+				}
+				out.HasActions = true
+				if i < len(vs.Values) {
+					if lit, ok := vs.Values[i].(*goast.CompositeLit); ok {
+						out.Names = append(out.Names, literalActionKeys(lit)...)
+					}
+				}
+			}
+		}
+	}
+	if len(out.Names) > 0 {
+		sort.Strings(out.Names)
+		out.Names = dedupSorted(out.Names)
+	}
+	return out, nil
+}
+
+func literalActionKeys(lit *goast.CompositeLit) []string {
+	var out []string
+	for _, el := range lit.Elts {
+		kv, ok := el.(*goast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		bl, ok := kv.Key.(*goast.BasicLit)
+		if !ok || bl.Kind != token.STRING {
+			continue
+		}
+		// strip surrounding quotes; rely on go/parser having validated them
+		val := bl.Value
+		if len(val) >= 2 {
+			val = val[1 : len(val)-1]
+		}
+		out = append(out, val)
+	}
+	return out
+}
+
+func dedupSorted(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := in[:1]
+	for _, s := range in[1:] {
+		if s != out[len(out)-1] {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/packages/sveltego/internal/codegen/actionscan_test.go
+++ b/packages/sveltego/internal/codegen/actionscan_test.go
@@ -1,0 +1,97 @@
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempServerActions(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "page.server.go")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestScanActions_LiteralKeys(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package login
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+var Actions = kit.ActionMap{
+	"default": func(ev *kit.RequestEvent) kit.ActionResult { return nil },
+	"submit":  func(ev *kit.RequestEvent) kit.ActionResult { return nil },
+}
+`
+	path := writeTempServerActions(t, body)
+	got, err := scanActions(path)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !got.HasActions {
+		t.Fatal("HasActions = false")
+	}
+	if len(got.Names) != 2 || got.Names[0] != "default" || got.Names[1] != "submit" {
+		t.Errorf("Names = %v, want [default submit]", got.Names)
+	}
+}
+
+func TestScanActions_NoVar(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package x
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+func Load(ctx *kit.LoadCtx) (any, error) { return nil, nil }
+`
+	path := writeTempServerActions(t, body)
+	got, err := scanActions(path)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got.HasActions {
+		t.Errorf("HasActions = true, want false")
+	}
+}
+
+func TestScanActions_DynamicKeysOmitted(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package x
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+var Actions kit.ActionMap
+`
+	path := writeTempServerActions(t, body)
+	got, err := scanActions(path)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !got.HasActions {
+		t.Fatal("HasActions = false")
+	}
+	if len(got.Names) != 0 {
+		t.Errorf("Names = %v, want empty", got.Names)
+	}
+}
+
+func TestScanActions_MissingFile(t *testing.T) {
+	t.Parallel()
+	got, err := scanActions(filepath.Join(t.TempDir(), "missing.go"))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got.HasActions {
+		t.Errorf("HasActions on missing = true")
+	}
+}

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -238,6 +238,11 @@ func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRou
 	opts := Options{PackageName: route.PackageName}
 	if route.HasPageServer {
 		opts.ServerFilePath = filepath.Join(route.Dir, "page.server.go")
+		actionInfo, err := scanActions(opts.ServerFilePath)
+		if err != nil {
+			return 0, err
+		}
+		opts.HasActions = actionInfo.HasActions
 	}
 	out, err := Generate(frag, opts)
 	if err != nil {

--- a/packages/sveltego/internal/codegen/codegen.go
+++ b/packages/sveltego/internal/codegen/codegen.go
@@ -16,6 +16,10 @@ type Options struct {
 	// ServerFilePath optionally points at a sibling +page.server.go whose
 	// Load() inline struct return is used to infer PageData fields.
 	ServerFilePath string
+	// HasActions is true when the sibling page.server.go declares
+	// `var Actions kit.ActionMap`. The page's PageData gains a `Form any`
+	// field so action result data can be threaded through the render.
+	HasActions bool
 }
 
 // LayoutOptions configures GenerateLayout.
@@ -45,6 +49,9 @@ func Generate(frag *ast.Fragment, opts Options) ([]byte, error) {
 	pageData, err := inferPageData(opts.ServerFilePath)
 	if err != nil {
 		return nil, err
+	}
+	if opts.HasActions {
+		pageData.Fields = append(pageData.Fields, pageDataField{Name: "Form", Type: "any"})
 	}
 
 	imports := mergeImports(scripts.Imports, pageData.Imports)

--- a/packages/sveltego/internal/codegen/wire.go
+++ b/packages/sveltego/internal/codegen/wire.go
@@ -47,7 +47,7 @@ func mirrorUserSource(in *userSourceFile) error {
 	if err != nil {
 		return fmt.Errorf("codegen: parse %s: %w", in.UserPath, err)
 	}
-	in.HasActions = hasFunc(parsed, "Actions")
+	in.HasActions = hasActionsVar(parsed)
 
 	rewritten, err := rewritePackageClause(stripped, in.PackageName)
 	if err != nil {
@@ -123,19 +123,27 @@ func rewritePackageClause(src []byte, name string) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-// hasFunc reports whether the parsed file declares a top-level function
-// (no receiver) named name.
-func hasFunc(f *goast.File, name string) bool {
+// hasActionsVar reports whether the parsed file declares a top-level
+// `var Actions ...` (any type or initializer). Form actions are
+// authored as `var Actions = kit.ActionMap{...}` per spec; the wire
+// emitter consults this flag to decide whether to reference the symbol
+// or emit a nil-returning stub.
+func hasActionsVar(f *goast.File) bool {
 	for _, decl := range f.Decls {
-		fn, ok := decl.(*goast.FuncDecl)
-		if !ok {
+		gd, ok := decl.(*goast.GenDecl)
+		if !ok || gd.Tok != token.VAR {
 			continue
 		}
-		if fn.Recv != nil {
-			continue
-		}
-		if fn.Name != nil && fn.Name.Name == name {
-			return true
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*goast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, name := range vs.Names {
+				if name != nil && name.Name == "Actions" {
+					return true
+				}
+			}
 		}
 	}
 	return false
@@ -169,12 +177,12 @@ func emitWire(genRoot, modulePath string, route mirrorRoute) error {
 
 	b.Line("")
 	if route.hasActions {
-		b.Line("// Actions wraps the user-authored Actions() so the manifest can")
-		b.Line("// reference it through the gen package.")
-		b.Line("func Actions() any { return usersrc.Actions() }")
+		b.Line("// Actions wraps the user-authored `var Actions kit.ActionMap` so the")
+		b.Line("// manifest can reference it through the gen package as router.ActionsHandler.")
+		b.Line("func Actions() any { return usersrc.Actions }")
 	} else {
 		b.Line("// Actions is emitted as a nil-returning stub because the user's")
-		b.Line("// page.server.go does not declare an Actions function. The manifest")
+		b.Line("// page.server.go does not declare an Actions variable. The manifest")
 		b.Line("// references this symbol unconditionally when HasPageServer is set.")
 		b.Line("func Actions() any { return nil }")
 	}

--- a/packages/sveltego/internal/codegen/wire_test.go
+++ b/packages/sveltego/internal/codegen/wire_test.go
@@ -60,7 +60,7 @@ func TestEmitWire_LoadAndActions(t *testing.T) {
 		t.Fatalf("read wire: %v", err)
 	}
 	got := string(src)
-	if !strings.Contains(got, "func Actions() any { return usersrc.Actions() }") {
+	if !strings.Contains(got, "func Actions() any { return usersrc.Actions }") {
 		t.Errorf("missing Actions wrapper:\n%s", got)
 	}
 	if !strings.Contains(got, `usersrc "myapp/.gen/usersrc/routes"`) {
@@ -77,8 +77,9 @@ package origpkg
 
 import "github.com/binsarjr/sveltego/exports/kit"
 
+var Actions = kit.ActionMap{}
+
 func Load(ctx *kit.LoadCtx) (any, error) { return nil, nil }
-func Actions() any                       { return nil }
 `)
 	dir := t.TempDir()
 	userPath := filepath.Join(dir, "page.server.go")

--- a/packages/sveltego/server/actions.go
+++ b/packages/sveltego/server/actions.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/runtime/router"
+)
+
+// injectFormField sets the `Form` field on data (when present) to
+// formValue and returns the resulting value. data is typically a
+// PageData struct alias the codegen emits with `Form any`; routes
+// without that field receive data unchanged. nil data falls through:
+// PageData zero value carries Form=nil so the page reads it as nil.
+func injectFormField(data, formValue any) any {
+	if data == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(data)
+	if rv.Kind() != reflect.Struct {
+		return data
+	}
+	formField := rv.FieldByName("Form")
+	if !formField.IsValid() {
+		return data
+	}
+	cp := reflect.New(rv.Type()).Elem()
+	cp.Set(rv)
+	target := cp.FieldByName("Form")
+	if !target.CanSet() {
+		return data
+	}
+	if formValue == nil {
+		target.Set(reflect.Zero(target.Type()))
+	} else {
+		target.Set(reflect.ValueOf(formValue))
+	}
+	return cp.Interface()
+}
+
+// dispatchAction resolves the form action keyed by the request URL's
+// `?/<name>` query (default: "default") against route.Actions and runs
+// it. The returned response or error follows the same shape as
+// renderPage so the surrounding pipeline writes one Response.
+//
+// Returning (nil, nil) means the caller should fall through to
+// renderPage with the `Form` payload installed via formData.
+func (s *Server) dispatchAction(r *http.Request, ev *kit.RequestEvent, route *router.Route) (*kit.Response, *formData, error) {
+	if route.Actions == nil {
+		return kit.MethodNotAllowed([]string{http.MethodGet}), nil, nil
+	}
+	rawMap := route.Actions()
+	actions, _ := rawMap.(kit.ActionMap)
+	if len(actions) == 0 {
+		return kit.MethodNotAllowed([]string{http.MethodGet}), nil, nil
+	}
+
+	name := actionNameFromQuery(r.URL.RawQuery)
+	fn, ok := actions[name]
+	if !ok {
+		return &kit.Response{
+			Status:  http.StatusNotFound,
+			Headers: http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}},
+			Body:    []byte("action not found: " + name),
+		}, nil, nil
+	}
+
+	result := fn(ev)
+	switch v := result.(type) {
+	case kit.ActionRedirectResult:
+		code := v.Code
+		if code == 0 {
+			code = http.StatusSeeOther
+		}
+		return &kit.Response{
+			Status:  code,
+			Headers: http.Header{"Location": []string{v.Location}},
+		}, nil, nil
+	case kit.ActionData:
+		return nil, &formData{code: codeOr(v.Code, http.StatusOK), data: v.Data}, nil
+	case kit.ActionFailData:
+		return nil, &formData{code: codeOr(v.Code, http.StatusBadRequest), data: v.Data}, nil
+	case nil:
+		return nil, nil, nil
+	default:
+		return nil, nil, errUnknownActionResult{}
+	}
+}
+
+// formData carries an ActionData / ActionFailData payload from the
+// dispatcher into renderPage so the page can expose it as PageData.Form.
+type formData struct {
+	code int
+	data any
+}
+
+// errUnknownActionResult is returned when a custom ActionResult escapes
+// the sealed sum. Defensive only: kit's unexported sealedAction method
+// already prevents this in well-behaved code.
+type errUnknownActionResult struct{}
+
+func (errUnknownActionResult) Error() string {
+	return "server: unknown ActionResult variant"
+}
+
+// actionNameFromQuery extracts the leading `/<name>` token from a raw
+// query string. SvelteKit encodes the action name as a bare key (e.g.
+// `?/submit`), not as a value, so url.ParseQuery sees it as the empty
+// value of `/submit`. The default action key is "default".
+func actionNameFromQuery(raw string) string {
+	if raw == "" {
+		return "default"
+	}
+	for _, part := range strings.Split(raw, "&") {
+		if !strings.HasPrefix(part, "/") {
+			continue
+		}
+		// strip optional `=` suffix
+		name := strings.TrimPrefix(part, "/")
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			name = name[:i]
+		}
+		if name == "" {
+			return "default"
+		}
+		return name
+	}
+	return "default"
+}
+
+func codeOr(code, fallback int) int {
+	if code == 0 {
+		return fallback
+	}
+	return code
+}

--- a/packages/sveltego/server/actions_integration_test.go
+++ b/packages/sveltego/server/actions_integration_test.go
@@ -1,0 +1,259 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/render"
+	"github.com/binsarjr/sveltego/runtime/router"
+)
+
+// pageDataWithForm mirrors the codegen-emitted PageData for routes that
+// declare both Load and Actions: the anonymous struct has a `Form any`
+// the dispatcher fills via reflection.
+type pageDataWithForm = struct {
+	Greeting string
+	Form     any
+}
+
+func formAwarePage() router.PageHandler {
+	return func(w *render.Writer, _ *kit.RenderCtx, data any) error {
+		d, _ := data.(pageDataWithForm)
+		w.WriteString("<h1>")
+		w.WriteString(d.Greeting)
+		w.WriteString("</h1>")
+		if msg, ok := d.Form.(string); ok {
+			w.WriteString("<p>form=")
+			w.WriteString(msg)
+			w.WriteString("</p>")
+		}
+		return nil
+	}
+}
+
+func formAwareLoad() router.LoadHandler {
+	return func(_ *kit.LoadCtx) (any, error) {
+		return pageDataWithForm{Greeting: "hello"}, nil
+	}
+}
+
+func TestActions_DefaultPostRendersWithFormData(t *testing.T) {
+	t.Parallel()
+	actions := kit.ActionMap{
+		"default": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionDataResult(200, "ok")
+		},
+	}
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.PostForm(ts.URL+"/login", url.Values{"email": {"alice@example.com"}})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "<p>form=ok</p>") {
+		t.Fatalf("body missing form data: %s", body)
+	}
+}
+
+func TestActions_NamedAction(t *testing.T) {
+	t.Parallel()
+	actions := kit.ActionMap{
+		"submit": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionDataResult(200, "submitted")
+		},
+	}
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/login?/submit", "application/x-www-form-urlencoded", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "form=submitted") {
+		t.Fatalf("body missing submitted form: %s", body)
+	}
+}
+
+func TestActions_MissingActionName(t *testing.T) {
+	t.Parallel()
+	actions := kit.ActionMap{
+		"default": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionDataResult(200, "ok")
+		},
+	}
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/login?/missing", "application/x-www-form-urlencoded", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestActions_FailRendersWithCode(t *testing.T) {
+	t.Parallel()
+	actions := kit.ActionMap{
+		"default": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionFail(422, "validation failed")
+		},
+	}
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/login", "application/x-www-form-urlencoded", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "form=validation failed") {
+		t.Fatalf("body missing failure data: %s", body)
+	}
+}
+
+func TestActions_RedirectShortCircuits(t *testing.T) {
+	t.Parallel()
+	actions := kit.ActionMap{
+		"default": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionRedirect(0, "/dashboard")
+		},
+	}
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := client.Post(ts.URL+"/login", "application/x-www-form-urlencoded", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/dashboard" {
+		t.Errorf("Location = %q, want /dashboard", loc)
+	}
+}
+
+func TestActions_PostWithoutActionsReturnsMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/static",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "static"}},
+		Page:     staticPage("<h1>static</h1>"),
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/static", "application/x-www-form-urlencoded", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Allow"); got != "GET" {
+		t.Errorf("Allow = %q, want GET", got)
+	}
+}
+
+func TestActions_BindFormInsideAction(t *testing.T) {
+	t.Parallel()
+	type loginForm struct {
+		Email    string `form:"email"`
+		Password string `form:"password"`
+	}
+	actions := kit.ActionMap{
+		"default": func(ev *kit.RequestEvent) kit.ActionResult {
+			var f loginForm
+			if err := ev.BindForm(&f); err != nil {
+				return kit.ActionFail(400, err.Error())
+			}
+			return kit.ActionDataResult(200, f.Email+":"+f.Password)
+		},
+	}
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.PostForm(ts.URL+"/login", url.Values{
+		"email":    {"u@e.com"},
+		"password": {"hunter2"},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "form=u@e.com:hunter2") {
+		t.Fatalf("body = %s", body)
+	}
+}

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -129,10 +129,21 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 	if route.Page == nil {
 		return nil, kit.SafeError{Code: http.StatusNotFound, Message: http.StatusText(http.StatusNotFound)}
 	}
+	var form *formData
+	if r.Method == http.MethodPost {
+		res, fd, err := s.dispatchAction(r, ev, route)
+		if err != nil {
+			return nil, err
+		}
+		if res != nil {
+			return res, nil
+		}
+		form = fd
+	}
 	if !optionsAllowSSR(route.Options) {
 		return s.renderEmptyShell(), nil
 	}
-	return s.renderPage(r, ev, route)
+	return s.renderPage(r, ev, route, form)
 }
 
 // optionsAllowSSR returns true unless the route declared SSR=false. The
@@ -213,8 +224,10 @@ func canonicalRedirect(u *url.URL, path string) string {
 
 // renderPage runs the load chain and renders the page into a fresh
 // buffer, returning a Response carrying the rendered HTML, status, and
-// the Set-Cookie headers accumulated by Load handlers.
-func (s *Server) renderPage(r *http.Request, ev *kit.RequestEvent, route *router.Route) (*kit.Response, error) {
+// the Set-Cookie headers accumulated by Load handlers. When form is
+// non-nil the page's PageData.Form field is set from form.data and the
+// response status follows form.code.
+func (s *Server) renderPage(r *http.Request, ev *kit.RequestEvent, route *router.Route, form *formData) (*kit.Response, error) {
 	var (
 		data        any
 		layoutDatas []any
@@ -242,6 +255,10 @@ func (s *Server) renderPage(r *http.Request, ev *kit.RequestEvent, route *router
 			}
 			data = d
 		}
+	}
+
+	if form != nil {
+		data = injectFormField(data, form.data)
 	}
 
 	buf := render.Acquire()
@@ -282,8 +299,12 @@ func (s *Server) renderPage(r *http.Request, ev *kit.RequestEvent, route *router
 	headers := http.Header{}
 	headers.Set("Content-Type", "text/html; charset=utf-8")
 	headers.Set("Content-Length", strconv.Itoa(len(body)))
+	status := http.StatusOK
+	if form != nil && form.code != 0 {
+		status = form.code
+	}
 	return &kit.Response{
-		Status:  http.StatusOK,
+		Status:  status,
 		Headers: headers,
 		Body:    body,
 	}, nil


### PR DESCRIPTION
Closes #30
Closes #31

Phase 0s: forms group bundle (Actions dispatch + BindForm/BindMultipart helpers).

## Summary

- `kit.ActionMap` (alias for `map[string]kit.ActionFn`) plus a sealed `ActionResult` sum (`ActionData`, `ActionFailData`, `ActionRedirectResult`) constructed via `kit.ActionDataResult` / `kit.ActionFail` / `kit.ActionRedirect`. The unexported `sealedAction()` method keeps user code from defining other variants.
- Reflection-based `(*RequestEvent).BindForm(dst)` / `BindMultipart(dst, maxMemory)` / `Files()` with per-type coercion (`int*`, `uint*`, `float*`, `bool`, `string`, `[]string`, `time.Time` via RFC3339, `*multipart.FileHeader`, `[]*multipart.FileHeader`). Coercion errors aggregate into `*BindError{FieldErrors}`. Default `maxMemory` is 32 MiB.
- Codegen scans `page.server.go` for `var Actions = ...` (var, not func — matches spec). When present, the route's `PageData` gains a `Form any` field; the wire emits `func Actions() any { return usersrc.Actions }` so the manifest's `Actions` slot resolves to the user's value.
- Server pipeline dispatches POST to a page route through the matched action: `?/<name>` query selects the entry (default key `"default"`). Missing name → 404, no Actions on a page route → 405 with `Allow: GET`. `ActionRedirectResult` short-circuits to a redirect (default 303); `ActionData` / `ActionFailData` re-render the page with `PageData.Form` set via reflection and the response status taken from `Code`.
- CSRF deferred to follow-up #123 (v0.3) — the codegen-time form scanner + token wiring crosses the parser/runtime boundary and warrants its own scope.

## Files

- `exports/kit/action.go` (+74 LOC) — sealed sum + helpers.
- `exports/kit/bind.go` (+196 LOC) — BindForm / BindMultipart / Files.
- `internal/codegen/actionscan.go` (+96 LOC) — `var Actions` detector + literal key extraction.
- `server/actions.go` (+115 LOC) — dispatch, query parser, Form-field reflector.
- `internal/codegen/codegen.go` — `Options.HasActions` + Form-field emission.
- `internal/codegen/build.go` — wires actionscan into emitPage.
- `internal/codegen/wire.go` — switched detection from `func Actions` to `var Actions`; wire emits `usersrc.Actions` (no parens).
- `server/pipeline.go` — POST → action dispatch branch; renderPage takes `*formData`.

## Test plan

- [x] `go test -race -count=1 ./...` (638 passes across 14 packages)
- [x] `gofumpt -l .` clean
- [x] `goimports -l -local github.com/binsarjr/sveltego .` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] `GOWORK=off go build ./...` clean
- [x] `GOWORK=off go test -race -count=1 -short ./...` clean
- [x] kit unit tests cover bind happy path, bind error aggregation, time RFC3339, multipart files, default tag = lowercased field name, action result helpers
- [x] codegen unit tests cover action detection (literal keys, dynamic-keyed, missing file, no-var case) and Form-field emission
- [x] server integration tests cover default action, named action, missing action → 404, fail with code → re-render with status, redirect → 303 short-circuit, POST to page route without Actions → 405, BindForm inside an action

## Acceptance items deferred

- **CSRF token validation** → follow-up issue #123 (v0.3 milestone). Token storage + form-element codegen detection crosses the parser/runtime line; out of scope for the forms group bundle.

## CSRF decision

Deferred. Implementing default-on CSRF requires a codegen pass that detects `<form method="POST">` (and the `nocsrf` opt-out attribute) and injects a hidden `_csrf_token` input. That's parser work plus a token cookie + comparison in the pipeline, and crosses the boundary defined for Phase 0s. Filed #123 with the full spec.