### PR TITLE
fix(routescan): normalize path separators for Windows test

### DIFF
--- a/packages/sveltego/internal/routescan/scan_test.go
+++ b/packages/sveltego/internal/routescan/scan_test.go
@@ -176,7 +176,7 @@ func TestScanErrorChainNearest(t *testing.T) {
 	if root == nil {
 		t.Fatal("missing / route")
 	}
-	if !strings.HasSuffix(root.ErrorBoundaryDir, "/routes") {
+	if !strings.HasSuffix(filepath.ToSlash(root.ErrorBoundaryDir), "/routes") {
 		t.Fatalf("root boundary dir = %q, want suffix /routes", root.ErrorBoundaryDir)
 	}
 	if root.ErrorBoundaryPackagePath != ".gen/routes" {
@@ -190,7 +190,7 @@ func TestScanErrorChainNearest(t *testing.T) {
 	if admin == nil {
 		t.Fatal("missing /admin route")
 	}
-	if !strings.HasSuffix(admin.ErrorBoundaryDir, "/admin") {
+	if !strings.HasSuffix(filepath.ToSlash(admin.ErrorBoundaryDir), "/admin") {
 		t.Fatalf("admin boundary dir = %q, want suffix /admin", admin.ErrorBoundaryDir)
 	}
 	if admin.ErrorBoundaryLayoutDepth != 2 {
@@ -201,7 +201,7 @@ func TestScanErrorChainNearest(t *testing.T) {
 	if users == nil {
 		t.Fatal("missing /admin/users route")
 	}
-	if !strings.HasSuffix(users.ErrorBoundaryDir, "/admin") {
+	if !strings.HasSuffix(filepath.ToSlash(users.ErrorBoundaryDir), "/admin") {
 		t.Fatalf("users boundary dir = %q, want suffix /admin", users.ErrorBoundaryDir)
 	}
 	if users.ErrorBoundaryLayoutDepth != 2 {


### PR DESCRIPTION
## Summary

Post-merge follow-up to #126 (Phase 0t error boundary). Windows CI failed on `TestScanErrorChainNearest` because `strings.HasSuffix(dir, "/routes")` doesn't match Windows-style `\\routes`. The test now normalizes via `filepath.ToSlash` before suffix-matching so the assertion works on every platform.

## Test plan

- [x] `go test -race -count=1 ./internal/routescan/...`
- [x] `gofumpt -l .` clean
- [x] `go vet ./...` clean
- [x] Windows CI matrix (push-to-main job) green after merge