### PR TITLE
feat(docs): Vitepress site, llms.txt, copy-for-LLM, AI guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ coverage*.out
 coverage*.html
 *.prof
 go.work.sum
+
+# Docs site (Vitepress)
+docs/.vitepress/dist/
+docs/.vitepress/cache/
+docs/node_modules/

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,91 @@
+import { defineConfig } from 'vitepress';
+import llmsTxt from './plugins/llms-txt';
+import rawMarkdown from './plugins/raw-md';
+
+export default defineConfig({
+  title: 'sveltego',
+  description: 'SvelteKit-shape framework for Go. SSR via codegen, no JS server runtime.',
+  cleanUrls: true,
+  lastUpdated: true,
+  appearance: 'dark',
+  head: [
+    ['meta', { name: 'theme-color', content: '#ff3e00' }],
+  ],
+  themeConfig: {
+    nav: [
+      { text: 'Guide', link: '/guide/quickstart' },
+      { text: 'Reference', link: '/reference/kit' },
+      { text: 'AI', link: '/ai-development' },
+      { text: 'GitHub', link: 'https://github.com/binsarjr/sveltego' },
+    ],
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Getting started',
+          items: [
+            { text: 'Quickstart', link: '/guide/quickstart' },
+          ],
+        },
+        {
+          text: 'Concepts',
+          items: [
+            { text: 'Routing', link: '/guide/routing' },
+            { text: 'Load', link: '/guide/load' },
+            { text: 'Form actions', link: '/guide/actions' },
+            { text: 'Hooks', link: '/guide/hooks' },
+            { text: 'Errors', link: '/guide/errors' },
+            { text: 'Components', link: '/guide/components' },
+            { text: 'Snippets', link: '/guide/snippets' },
+          ],
+        },
+        {
+          text: 'Build & deploy',
+          items: [
+            { text: 'Build', link: '/guide/build' },
+            { text: 'Deploy', link: '/guide/deploy' },
+            { text: 'CSP', link: '/guide/csp' },
+          ],
+        },
+        {
+          text: 'Migration',
+          items: [
+            { text: 'From SvelteKit', link: '/guide/migration' },
+            { text: 'FAQ', link: '/guide/faq' },
+          ],
+        },
+      ],
+      '/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'kit', link: '/reference/kit' },
+            { text: 'Routes', link: '/reference/routes' },
+            { text: 'Manifest', link: '/reference/manifest' },
+            { text: 'CLI', link: '/reference/cli' },
+          ],
+        },
+      ],
+    },
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/binsarjr/sveltego' },
+    ],
+    search: {
+      provider: 'local',
+    },
+    editLink: {
+      pattern: 'https://github.com/binsarjr/sveltego/edit/main/docs/:path',
+      text: 'Edit this page on GitHub',
+    },
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'sveltego contributors',
+    },
+  },
+  vite: {
+    plugins: [llmsTxt(), rawMarkdown()],
+  },
+  markdown: {
+    theme: { light: 'github-light', dark: 'github-dark' },
+    lineNumbers: false,
+  },
+});

--- a/docs/.vitepress/plugins/llms-txt.ts
+++ b/docs/.vitepress/plugins/llms-txt.ts
@@ -1,0 +1,112 @@
+import { glob } from 'tinyglobby';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+
+const SITE_URL = 'https://sveltego.dev';
+const SIZE_WARN = 500 * 1024;
+
+interface PageMeta {
+  file: string;
+  slug: string;
+  title: string;
+  summary: string;
+  order: number;
+  body: string;
+}
+
+function stripFrontmatter(src: string): { meta: Record<string, string>; body: string } {
+  if (!src.startsWith('---\n')) {
+    return { meta: {}, body: src };
+  }
+  const end = src.indexOf('\n---\n', 4);
+  if (end === -1) {
+    return { meta: {}, body: src };
+  }
+  const fm = src.slice(4, end);
+  const body = src.slice(end + 5);
+  const meta: Record<string, string> = {};
+  for (const line of fm.split('\n')) {
+    const i = line.indexOf(':');
+    if (i === -1) continue;
+    const k = line.slice(0, i).trim();
+    let v = line.slice(i + 1).trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1);
+    }
+    meta[k] = v;
+  }
+  return { meta, body };
+}
+
+function firstHeading(body: string): string {
+  for (const line of body.split('\n')) {
+    if (line.startsWith('# ')) return line.slice(2).trim();
+  }
+  return '';
+}
+
+function slugOf(file: string): string {
+  if (file === 'index.md') return '';
+  return file.replace(/\.md$/, '');
+}
+
+export default function llmsTxtPlugin(): Plugin {
+  let outDir = '';
+  let docsRoot = '';
+  return {
+    name: 'sveltego:llms-txt',
+    apply: 'build',
+    configResolved(cfg) {
+      outDir = cfg.build.outDir;
+      docsRoot = cfg.root;
+    },
+    async closeBundle() {
+      if (!outDir || !docsRoot) return;
+      const files = await glob(['**/*.md', '!.vitepress/**', '!node_modules/**'], {
+        cwd: docsRoot,
+      });
+      const pages: PageMeta[] = [];
+      for (const file of files) {
+        const src = await readFile(path.join(docsRoot, file), 'utf8');
+        const { meta, body } = stripFrontmatter(src);
+        const title = meta.title || firstHeading(body) || file;
+        const summary = meta.summary || '';
+        const order = meta.order ? Number(meta.order) : 999;
+        pages.push({ file, slug: slugOf(file), title, summary, order, body });
+      }
+      pages.sort((a, b) => a.order - b.order || a.file.localeCompare(b.file));
+
+      const indexLines: string[] = [
+        '# sveltego',
+        '',
+        '> SvelteKit-shape framework for Go. SSR via codegen, no JS server runtime.',
+        '',
+        '## Docs',
+        '',
+      ];
+      for (const p of pages) {
+        const url = p.slug === '' ? SITE_URL : `${SITE_URL}/${p.slug}`;
+        const summary = p.summary ? `: ${p.summary}` : '';
+        indexLines.push(`- [${p.title}](${url})${summary}`);
+      }
+      const index = indexLines.join('\n') + '\n';
+      await writeFile(path.join(outDir, 'llms.txt'), index);
+
+      const parts: string[] = [];
+      for (const p of pages) {
+        parts.push(`# ${p.title}\n\n${p.body.trim()}\n`);
+      }
+      const full = parts.join('\n---\n\n');
+      await writeFile(path.join(outDir, 'llms-full.txt'), full);
+
+      const size = Buffer.byteLength(full, 'utf8');
+      if (size > SIZE_WARN) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[sveltego:llms-txt] llms-full.txt is ${(size / 1024).toFixed(1)} KiB — exceeds ${SIZE_WARN / 1024} KiB warning threshold`,
+        );
+      }
+    },
+  };
+}

--- a/docs/.vitepress/plugins/raw-md.ts
+++ b/docs/.vitepress/plugins/raw-md.ts
@@ -1,0 +1,50 @@
+import { glob } from 'tinyglobby';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+
+function stripFrontmatter(src: string): string {
+  if (!src.startsWith('---\n')) return src;
+  const end = src.indexOf('\n---\n', 4);
+  if (end === -1) return src;
+  return src.slice(end + 5).replace(/^\n+/, '');
+}
+
+export default function rawMarkdownPlugin(): Plugin {
+  let outDir = '';
+  let docsRoot = '';
+  return {
+    name: 'sveltego:raw-md',
+    configResolved(cfg) {
+      outDir = cfg.build.outDir;
+      docsRoot = cfg.root;
+    },
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        if (!req.url) return next();
+        const u = req.url.split('?')[0];
+        if (!u.endsWith('.md')) return next();
+        const rel = u.replace(/^\//, '');
+        try {
+          const src = await readFile(path.join(server.config.root, rel), 'utf8');
+          res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+          res.end(stripFrontmatter(src));
+        } catch {
+          next();
+        }
+      });
+    },
+    async closeBundle() {
+      if (!outDir || !docsRoot) return;
+      const files = await glob(['**/*.md', '!.vitepress/**', '!node_modules/**'], {
+        cwd: docsRoot,
+      });
+      for (const file of files) {
+        const src = await readFile(path.join(docsRoot, file), 'utf8');
+        const out = path.join(outDir, file);
+        await mkdir(path.dirname(out), { recursive: true });
+        await writeFile(out, stripFrontmatter(src));
+      }
+    },
+  };
+}

--- a/docs/.vitepress/theme/components/CopyForLLM.vue
+++ b/docs/.vitepress/theme/components/CopyForLLM.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useData } from 'vitepress';
+
+const { page, frontmatter } = useData();
+const toast = ref('');
+
+function pageTitle(): string {
+  return (
+    (frontmatter.value && (frontmatter.value as Record<string, string>).title) ||
+    page.value.title ||
+    page.value.relativePath
+  );
+}
+
+function pageURL(): string {
+  if (typeof window === 'undefined') return '';
+  return window.location.href;
+}
+
+function rawMdURL(): string {
+  if (typeof window === 'undefined') return '';
+  const rel = page.value.relativePath;
+  return new URL(`/${rel}`, window.location.origin).toString();
+}
+
+async function fetchMd(): Promise<string> {
+  const res = await fetch(rawMdURL());
+  if (!res.ok) throw new Error(`fetch ${res.status}`);
+  return await res.text();
+}
+
+async function copy(forLLM: boolean) {
+  try {
+    let body = await fetchMd();
+    if (forLLM) {
+      body = `# sveltego docs — ${pageTitle()}\n\nSource: ${pageURL()}\n\n${body}`;
+    }
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(body);
+    } else {
+      const ta = document.createElement('textarea');
+      ta.value = body;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+    toast.value = 'Copied';
+  } catch (err) {
+    toast.value = `Failed: ${(err as Error).message}`;
+  }
+  setTimeout(() => {
+    toast.value = '';
+  }, 1800);
+}
+</script>
+
+<template>
+  <div class="copy-for-llm">
+    <button type="button" @click="copy(false)" aria-label="Copy page as Markdown">
+      Copy as Markdown
+    </button>
+    <button type="button" @click="copy(true)" aria-label="Copy page for LLM">
+      Copy for LLM
+    </button>
+    <span v-if="toast" class="toast">{{ toast }}</span>
+  </div>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,14 @@
+import DefaultTheme from 'vitepress/theme';
+import type { Theme } from 'vitepress';
+import { h } from 'vue';
+import CopyForLLM from './components/CopyForLLM.vue';
+import './style.css';
+
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'doc-before': () => h(CopyForLLM),
+    });
+  },
+} satisfies Theme;

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,0 +1,28 @@
+.copy-for-llm {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0 0 1rem 0;
+  flex-wrap: wrap;
+}
+
+.copy-for-llm button {
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.copy-for-llm button:hover {
+  background: var(--vp-c-bg-mute);
+}
+
+.copy-for-llm .toast {
+  font-size: 0.8rem;
+  color: var(--vp-c-text-2);
+  align-self: center;
+}

--- a/docs/ai-development.md
+++ b/docs/ai-development.md
@@ -1,0 +1,121 @@
+---
+title: Working with AI assistants
+order: 100
+summary: Configure Claude Code, Cursor, Copilot, and Continue for sveltego projects.
+---
+
+# Working with AI assistants
+
+sveltego is built with AI-assisted development in mind. Project templates ship `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `.github/copilot-instructions.md`; the docs site exposes `llms.txt` and a "Copy for LLM" button on every page; an MCP server is on the v1.1 roadmap (#71).
+
+This page collects the setup snippets and the gotchas worth knowing.
+
+## Quick setup
+
+### Claude Code / Claude Desktop
+
+Project-level instructions live at the repo root in `CLAUDE.md`. Claude Code reads it automatically. The shipped `CLAUDE.md` includes the read-this-first list, the Go-expression invariants, and the verification gates.
+
+For Claude Desktop's MCP integration:
+
+```jsonc
+// ~/.config/claude/mcp.json
+{
+  "mcpServers": {
+    "sveltego": { "command": "sveltego", "args": ["mcp"] }
+  }
+}
+```
+
+The `sveltego mcp` command lands with #71. Until then, the Copy-for-LLM buttons on this site cover the same ingestion path.
+
+### Cursor
+
+Drop `.cursorrules` from `sveltego init --ai` into your project root. Cursor reads it automatically and applies it to every chat.
+
+For MCP: Cursor Settings → MCP → add `sveltego mcp`.
+
+### GitHub Copilot
+
+`sveltego init --ai` writes `.github/copilot-instructions.md`. Copilot Chat picks it up automatically; Copilot inline completion uses it as additional context where supported.
+
+### Continue
+
+```jsonc
+// .continue/config.json
+{
+  "rules": ["./AGENTS.md"]
+}
+```
+
+Continue resolves `AGENTS.md` as the master rules file; the project keeps `.cursorrules` and `copilot-instructions.md` in sync via a simple sync step (RFC #103).
+
+## Project templates
+
+```sh
+sveltego init --ai
+```
+
+Adds `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`. AGENTS.md is the master; the other three are generated from it. Edit AGENTS.md and re-run the sync to update the rest.
+
+## Prompting tips
+
+### sveltego-specific gotchas
+
+LLMs default to JavaScript when generating Svelte. Remind them:
+
+> Use Go expressions inside mustaches. PascalCase fields. `nil` not `null`. `len(x)` not `x.length`. Server modules need `//go:build sveltego` at the top.
+
+The shipped templates do this for you; the prompts below assume the rules are loaded.
+
+### Three example prompts that work
+
+**Scaffold a route**
+
+> Create a `src/routes/blog/[slug]` route with `+page.svelte` and `+page.server.go`. The page shows a `Post` fetched by slug from `db.PostBySlug(ctx, slug)`. Fields: `Title`, `Body` (HTML), `PublishedAt` (`time.Time`).
+
+**Write a form action**
+
+> Add a comment form to `src/routes/blog/[slug]/+page.svelte` and an action in `+page.server.go` that validates body is non-empty, appends to `db.Comments`, and redirects back to the page on success or returns `kit.ActionFail(422, ...)` on validation failure.
+
+**Add a hook**
+
+> Add `hooks.server.go` with a `Handle` that reads cookie `session`, calls `auth.LookupUser(token)`, and attaches `*User` to `ev.Locals["user"]`. Use `kit.Sequence` so we can chain another handler later.
+
+## Watch out for
+
+LLMs reach for SvelteKit-flavored patterns. Reject these:
+
+- `export let prop` → use `$props[T]()`.
+- `<script>` without `lang="go"` → reject.
+- `kit.json(...)` (lowercase) → actual API is `kit.JSON(status, body)`.
+- `throw redirect(303, ...)` → `return data, kit.Redirect(303, ...)`.
+- `data.posts.length` in mustaches → `len(Data.Posts)`.
+- `data.user?.name` → Go has no optional chaining; check `Data.User != nil`.
+- `useState`, `writable`, `derived` from Svelte stores → use runes (`$state`, `$derived`).
+- Universal Load (`+page.ts`) → server-only by design; not supported.
+
+## Markdown access for assistants
+
+Every page on this site is reachable as raw markdown:
+
+- `https://sveltego.dev/guide/routing` → HTML
+- `https://sveltego.dev/guide/routing.md` → markdown
+
+Two buttons sit at the top of every page:
+
+- **Copy as Markdown** — copies the page body without frontmatter.
+- **Copy for LLM** — prepends a small context header (page title and source URL) so the assistant has provenance.
+
+Two single-fetch endpoints for whole-site ingestion:
+
+- `https://sveltego.dev/llms.txt` — curated index with one-line summaries.
+- `https://sveltego.dev/llms-full.txt` — every page concatenated as markdown.
+
+Both are generated at docs build, ordered by frontmatter `order`.
+
+## More
+
+- AGENTS.md spec: RFC #103.
+- llms.txt convention: <https://llmstxt.org/>.
+- Project conventions live in `CLAUDE.md` at the repo root and in per-package `CLAUDE.md` files where helpful.

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -1,0 +1,87 @@
+---
+title: Form actions
+order: 40
+summary: POST handlers tied to a page — default and named actions, validation, redirect.
+---
+
+# Form actions
+
+Form actions are POST handlers attached to a page. They live in `+page.server.go` next to `Load` and run on `POST` to the page route.
+
+## Shape
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+var Actions = kit.ActionMap{
+  "default": func(ev *kit.RequestEvent) kit.ActionResult {
+    if err := ev.Request.ParseForm(); err != nil {
+      return kit.ActionFail(400, kit.M{"error": err.Error()})
+    }
+    name := ev.Request.PostForm.Get("name")
+    if name == "" {
+      return kit.ActionFail(422, kit.M{"name": "required"})
+    }
+    // ... persist
+    return kit.ActionRedirect(303, "/thanks")
+  },
+}
+```
+
+The dispatcher reads the request's `?/<name>` query and looks up the matching key in `Actions`. Absent query → `"default"`.
+
+## Results
+
+| Constructor | Type | Effect |
+|---|---|---|
+| `kit.ActionDataResult(code, data)` | `ActionData` | Re-render with `data` exposed via `Form`. |
+| `kit.ActionFail(code, data)` | `ActionFailData` | Re-render with failure status (typically 4xx). |
+| `kit.ActionRedirect(code, url)` | `ActionRedirectResult` | Redirect (default 303). |
+
+The `ActionResult` interface is sealed: only the three result types satisfy it. Construct via the helpers above.
+
+## Form data inside the template
+
+After an action runs, the page re-renders with `Form` populated. Access in the template as `{Form.error}`, `{Form.name}`, etc., depending on what the action returned.
+
+```svelte
+<script lang="go">
+  type PageData struct{}
+</script>
+
+<form method="POST">
+  <input name="name" />
+  <button>Submit</button>
+  {#if Form != nil}
+    <p class="error">{Form.error}</p>
+  {/if}
+</form>
+```
+
+## Multiple actions
+
+Name them by query parameter:
+
+```go
+var Actions = kit.ActionMap{
+  "create": createAction,
+  "delete": deleteAction,
+}
+```
+
+Submit to `?/create` or `?/delete`:
+
+```svelte
+<form method="POST" action="?/delete">
+  <input type="hidden" name="id" value="{Data.ID}" />
+  <button>Delete</button>
+</form>
+```
+
+## Progressive enhancement
+
+Actions degrade gracefully without JavaScript: a plain `<form method="POST">` works. Client-side enhancement (without full reload) lands with the v0.3 client bundle work — track issue #34.

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -1,0 +1,68 @@
+---
+title: Build
+order: 80
+summary: sveltego build, .gen output, Vite client bundle, single-binary deploy.
+---
+
+# Build
+
+`sveltego build` runs codegen then hands off to `go build`. The output is a single binary plus the Vite client bundle.
+
+## Pipeline
+
+1. Scan `src/routes/**` for `+page.svelte`, `+page.server.go`, `+layout.svelte`, `+layout.server.go`, `+server.go`, `+error.svelte`.
+2. Parse `.svelte` files via the sveltego parser; validate Go expressions in mustaches via `go/parser.ParseExpr`.
+3. Emit `.gen/*.go` — one Go file per template, plus a manifest registering routes, layouts, and page options.
+4. Run Vite to produce the client hydration bundle (`dist/`).
+5. Hand off to `go build` to produce the server binary.
+
+## Generated layout
+
+```
+.gen/
+  routes/
+    page__root.gen.go         # +page.svelte at /
+    page__blog__slug.gen.go   # +page.svelte at /blog/[slug]
+    layout__root.gen.go       # +layout.svelte at root
+    server__api__hello.gen.go # +server.go at /api/hello
+  manifest.gen.go             # routes, layouts, params, hooks
+  links.gen.go                # typed kit.Link helpers per route
+```
+
+The `.gen/` directory is gitignored; it is regenerated on every build.
+
+## Page options
+
+Declare per-page options as exported constants in `+page.server.go` or `+layout.server.go`:
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+const (
+  Prerender     = true
+  SSR           = true
+  CSR           = false
+  TrailingSlash = kit.TrailingSlashNever
+)
+```
+
+Layout values cascade to descendants; page values override the cascade. The manifest stores the resolved value per route, so the pipeline does not re-walk the layout chain at request time.
+
+## Tooling commands
+
+| Command | Purpose |
+|---|---|
+| `sveltego build` | Full codegen + go build. |
+| `sveltego compile` | Codegen only. |
+| `sveltego dev` | Watch + regenerate. |
+| `sveltego check` | Validate without writing output. |
+| `sveltego routes` | Print the route table. |
+| `sveltego version` | Print version. |
+
+## Determinism
+
+Codegen is deterministic byte-for-byte. Two builds of the same source produce identical `.gen/` output. Golden tests in the codegen package enforce this; see issue #104 for the `-update` flag flow.

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -1,0 +1,98 @@
+---
+title: Components
+order: 70
+summary: Svelte 5 runes — $props, $state, $derived, $effect, $bindable.
+---
+
+# Components
+
+sveltego targets **Svelte 5 only**. Legacy Svelte 4 reactivity (`$:`, store auto-subscriptions, `export let`) is not supported. Use runes.
+
+## Props
+
+```svelte
+<script lang="go">
+  type Props struct {
+    Name  string
+    Count int
+  }
+  var p = $props[Props]()
+</script>
+
+<p>Hello {p.Name}, {p.Count} unread.</p>
+```
+
+`$props[T]()` returns a typed value. Field access in the template (`{p.Name}`) is a Go expression: PascalCase, no JS pattern destructuring at the prop boundary.
+
+## State
+
+```svelte
+<script lang="go">
+  var count = $state(0)
+</script>
+
+<button onclick={func() { count++ }}>
+  Clicked {count} times
+</button>
+```
+
+`$state[T](initial)` creates a reactive cell. Reads and writes are via the cell value; the runtime tracks dependencies for re-render on the client.
+
+## Derived
+
+```svelte
+<script lang="go">
+  var count = $state(0)
+  var doubled = $derived(count * 2)
+</script>
+
+<p>{doubled}</p>
+```
+
+`$derived(expr)` recomputes when its dependencies change. Pure expressions only — no I/O.
+
+## Effects
+
+```svelte
+<script lang="go">
+  var count = $state(0)
+  $effect(func() {
+    log("count changed to", count)
+  })
+</script>
+```
+
+`$effect(fn)` runs after the DOM updates and re-runs when its dependencies change. Use for side effects that must observe state.
+
+## Bindable
+
+```svelte
+<script lang="go">
+  type Props struct {
+    Value string
+  }
+  var p = $bindable[Props]()
+</script>
+
+<input bind:value={p.Value} />
+```
+
+`$bindable[T]()` declares a two-way binding. The parent component supplies and updates the bound value through the same field.
+
+## Mustache expressions
+
+Inside `{...}` you write Go:
+
+```svelte
+{Data.User.Name}
+{len(Data.Posts)}
+{strings.ToUpper(Data.Title)}
+{#if Data.Posts != nil && len(Data.Posts) > 0}
+  ...
+{/if}
+{#each Data.Posts as post}
+  <li>{post.Title}</li>
+{/each}
+```
+
+Validated at codegen via `go/parser.ParseExpr`. Type errors surface at `sveltego build`, not runtime.

--- a/docs/guide/csp.md
+++ b/docs/guide/csp.md
@@ -1,0 +1,68 @@
+---
+title: CSP
+order: 86
+summary: Content-Security-Policy via kit.CSPConfig with per-request nonce.
+---
+
+# Content Security Policy
+
+sveltego ships a CSP middleware behind `kit.CSPConfig`. Strict mode emits `Content-Security-Policy`; report-only mode emits `Content-Security-Policy-Report-Only` so violations are observed without enforcement during rollout.
+
+## Enable
+
+```go
+cfg := kit.CSPConfig{
+  Mode: kit.CSPStrict,
+  Directives: map[string][]string{
+    // override or extend the defaults
+    "img-src": {"'self'", "data:", "https://cdn.example.com"},
+  },
+  ReportTo: "csp-endpoint",
+}
+```
+
+Pass `cfg` to the server constructor; the pipeline inserts a per-request nonce into `Locals` and splices it into the `script-src` directive.
+
+## Defaults
+
+`kit.DefaultCSPDirectives()` returns:
+
+```
+default-src 'self'
+script-src  'strict-dynamic'
+style-src   'self' 'unsafe-inline'
+img-src     'self' data:
+connect-src 'self'
+base-uri    'self'
+form-action 'self'
+```
+
+Your `Directives` map merges over this baseline. Setting a directive to an empty slice removes it.
+
+## Inline scripts
+
+Use the per-request nonce on every inline `<script>`:
+
+```svelte
+<script lang="go">
+  // SSR template
+</script>
+
+<script{kit.NonceAttr(Ctx)}>
+  console.log("hello");
+</script>
+```
+
+`kit.NonceAttr(ev)` returns ` nonce="<n>"` when CSP is on, or the empty string when off — so the same template compiles uniformly across opt-in and opt-out builds.
+
+## Modes
+
+| Mode | Effect |
+|---|---|
+| `kit.CSPOff` | No header. Default. |
+| `kit.CSPStrict` | `Content-Security-Policy` enforced. |
+| `kit.CSPReportOnly` | `Content-Security-Policy-Report-Only` for observation. |
+
+## Header determinism
+
+Directive order is deterministic (alphabetical) so two requests with equivalent input produce byte-identical headers. This simplifies caching and snapshot tests.

--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -1,0 +1,70 @@
+---
+title: Deploy
+order: 85
+summary: Single binary plus static assets — Docker, systemd, Cloudflare Workers.
+---
+
+# Deploy
+
+A built sveltego app is one Go binary plus a `dist/` directory of static assets. Deploy as you would any Go HTTP server.
+
+## Single binary
+
+```sh
+sveltego build
+go build -o app ./cmd/app
+./app
+```
+
+Set `PORT`, log level via `-v`/`-vv`/`-vvv`, and any environment your `Init` hook expects.
+
+## Docker
+
+```dockerfile
+FROM golang:1.23 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go install github.com/binsarjr/sveltego/cmd/sveltego@latest \
+    && sveltego build \
+    && go build -trimpath -ldflags="-s -w" -o /out/app ./cmd/app
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=build /out/app /app
+COPY --from=build /src/dist /dist
+USER nonroot:nonroot
+EXPOSE 8080
+ENTRYPOINT ["/app"]
+```
+
+The image is small because the binary is statically linked and the Vite output is plain static files.
+
+## systemd
+
+```ini
+[Unit]
+Description=sveltego app
+After=network.target
+
+[Service]
+ExecStart=/srv/app
+Environment=PORT=8080
+Restart=on-failure
+User=app
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Cloudflare Workers
+
+The Cloudflare Workers adapter is in scope (issue #92) but not yet implemented. Vercel and Netlify Functions adapters are explicitly out of scope; see [non-goals](/guide/faq#non-goals).
+
+## Reverse proxy
+
+Behind nginx or Caddy, terminate TLS at the proxy and forward to the Go binary. Honor `X-Forwarded-*` headers as you would any Go server. sveltego does not assume direct internet exposure.
+
+## Static assets
+
+The Vite output lives in `dist/`. Serve it with whatever static handler you prefer; `http.FileServer` works. Long-lived `Cache-Control` is safe because filenames are content-hashed.

--- a/docs/guide/errors.md
+++ b/docs/guide/errors.md
@@ -1,0 +1,77 @@
+---
+title: Errors
+order: 60
+summary: kit.Error, kit.Redirect, kit.Fail, +error.svelte, SafeError contract.
+---
+
+# Errors
+
+sveltego uses idiomatic Go error returns. No panic-as-control-flow. Three sentinel constructors cover the common cases.
+
+## Sentinels
+
+| Constructor | Type | Used for |
+|---|---|---|
+| `kit.Error(code, msg)` | `*HTTPErr` | HTTP error short-circuit (404, 500, ...). |
+| `kit.Redirect(code, location)` | `*RedirectErr` | Redirect (303 POST→GET, 307/308 method-preserving). |
+| `kit.Fail(code, data)` | `*FailErr` | Form action validation failure with form-bound data. |
+
+All three implement `error` and `httpStatuser`. The pipeline detects them and writes the appropriate response.
+
+## Returning from Load
+
+```go
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+  user, err := authUser(ctx.Request)
+  if err != nil {
+    return PageData{}, kit.Redirect(303, "/login")
+  }
+  if !user.IsAdmin {
+    return PageData{}, kit.Error(403, "admins only")
+  }
+  return PageData{User: user}, nil
+}
+```
+
+## Error boundary
+
+`+error.svelte` catches errors from any descendant page or layout. The nearest `+error.svelte` walking up from the failing route is rendered.
+
+```svelte
+<script lang="go">
+  type PageData struct {
+    Error kit.SafeError
+  }
+</script>
+
+<h1>{Data.Error.Code}: {Data.Error.Message}</h1>
+{#if Data.Error.ID != ""}
+  <p>Reference: {Data.Error.ID}</p>
+{/if}
+```
+
+## SafeError
+
+`HandleError` produces a `kit.SafeError` — the user-facing contract:
+
+```go
+type SafeError struct {
+  Code    int
+  Message string
+  ID      string
+}
+```
+
+The pipeline never exposes the raw error to the client. Log the raw error inside `HandleError`; surface only `SafeError` in the boundary.
+
+## Default behavior
+
+If no `HandleError` is defined, `kit.IdentityHandleError` returns a generic 500 with no body detail. Set one in `hooks.server.go` to customize:
+
+```go
+func HandleError(ev *kit.RequestEvent, err error) kit.SafeError {
+  id := correlationID(ev)
+  slog.ErrorContext(ev.Request.Context(), "request failed", "err", err, "id", id)
+  return kit.SafeError{Code: 500, Message: "internal error", ID: id}
+}
+```

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -1,0 +1,61 @@
+---
+title: FAQ
+order: 95
+summary: Common questions and the canonical non-goals list.
+---
+
+# FAQ
+
+## Why not embed a JS runtime?
+
+Adapters layered on top of SvelteKit-the-JS-server inherit every limitation of the chosen runtime: foreign concurrency model, no goroutines, no `context.Context`, IPC overhead per request. Going faster than the runtime is impossible.
+
+The SvelteKit *shape* (file convention, mental model) is what users want — not the SvelteKit *implementation*. Rewriting the shape in Go unlocks the standard library, goroutines, and a target throughput of 20–40k rps for mid-complexity SSR.
+
+## Why Svelte 5 only?
+
+Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) are easier to compile to Go than legacy `$:` reactivity. Locking to Svelte 5 keeps the codegen surface tractable and avoids a forever-deprecation tail.
+
+## Can I write TypeScript in `<script>`?
+
+No. `<script lang="go">` is the only supported language. The expression validator runs `go/parser` on every mustache.
+
+## Can I use my SvelteKit components?
+
+Markup mostly. Mustaches must be rewritten to Go. Component scripts must be rewritten to Go. The result is a port, not a drop-in.
+
+## Where is hot reload?
+
+`sveltego dev` watches `src/routes/**` and regenerates `.gen/*.go` on change. The Go server restart is the primary feedback loop. Browser HMR for the Vite client bundle works as in any Vite project.
+
+## How do I serve static files?
+
+`http.FileServer` against the Vite output (`dist/`). sveltego does not bundle a static handler; you pick.
+
+## How do I add WebSockets?
+
+Bring `gorilla/websocket` (or any other library). Mount the upgrade handler in your server. WebSocket primitives are not in the `kit` package by design.
+
+## How do I add i18n?
+
+Bring `go-i18n`. Pass the localizer through `Locals` from `Handle`. i18n is not in `kit` by design.
+
+## Non-goals
+
+The following are explicitly **not** going to ship in `kit` or core. See `tasks/decisions/0005-non-goals.md` and the project README for canonical reasoning.
+
+- Universal (shared client+server) `Load` — server-only by design.
+- `<script context="module">`.
+- WebSocket / SSE primitives in core.
+- Vercel / Netlify Functions adapters (Cloudflare Workers adapter is in scope).
+- vitePreprocess / arbitrary preprocessor pipeline.
+- JSDoc-driven type discovery (Go types only).
+- Deep dynamic-import code splitting beyond per-route.
+- Runtime template interpretation.
+- View Transitions API in core.
+- Built-in i18n primitives.
+- Built-in form-validation library.
+- Svelte 4 legacy reactivity (`$:`, store autoload).
+- Server-side dynamic JS execution.
+- Native Go bundler replacing Vite for the client.
+- Multi-tenant / RBAC primitives in `kit`.

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -1,0 +1,89 @@
+---
+title: Hooks
+order: 50
+summary: Handle, HandleError, HandleFetch, Reroute, Init — request lifecycle hooks.
+---
+
+# Hooks
+
+`src/hooks.server.go` exports five optional hooks. Generated code wires the missing ones to identity defaults so you only write what you need.
+
+```go
+//go:build sveltego
+
+package hooks
+
+import (
+  "context"
+  "net/http"
+  "net/url"
+
+  "github.com/binsarjr/sveltego/exports/kit"
+)
+
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) {
+  // pre: read cookie, set ev.Locals["user"]
+  res, err := resolve(ev)
+  // post: mutate response headers
+  return res, err
+}
+
+func HandleError(ev *kit.RequestEvent, err error) kit.SafeError {
+  return kit.SafeError{Code: 500, Message: "something went wrong"}
+}
+
+func HandleFetch(ev *kit.RequestEvent, req *http.Request) (*http.Response, error) {
+  return http.DefaultClient.Do(req)
+}
+
+func Reroute(u *url.URL) string {
+  return ""
+}
+
+func Init(ctx context.Context) error {
+  return nil
+}
+```
+
+## Handle
+
+`Handle` wraps the entire request pipeline. Call `resolve(ev)` to advance to route resolution. Return without calling `resolve` to short-circuit.
+
+Compose multiple handlers with `kit.Sequence`:
+
+```go
+var Handle = kit.Sequence(authHandle, requestIDHandle, telemetryHandle)
+```
+
+`Sequence` runs handlers left-to-right; each one's `resolve` advances to the next. Returning early from any handler short-circuits the rest.
+
+## HandleError
+
+Called whenever `Handle`, `Load`, render, or a `+server.go` handler returns an error. Returns a `kit.SafeError` — the user-facing contract: `Code`, `Message`, `ID`. Logs the raw error; the response body never echoes internal detail.
+
+## HandleFetch
+
+Intercepts outbound HTTP from `Load` and `+server.go`. Use it to add auth headers, redirect to local services, or apply request-scoped retries.
+
+`RequestEvent.Fetch(req)` dispatches through `HandleFetch`; bypass it (e.g. `http.DefaultClient.Do`) and the hook is silently skipped.
+
+## Reroute
+
+Runs before route matching. Return a non-empty path to rewrite the URL used for lookup. `ev.URL` is preserved as the original; `ev.MatchPath` carries the rewrite. Empty string = no rewrite.
+
+```go
+func Reroute(u *url.URL) string {
+  if u.Path == "/old-path" {
+    return "/new-path"
+  }
+  return ""
+}
+```
+
+## Init
+
+Runs once at server start, before the first request. Use for warmup: open DB pools, prime caches, register metrics. Returning a non-nil error aborts startup.
+
+## Defaults
+
+`kit.DefaultHooks()` returns identity defaults for every field. `kit.Hooks{}.WithDefaults()` fills in the missing ones — idempotent, called by generated wiring code.

--- a/docs/guide/load.md
+++ b/docs/guide/load.md
@@ -1,0 +1,83 @@
+---
+title: Load
+order: 30
+summary: Server-side Load functions, parent layout data, request-scoped fetch.
+---
+
+# Load
+
+`Load` is the server-side data loader for a page or layout. It receives a `*kit.LoadCtx` and returns a typed `PageData` (or `LayoutData`) plus an error.
+
+## Page load
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+type PageData struct {
+  Title string
+  Posts []Post
+}
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+  posts, err := db.RecentPosts(ctx.Request.Context())
+  if err != nil {
+    return PageData{}, err
+  }
+  return PageData{Title: "Recent posts", Posts: posts}, nil
+}
+```
+
+Inside the template, fields are referenced as `{Data.Title}`, `{Data.Posts}`, etc. PascalCase, Go expressions, `nil` not `null`.
+
+## Layout load
+
+`+layout.server.go` works the same way and exports `LayoutData`. The pipeline runs each layer's `Load` outer-to-inner. Children read the immediate parent through `ctx.Parent()`:
+
+```go
+parent := ctx.Parent().(rootlayout.LayoutData)
+```
+
+The cast is explicit so type changes show up at build.
+
+## Errors and short-circuits
+
+`Load` returns `error` for typed control flow:
+
+```go
+return PageData{}, kit.Error(404, "post not found")
+return PageData{}, kit.Redirect(303, "/login")
+```
+
+`kit.Redirect` and `kit.Error` carry HTTP semantics; the pipeline routes them to the appropriate response. See [Errors](/guide/errors) for the full set.
+
+## Fetch through hooks
+
+`ctx.Request` is the live request; outbound HTTP from `Load` should go through `ev.Fetch(req)` so `HandleFetch` can intercept it. Generated wrappers reach for that method when available — write your own outbound calls the same way:
+
+```go
+req, _ := http.NewRequestWithContext(ctx.Request.Context(), "GET", "https://api/...", nil)
+res, err := ev.Fetch(req)
+```
+
+## Streaming
+
+Defer slow work via `kit.Stream`:
+
+```go
+return PageData{
+  Hero:    fast,
+  Reviews: kit.Stream(func() ([]Review, error) { return slow() }),
+}, nil
+```
+
+The render path emits a placeholder, flushes the shell, then patches the slot when the goroutine resolves. Default timeout is `kit.DefaultStreamTimeout` (30s).
+
+## What `Load` cannot do
+
+- It cannot run on the client. Loaders are server-only.
+- It must not mutate `RequestEvent.Locals` after `Handle` finished — read only.
+- It cannot write to `http.ResponseWriter`; responses come from the page template or a `+server.go` handler.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,0 +1,97 @@
+---
+title: Migration from SvelteKit
+order: 90
+summary: What carries over, what changes, what does not exist in sveltego.
+---
+
+# Migration from SvelteKit
+
+sveltego mirrors SvelteKit's *shape*, not its *implementation*. The file conventions and mental model are the same; the language is Go, and a few features are explicit non-goals.
+
+## What carries over
+
+| SvelteKit | sveltego |
+|---|---|
+| `+page.svelte` | `+page.svelte` |
+| `+page.server.ts` | `+page.server.go` |
+| `+layout.svelte` | `+layout.svelte` |
+| `+layout.server.ts` | `+layout.server.go` |
+| `+server.ts` | `+server.go` |
+| `+error.svelte` | `+error.svelte` |
+| `hooks.server.ts` | `hooks.server.go` |
+| `[param]`, `[[opt]]`, `[...rest]`, `(group)` | identical |
+| `$lib` alias | `$lib` alias (resolves to `src/lib`) |
+| `$env/static/private`, `$env/static/public`, `$env/dynamic/*` | `kit/env` package |
+
+## What changes
+
+- **Language.** `<script>` is Go, not TypeScript. Mustaches are Go expressions.
+- **Field naming.** PascalCase fields, not camelCase: `{Data.UserName}`, not `{data.userName}`.
+- **Nullability.** `nil`, not `null`. `data == nil`, not `data === undefined`.
+- **Length.** `len(xs)`, not `xs.length`.
+- **Errors.** Idiomatic Go errors. `kit.Redirect(303, ...)` and `kit.Error(404, ...)` are returned, not thrown.
+- **Form actions.** `kit.ActionResult` is a sealed sum: `ActionData`, `ActionFailData`, `ActionRedirectResult`. Construct via `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`.
+- **Build constraint.** Every `.go` file under `src/routes/**` and `src/params/**` MUST start with `//go:build sveltego` so Go's default toolchain skips them; codegen reads them through `go/parser`.
+
+## What does not exist
+
+These are explicit non-goals (see [FAQ](/guide/faq#non-goals)):
+
+- **Universal Load** (`+page.ts`, `+layout.ts`). Loaders are server-only.
+- **`<script context="module">`.** Deprecated upstream.
+- **vitePreprocess** and arbitrary preprocessor pipelines.
+- **Svelte 4 legacy reactivity** (`$:`, store auto-subscribe, `export let`). Use runes.
+- **WebSocket primitives in core.** Bring `gorilla/websocket`.
+- **i18n primitives.** Bring `go-i18n` (or similar).
+- **Form-validation library.** Bring `go-playground/validator`.
+- **View Transitions API** in core.
+- **JS code splitting beyond per-route.**
+
+## Side-by-side example
+
+### SvelteKit
+
+```ts
+// +page.server.ts
+import { redirect, error } from '@sveltejs/kit';
+
+export async function load({ locals, params }) {
+  if (!locals.user) throw redirect(303, '/login');
+  const post = await db.post(params.slug);
+  if (!post) throw error(404, 'not found');
+  return { post };
+}
+```
+
+### sveltego
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+type PageData struct {
+  Post Post
+}
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+  user, _ := ctx.Locals["user"].(*User)
+  if user == nil {
+    return PageData{}, kit.Redirect(303, "/login")
+  }
+  post, err := db.Post(ctx.Request.Context(), ctx.Params["slug"])
+  if err != nil {
+    return PageData{}, err
+  }
+  if post == nil {
+    return PageData{}, kit.Error(404, "not found")
+  }
+  return PageData{Post: *post}, nil
+}
+```
+
+## Incremental migration
+
+You cannot incrementally swap a SvelteKit project to sveltego — the Go expression model and codegen pipeline rule that out. Treat sveltego as a port: rewrite the server side in Go, keep the `.svelte` markup mostly intact, replace mustaches with Go expressions.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,0 +1,94 @@
+---
+title: Quickstart
+order: 10
+summary: Install the sveltego CLI, scaffold a project, run dev, build, ship.
+---
+
+# Quickstart
+
+sveltego is pre-alpha. Expect rough edges and breaking changes. The shape below tracks the v1.0 milestone; commands and flags may shift.
+
+## Install
+
+```sh
+go install github.com/binsarjr/sveltego/cmd/sveltego@latest
+sveltego version
+```
+
+The CLI is a single binary. No Node runtime is required to run a built app; Node is only needed at build time for the Vite client bundle.
+
+## Scaffold
+
+```sh
+mkdir hello && cd hello
+sveltego init
+```
+
+This produces:
+
+```
+hello/
+  src/
+    routes/
+      +page.svelte
+      +page.server.go      # //go:build sveltego
+    hooks.server.go        # //go:build sveltego (optional)
+    lib/                   # $lib alias target
+  go.mod
+  package.json             # Vite client bundle
+  sveltego.config.go
+```
+
+## A minimal route
+
+`src/routes/+page.svelte`:
+
+```svelte
+<script lang="go">
+  type PageData struct {
+    Greeting string
+  }
+</script>
+
+<h1>{Data.Greeting}</h1>
+```
+
+`src/routes/+page.server.go`:
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+  return PageData{Greeting: "hello, sveltego"}, nil
+}
+```
+
+## Develop
+
+```sh
+sveltego dev
+```
+
+This starts the dev server, watches `src/routes/**`, regenerates `.gen/*.go`, and proxies the Vite dev server for the client bundle.
+
+## Build
+
+```sh
+sveltego build
+go build -o app ./cmd/app
+./app
+```
+
+The `build` step writes `.gen/*.go`; the standard `go build` produces a single binary. Deploy that binary plus the `dist/` Vite output as static assets.
+
+## Next steps
+
+- [Routing](/guide/routing) — `+page.svelte`, params, groups, optional and rest segments.
+- [Load](/guide/load) — server-side data loading, parent layouts, fetch.
+- [Form actions](/guide/actions) — POST handlers tied to a page.
+- [Hooks](/guide/hooks) — `Handle`, `HandleError`, `HandleFetch`, `Reroute`, `Init`.
+- [Migration from SvelteKit](/guide/migration) — what carries over and what does not.

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -1,0 +1,86 @@
+---
+title: Routing
+order: 20
+summary: File-based routing — +page.svelte, +page.server.go, +server.go, params, groups.
+---
+
+# Routing
+
+sveltego uses file-based routing under `src/routes/`. The conventions match SvelteKit, with one constraint: every Go file in `src/routes/**` and `src/params/**` MUST start with `//go:build sveltego` so Go's default toolchain skips them. Codegen reads them through `go/parser` directly.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `+page.svelte` | SSR template. Mustache expressions are Go. |
+| `+page.server.go` | Page server module: `Load`, `Actions`. |
+| `+layout.svelte` | Layout chain. Wraps descendant `+page.svelte`. |
+| `+layout.server.go` | Layout-level `Load` cascading to children. |
+| `+server.go` | REST endpoints (`GET`, `POST`, ...). No template. |
+| `+error.svelte` | Error boundary for the subtree. |
+| `+page@.svelte` | Layout reset — opt out of the parent chain. |
+
+## Path patterns
+
+| Pattern | Example | Description |
+|---|---|---|
+| `[param]` | `blog/[slug]/+page.svelte` | Required parameter. |
+| `[[optional]]` | `[[lang]]/+page.svelte` | Optional segment. |
+| `[...rest]` | `docs/[...path]/+page.svelte` | Catch-all rest. |
+| `(group)` | `(marketing)/+layout.svelte` | Group with no URL segment. |
+| `[name=matcher]` | `users/[id=int]/+page.svelte` | Param matcher. |
+
+## Param matchers
+
+Built-in matchers: `int`, `uuid`, `slug`. Add your own under `src/params/`:
+
+```go
+//go:build sveltego
+
+package params
+
+func Hex(value string) bool {
+  for _, r := range value {
+    switch {
+    case r >= '0' && r <= '9':
+    case r >= 'a' && r <= 'f':
+    default:
+      return false
+    }
+  }
+  return true
+}
+```
+
+Reference it as `[id=hex]`.
+
+## Endpoints
+
+`+server.go` exposes named handlers per HTTP method:
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+func GET(ev *kit.RequestEvent) *kit.Response {
+  return kit.JSON(200, kit.M{"ok": true})
+}
+
+func POST(ev *kit.RequestEvent) *kit.Response {
+  // read ev.Request.Body, return *kit.Response
+  return kit.NoContent()
+}
+```
+
+If a method is not exported, the router answers `405 Method Not Allowed` with a sorted `Allow` header.
+
+## Layouts and reset
+
+A `+page@.svelte` (note the trailing `@`) opts out of the parent layout chain — useful for full-bleed pages inside a section that otherwise applies a marketing shell.
+
+## Out of scope
+
+`+page.ts` / `+layout.ts` (universal Load) is **not** supported. Loaders are server-only by design. See [non-goals](/guide/faq#non-goals).

--- a/docs/guide/snippets.md
+++ b/docs/guide/snippets.md
@@ -1,0 +1,58 @@
+---
+title: Snippets
+order: 75
+summary: Reusable template fragments via {#snippet} and {@render}.
+---
+
+# Snippets
+
+Snippets are reusable template fragments declared inside a component. They replace slot fall-throughs from older Svelte versions and compose better with typed props.
+
+## Declaring
+
+```svelte
+{#snippet greeting(name string)}
+  <p>Hello {name}.</p>
+{/snippet}
+```
+
+A snippet captures parameters by name. Inside the body, parameters are Go-typed; field access is `{name}`, not `{name.value}` or anything JS-flavored.
+
+## Rendering
+
+```svelte
+{@render greeting("world")}
+```
+
+`{@render snippet(args...)}` invokes a snippet. Multiple invocations with different arguments produce different output.
+
+## Snippets as props
+
+A component can accept snippets as props:
+
+```svelte
+<script lang="go">
+  type Props struct {
+    Item func(p Post)
+  }
+  var p = $props[Props]()
+</script>
+
+{#each Data.Posts as post}
+  {@render p.Item(post)}
+{/each}
+```
+
+The parent passes a snippet:
+
+```svelte
+<List Item={#snippet (post Post)}
+  <article>
+    <h2>{post.Title}</h2>
+  </article>
+{/snippet} />
+```
+
+## Out of scope
+
+`<svelte:fragment>` and named slot syntax are not part of the Svelte 5 surface and are not implemented. Use snippets for every fragment-as-prop case.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,47 @@
+---
+layout: home
+title: sveltego
+order: 0
+summary: SvelteKit-shape framework for Go. SSR via codegen, no JS server runtime.
+
+hero:
+  name: sveltego
+  text: SvelteKit shape, in pure Go
+  tagline: Server-side rendering via codegen. Go expressions in templates. No JS runtime on the server.
+  actions:
+    - theme: brand
+      text: Quickstart
+      link: /guide/quickstart
+    - theme: alt
+      text: Reference
+      link: /reference/kit
+    - theme: alt
+      text: GitHub
+      link: https://github.com/binsarjr/sveltego
+
+features:
+  - title: Pure Go server
+    details: .svelte templates compile to .gen/*.go. No goja, v8go, or Bun on the request path.
+  - title: Familiar conventions
+    details: +page.svelte, +page.server.go, +layout.svelte, +error.svelte, hooks.server.go. Same shape as SvelteKit.
+  - title: Go expressions
+    details: '{Data.User.Name}, {len(Data.Posts)}, nil not null. Validated at codegen via go/parser.'
+  - title: Svelte 5 runes
+    details: $props, $state, $derived, $effect, $bindable. No legacy reactivity.
+  - title: Codegen, not interpretation
+    details: Static decisions at build time. Targeted 20–40k rps for mid-complexity SSR.
+  - title: AI-native docs
+    details: llms.txt, llms-full.txt, copy-for-LLM buttons, project-aware AGENTS.md.
+---
+
+## What is sveltego?
+
+sveltego is a rewrite of SvelteKit's shape in pure Go. The file conventions, the data-loading model, the error boundaries, the form actions, the hooks pipeline — all of it lands in Go without a JS runtime on the server.
+
+`.svelte` templates compile to Go source. The `<script>` block hosts Go directly; mustache expressions (`{...}`) are Go expressions, validated at codegen via `go/parser`. Vite is retained at build time only, for the client hydration bundle.
+
+## Why a rewrite?
+
+Adapters layered on top of SvelteKit-the-JS-server inherit every limitation of the chosen runtime. The SvelteKit *shape* (file convention, mental model) is what users want — not the SvelteKit *implementation*. A native Go target unlocks goroutines, `context.Context`, and the Go standard library on every request path.
+
+See the [Quickstart](/guide/quickstart) to scaffold your first app, or the [migration guide](/guide/migration) if you are coming from SvelteKit.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,2569 @@
+{
+  "name": "@sveltego/docs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sveltego/docs",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tinyglobby": "^0.2.10",
+        "vitepress": "^1.5.0",
+        "vue": "^3.5.13"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.17.0.tgz",
+      "integrity": "sha512-nuhHZdTiCtRzJEe9VSNzyqE9cOQMt01UWBzymFnjbgwrxxZpbGHQde6Oa/y9zyspTCjbUtb7Q5HQek1CLiLyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.51.0.tgz",
+      "integrity": "sha512-PKrKlIla1U2J7mFcIQn6N3pWP4oySmkxShnbbDsj/H7818gKbET5KsUwsVoNjWIxHKTJMCTcQ7ekAJ8Ea23NMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.51.0.tgz",
+      "integrity": "sha512-U+HCY1K16Km91pIRL1kN6bW6BbGFAF/WhkRSCx4wyl1aFpbrlhSFQs/dAwWbmyBiHWwVWhl7stWHQ1pum5EfMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.51.0.tgz",
+      "integrity": "sha512-YPJ3dEuZLCRp846Az94t6Z2gwSNRazP+SmBco7p6SCa4fYrtIE820PDXYZshbNrj2Z8Qfbmv7BQ1Lecl5L3G/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.51.0.tgz",
+      "integrity": "sha512-/gEwLlR7fQ7YjOW+ADRZ0NxLDtpTC61FSzlZ01Gdl1kTJfU0Rq3Y/TYqwxGxlQGcUiXtGzrpjxXWh3Y0TZD6NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.51.0.tgz",
+      "integrity": "sha512-nRwUN1Y2cKyOAFZyIBagkEfZSIhP05nWhT4Rjwl84lcjECssYggftrAODrZ4leakXxSGjhxs/AdaAFEIBqwVFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.51.0.tgz",
+      "integrity": "sha512-pybzYCG7VoQKppo+z5iZOKpW8XqtFxhsAIRgEaNboCnfypKukiBHJAwB+pmr7vMZXBsOHwklGYWwCG82e8qshA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.51.0.tgz",
+      "integrity": "sha512-DWVIlj6RqcvdhwP0gBU9OpOQPnHdcAk9jlT+z8rsNb2+liWv4eUlfQZ7saGBraFsnygEHD3PtdppIHvqwBAb5w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.51.0.tgz",
+      "integrity": "sha512-bA25s12iUDJi/X8M7tWlPRT8GeOhls/yDbdoUqinz27lNqsOlcM1UrAxIKdIZ6lm3sXit+ewPIz1pS2x6rXu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.51.0.tgz",
+      "integrity": "sha512-zj+RcE5e0NE0/ew6oEOTgOplPHry+w2oi7h0Y87lhdq4E0d7xLS31KVB8kKfCGkrG7AYtZvrcyvLOKS5d0no4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.51.0.tgz",
+      "integrity": "sha512-/HDgccfye1Rq3bPxaSCsvSEBHzSMmtpM9ZRGRtAuC62Cv+ql/76IWnxjGTDXtqIJ+/j7ZlFYAzq9fkp95wF2SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.51.0.tgz",
+      "integrity": "sha512-nJdW+WBwGlXWMJbxxB7/AJPvNq0lLJSudXmIQCJbmH8jsOXQhRpAtoCD4ceLyJKv3ze9JbQu4Gqu5JDLckuFcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.51.0.tgz",
+      "integrity": "sha512-bsBgRI/1h1mjS3eCyfGau78yGZVmiDLmT1aU6dMnk75/T0SgKqnSKNpQ53xKoDYVChGDcNnpHXWpoUSo8MH1+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.51.0.tgz",
+      "integrity": "sha512-zPrIDVPpmKWgrjmWOqpqrhqAhNjvVkjoj+mqw2NBPxEOuKNzP0H+Qz5NJLLTOepBVj1UFedFaF3AUgxLsB9ukQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.80",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.80.tgz",
+      "integrity": "sha512-iglncJJ6X/dVuzFDU32MrHwwo4RBwivGf108dgyYg+HKS78ifx0h7sTenpDZMVT+UhdS6CSgZcvY/SvRXlIEUg==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.33",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.10",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.33",
+        "@vue/runtime-core": "3.5.33",
+        "@vue/shared": "3.5.33",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33"
+      },
+      "peerDependencies": {
+        "vue": "3.5.33"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.51.0.tgz",
+      "integrity": "sha512-u3XS8HaTzt5YN90KPsOXMRjYJUMVD1dtr6yi4NXQluMbZ5IjQNBu1MEabdAxFhYtEuexqomPMSmRIhQJUd3QSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@algolia/abtesting": "1.17.0",
+        "@algolia/client-abtesting": "5.51.0",
+        "@algolia/client-analytics": "5.51.0",
+        "@algolia/client-common": "5.51.0",
+        "@algolia/client-insights": "5.51.0",
+        "@algolia/client-personalization": "5.51.0",
+        "@algolia/client-query-suggestions": "5.51.0",
+        "@algolia/client-search": "5.51.0",
+        "@algolia/ingestion": "1.51.0",
+        "@algolia/monitoring": "1.51.0",
+        "@algolia/recommend": "5.51.0",
+        "@algolia/requester-browser-xhr": "5.51.0",
+        "@algolia/requester-fetch": "5.51.0",
+        "@algolia/requester-node-http": "5.51.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-sfc": "3.5.33",
+        "@vue/runtime-dom": "3.5.33",
+        "@vue/server-renderer": "3.5.33",
+        "@vue/shared": "3.5.33"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sveltego/docs",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Documentation site for sveltego (Vitepress).",
+  "scripts": {
+    "dev": "vitepress dev .",
+    "build": "vitepress build .",
+    "preview": "vitepress preview ."
+  },
+  "devDependencies": {
+    "tinyglobby": "^0.2.10",
+    "vitepress": "^1.5.0",
+    "vue": "^3.5.13"
+  }
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,59 @@
+---
+title: CLI
+order: 230
+summary: sveltego command reference — build, compile, dev, check, routes, version.
+---
+
+# CLI
+
+`sveltego` is the project's command-line entry point. Install with:
+
+```sh
+go install github.com/binsarjr/sveltego/cmd/sveltego@latest
+```
+
+## Global flags
+
+| Flag | Description |
+|---|---|
+| `-c, --config <path>` | Path to sveltego config (no-op until #21). |
+| `--cwd <path>` | Working directory override (no-op until #21). |
+| `-v, -vv, -vvv` | Increase log verbosity (info, debug, debug+source). |
+
+Verbosity defaults to warn-level. Logs use `slog` with a text handler on stderr.
+
+## Subcommands
+
+### `sveltego build`
+
+Full pipeline: codegen → Vite client bundle → `go build`.
+
+### `sveltego compile`
+
+Codegen only. Writes `.gen/*.go`. Use this when iterating on templates without rebuilding the binary.
+
+### `sveltego dev`
+
+Watch + regenerate. Restarts the server on `.gen/` change. Proxies the Vite dev server for client HMR.
+
+### `sveltego check`
+
+Validate without writing output. Runs the parser and Go expression validator over every `+page.svelte` / `+layout.svelte`. Use this in CI before `build`.
+
+### `sveltego routes`
+
+Print the route table. One line per route with: pattern, file, presence of `Load`, presence of `Actions`, resolved `PageOptions`.
+
+### `sveltego version`
+
+Print version, commit, build date.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | success |
+| 1 | command-level error (parse, codegen, build) |
+| 2 | internal panic — file an issue |
+
+The CLI silences cobra's automatic usage-on-error since most failures are user-fixable parse errors that benefit from a clean message, not a usage dump.

--- a/docs/reference/kit.md
+++ b/docs/reference/kit.md
@@ -1,0 +1,179 @@
+---
+title: kit package
+order: 200
+summary: Public runtime API — RequestEvent, Hooks, Cookies, Action, CSP, sentinels.
+---
+
+# kit
+
+`github.com/binsarjr/sveltego/exports/kit` is the public runtime API. Generated code and user route handlers depend on it.
+
+This page summarises the surface. Source is the canonical spec; godoc is generated from it. See `packages/sveltego/exports/kit/` in the repo.
+
+## Contexts
+
+| Type | Used in | Purpose |
+|---|---|---|
+| `RequestEvent` | hooks, `+server.go`, actions | Request-scoped state with `URL`, `Params`, `Locals`, `Cookies`. |
+| `RenderCtx` | generated render code | SSR-time context passed into templates. |
+| `LoadCtx` | `Load` in `+page.server.go`, `+layout.server.go` | Load-time context with `Parent()` for layout chain. |
+
+`RequestEvent.Fetch(req)` dispatches outbound HTTP through `HandleFetch`.
+
+## Hooks
+
+```go
+type HandleFn       func(ev *RequestEvent, resolve ResolveFn) (*Response, error)
+type HandleErrorFn  func(ev *RequestEvent, err error) SafeError
+type HandleFetchFn  func(ev *RequestEvent, req *http.Request) (*http.Response, error)
+type RerouteFn      func(u *url.URL) string
+type InitFn         func(ctx context.Context) error
+```
+
+Compose handlers with `kit.Sequence(...)`. Defaults via `kit.DefaultHooks()` and `Hooks{}.WithDefaults()`.
+
+## Errors and short-circuits
+
+```go
+kit.Redirect(code int, location string) error
+kit.Error(code int, message string) error
+kit.Fail(code int, data any) error
+```
+
+All three implement `error` and `httpStatuser`.
+
+`SafeError{Code, Message, ID}` is the user-facing error contract returned from `HandleError`.
+
+## Responses
+
+```go
+kit.NewResponse(status int, body []byte) *Response
+kit.JSON(status int, body any) *Response
+kit.Text(status int, body string) *Response
+kit.XML(status int, body []byte) *Response
+kit.NoContent() *Response
+kit.MethodNotAllowed(allowed []string) *Response
+```
+
+`kit.M` is shorthand for `map[string]any`.
+
+## Form actions
+
+```go
+type ActionFn  = func(ev *RequestEvent) ActionResult
+type ActionMap = map[string]ActionFn
+
+kit.ActionDataResult(code int, data any) ActionResult
+kit.ActionFail(code int, data any) ActionResult
+kit.ActionRedirect(code int, location string) ActionResult
+```
+
+Result types: `ActionData`, `ActionFailData`, `ActionRedirectResult`. The interface is sealed.
+
+## Cookies
+
+```go
+type Cookies struct{ /* ... */ }
+type CookieOpts struct {
+  Path     string
+  Domain   string
+  MaxAge   time.Duration
+  Expires  time.Time
+  HttpOnly *bool
+  Secure   *bool
+  SameSite http.SameSite
+}
+
+(c *Cookies) Get(name string) (string, bool)
+(c *Cookies) Set(name, value string, opts CookieOpts)
+(c *Cookies) SetExposed(name, value string, opts CookieOpts)
+(c *Cookies) Delete(name string, opts CookieOpts)
+(c *Cookies) Apply(w http.ResponseWriter)
+```
+
+Secure defaults: `HttpOnly=true`, `SameSite=Lax`, `Path="/"`, `Secure=request-scheme`.
+
+## CSP
+
+```go
+type CSPMode int
+const (
+  CSPOff CSPMode = iota
+  CSPStrict
+  CSPReportOnly
+)
+
+type CSPConfig struct {
+  Mode       CSPMode
+  Directives map[string][]string
+  ReportTo   string
+}
+
+kit.DefaultCSPDirectives() map[string][]string
+kit.BuildCSPHeader(cfg CSPConfig, nonce string) string
+kit.CSPHeaderName(mode CSPMode) string
+kit.Nonce(ev *RequestEvent) string
+kit.NonceAttr(ev *RequestEvent) string
+```
+
+## Streaming
+
+```go
+kit.Stream[T](fn func() (T, error)) *Streamed[T]
+(s *Streamed[T]) Wait(ctx context.Context, timeout time.Duration) (T, error)
+(s *Streamed[T]) IsResolved() bool
+kit.DefaultStreamTimeout = 30 * time.Second
+```
+
+## Page options
+
+```go
+type TrailingSlash uint8
+const (
+  TrailingSlashDefault TrailingSlash = iota
+  TrailingSlashNever
+  TrailingSlashAlways
+  TrailingSlashIgnore
+)
+
+type PageOptions struct {
+  Prerender     bool
+  SSR           bool
+  CSR           bool
+  TrailingSlash TrailingSlash
+}
+```
+
+`PageOptions.Merge(override PageOptionsOverride) PageOptions` cascades layout values into pages.
+
+## Link
+
+```go
+kit.Link(pattern string, params map[string]string) (string, error)
+```
+
+Runtime fallback. Codegen-emitted typed helpers under `<module>/.gen/links` are preferred — they fail at compile time when the route is renamed.
+
+## Sitemap and robots
+
+```go
+kit.NewSitemap(baseURL string) *SitemapBuilder
+(b *SitemapBuilder) Add(path string, lastMod time.Time, freq ChangeFreq, priority float64) *SitemapBuilder
+(b *SitemapBuilder) Bytes() []byte
+
+kit.NewRobots() *RobotsBuilder
+(r *RobotsBuilder) UserAgent(name string) *RobotsBuilder
+(r *RobotsBuilder) Allow(path string) *RobotsBuilder
+(r *RobotsBuilder) Disallow(path string) *RobotsBuilder
+(r *RobotsBuilder) Sitemap(url string) *RobotsBuilder
+(r *RobotsBuilder) String() string
+```
+
+## Subpackages
+
+- `kit/env` — `StaticPrivate`, `StaticPublic`, `DynamicPrivate`, `DynamicPublic`. Public accessors enforce a `PUBLIC_` key prefix.
+- `kit/params` — built-in matchers `Int`, `UUID`, `Slug`, plus `DefaultMatchers()`.
+
+## Stability
+
+This package is the project's primary stability surface. Breaking changes follow the procedure in RFC #97. Until v1.0 the surface is marked experimental; treat tagged releases as gates.

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -1,0 +1,43 @@
+---
+title: Manifest
+order: 220
+summary: The manifest.gen.go contract — registered routes, layouts, hooks, page options.
+---
+
+# Manifest
+
+`manifest.gen.go` is the registry the runtime consults at request time. Codegen emits it; user code does not edit it.
+
+## What it registers
+
+- **Routes.** Each `+page.svelte` and `+server.go` produces an entry with: pattern, render function, optional `Load`, optional `Actions`, resolved `PageOptions`.
+- **Layouts.** Each `+layout.svelte` produces an entry with: pattern, render function, optional `Load`, link to parent.
+- **Error boundaries.** Each `+error.svelte` registers under its mount point.
+- **Param matchers.** Functions exported from `src/params/<name>.go` map to matcher names usable in patterns (`[id=hex]`).
+- **Hooks.** `Handle`, `HandleError`, `HandleFetch`, `Reroute`, `Init` from `hooks.server.go`. Missing fields are filled with `kit.Identity*` defaults.
+- **Page options.** Resolved per-route values for `Prerender`, `SSR`, `CSR`, `TrailingSlash` after layout cascade.
+
+## Why a manifest
+
+Runtime route lookup is a map index, not a tree walk. Every static decision (which Load runs, what TrailingSlash mode applies, which matcher validates a param) is resolved at codegen so the request path stays branch-free.
+
+## Lifecycle
+
+1. `sveltego compile` (or the `compile` step inside `build`) emits `.gen/manifest.gen.go`.
+2. `sveltego build` then runs `go build`, which links the manifest into the binary.
+3. The server, on `Init`, reads the manifest registrations and constructs the router.
+
+## Why you can't edit it
+
+The file is overwritten on every codegen run. Source of truth lives in:
+
+- `+page.server.go` for `Load`, `Actions`, page options.
+- `+layout.server.go` for layout `Load` and cascaded options.
+- `hooks.server.go` for hooks.
+- File paths under `src/routes/` for patterns.
+
+Edit those; rebuild; the manifest follows.
+
+## Inspecting
+
+`sveltego routes` prints the route table without compiling Go. Use it to verify a new route is registered before you reach for `go build`.

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -1,0 +1,69 @@
+---
+title: Route conventions
+order: 210
+summary: File names, build tag, generated output, and the route-matching contract.
+---
+
+# Route conventions
+
+## Tree
+
+```
+src/routes/
+  +page.svelte               # SSR template
+  +page.server.go            # Load(), Actions       (//go:build sveltego)
+  +layout.svelte             # layout chain
+  +layout.server.go          # parent data flow      (//go:build sveltego)
+  +server.go                 # REST endpoints        (//go:build sveltego)
+  +error.svelte              # error boundary
+  (group)/                   # route group, no URL segment
+  +page@.svelte              # layout reset
+  [param]/                   # required param
+  [[optional]]/              # optional segment
+  [...rest]/                 # catch-all
+src/params/<name>.go         # param matcher        (//go:build sveltego)
+src/lib/                     # $lib alias target
+hooks.server.go              # hooks pipeline       (//go:build sveltego)
+```
+
+## Build tag
+
+Every `.go` file under `src/routes/**` and `src/params/**` and at `src/hooks.server.go` MUST start with:
+
+```go
+//go:build sveltego
+```
+
+The tag prevents Go's default toolchain (build, vet, lint) from compiling these files. Codegen reads them through `go/parser` directly. See ADR 0003 amendment.
+
+## Match precedence
+
+The router prefers more specific patterns. Roughly:
+
+1. Static segments beat dynamic.
+2. Required `[name]` beats optional `[[name]]`.
+3. Optional beats catch-all `[...rest]`.
+4. Param matchers (`[id=int]`) tie-break toward the matcher that accepts.
+5. Layout reset (`+page@.svelte`) participates without affecting precedence.
+
+`sveltego routes` prints the resolved table for inspection.
+
+## Generated output
+
+`.gen/` (gitignored) holds:
+
+- `routes/` — one file per template, plus per-route render functions.
+- `manifest.gen.go` — registers routes, layouts, hooks, params, page options.
+- `links.gen.go` — typed `kit.Link` helpers per route.
+
+Two builds of the same source produce byte-identical `.gen/` output. Golden tests enforce determinism (#104).
+
+## File naming gotchas
+
+- `+page.svelte` — leading `+` is required.
+- `+page.server.go` — note the `.server.` infix and the `+`.
+- `page.server.go` (no `+`) is treated as a normal package file, not a sveltego module.
+- `+server.go` — REST endpoint, no template.
+- `+page@.svelte` — trailing `@` (before the extension) signals a layout reset.
+
+When in doubt, run `sveltego routes` and verify the entry appears.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -724,3 +724,24 @@
 3. **Accessible-name checks (`<a>`, `<button>`, label) recurse through block constructs, not only direct children.** Walk `{#if}`/`{#each}`/`{#await}`/`{#key}` branches the same way the codegen emit pass does. Naive immediate-child walks produce false positives on every real template.
 4. **Validation rules over static taxonomies (ARIA roles, HTML elements, etc.) skip dynamic and interpolated attribute values.** A codegen-time check cannot know runtime values; flagging them produces noise. Static-only validation is the intentional shape, not a bug.
 5. **`a11y` warnings are non-fatal by default.** Do NOT wire into `b.Fail`. Return `[]Diagnostic` for the caller (CLI/build) to render; promotion to fatal lives behind an explicit flag (deferred follow-up). The same standalone-callable shape lets editor integrations (`packages/lsp/`) consume the same pass.
+
+## Phase 0jj — docs bundle: Vitepress + llms.txt + Copy-for-LLM + AI guide (2026-04-30)
+
+### Insight
+
+- **Vitepress closeBundle hook is the right place to emit auxiliary text artifacts** (`llms.txt`, raw `.md`, `llms-full.txt`). `buildEnd` from the Rollup hook spec works too but `closeBundle` runs after Vite has fully written `outDir`, so subsequent `writeFile` calls are guaranteed to land in the same directory the rest of the build wrote into. Writing to the resolved `cfg.build.outDir` (not a hardcoded `dist/`) keeps the plugin portable across Vitepress upgrades that may relocate the output root.
+- **`tinyglobby` is the canonical Vitepress glob library** (matches the example in spec #70) and ships zero transitive cost. No `globby`, no `fast-glob`. One devDep, no surprises.
+- **Frontmatter parsing in a docs plugin should stay hand-rolled, not import gray-matter.** Five lines of `split('\n').forEach` over `key: value` covers every field we declare (title, order, summary). Reaching for gray-matter pulls in stricter YAML semantics we don't need and a transitive surface we have to audit.
+- **Vue file extension matters for Vitepress 1.x theme components.** `.vue` SFCs work out of the box; a `.svelte` or `.tsx` file in the theme folder will not be picked up by the default theme extension layer. The component lives in `theme/components/CopyForLLM.vue` and gets injected via `Layout` slot in `theme/index.ts`.
+- **Raw-md serving in dev needs middleware, not file-system passthrough.** Vitepress' default dev server transforms every `.md` request into HTML via `vue-router`. The plugin must `configureServer` and intercept before the default handler fires. Production is simpler — just write the raw files alongside the HTML at `closeBundle`.
+- **Copy-for-LLM clipboard fallback is mandatory.** `navigator.clipboard.writeText` requires a secure context; on local previews over plain HTTP the API is gated. The component falls back to `document.execCommand('copy')` via a hidden textarea so the button works on `localhost` builds and over LAN proxies during demos.
+- **Keep docs scope strictly disjoint from packages/sveltego/**.** Touching any Go package would conflict with the 9 parallel agents working on the codegen/runtime tree. The only repo-root files allowed beyond `docs/**` are `.gitignore` (to ignore Vitepress' `dist/` and `cache/`) and `tasks/lessons.md` (append-only journal).
+
+### Self-rules
+
+1. **Docs site outputs go in `closeBundle`, not `buildEnd`.** Writing through `cfg.build.outDir` keeps the plugin tied to Vitepress' actual output path; never hardcode `dist/`.
+2. **Reach for `tinyglobby` for any new Vitepress plugin that walks the source tree.** Matches Vitepress's own ecosystem choice and avoids a heavier dep tree.
+3. **Hand-roll frontmatter parsing in plugins that only consume known keys.** Five-line split-on-colon beats importing gray-matter when the schema is `{title, order, summary}`. Save the dep budget for things that earn it.
+4. **Vitepress theme components live in `.vue`; Layout slots are the injection seam.** No `.svelte` in Vitepress, no JSX without explicit setup. Use `h(DefaultTheme.Layout, null, { 'doc-before': () => h(Component) })` to inject content above the page body without overriding the default theme wholesale.
+5. **Always provide a clipboard-API fallback for "Copy" buttons in static docs.** `localhost` over plain HTTP is the most common build-test path; failing silently there guarantees a "doesn't work" bug report. Hidden-textarea + `document.execCommand('copy')` handles every legacy path.
+6. **Concurrency-disjoint scope is the entire job in a parallel-agent phase.** When 9 other agents touch `packages/sveltego/**`, the docs phase touches `docs/**` plus `.gitignore` plus `tasks/lessons.md` — period. No code refactors, no doc reflows in `README.md`. Cross-doc consistency happens in a follow-up serial commit if needed.


### PR DESCRIPTION
## Summary

- Stand up Vitepress docs site at `docs/` with full guide (quickstart, routing, load, actions, hooks, errors, components, snippets, build, deploy, csp, migration, faq) and reference (kit, routes, manifest, cli) plus AI-assistant guide.
- Custom Vitepress plugin emits `llms.txt` (curated index) and `llms-full.txt` (concatenated full docs) at build, ordered by frontmatter `order`.
- Custom Vitepress plugin serves and writes raw `.md` for every page; dev server middleware streams the source markdown with `Content-Type: text/markdown`.
- Theme component injects `Copy as Markdown` and `Copy for LLM` buttons on every page; clipboard API with hidden-textarea fallback for non-secure contexts.

Closes #61
Closes #70
Closes #72
Closes #75

## Test plan

- [x] `cd docs && npm install && npm run build` produces `docs/.vitepress/dist/` with HTML, raw `.md`, `llms.txt`, `llms-full.txt`.
- [x] `llms.txt` lists every doc page with title and summary, ordered by frontmatter `order`.
- [x] `llms-full.txt` concatenates every page; size warning fires above 500 KiB.
- [x] Raw `/guide/routing.md` etc. is written alongside the HTML.
- [x] `go vet ./...` and `go test -race -short ./...` (per-module) clean — no Go packages touched.
- [x] No edits to `packages/sveltego/**`, `cmd/**`, `adapters/**`, `templates/**`, `editor/**`, `playgrounds/**`.