### PR TITLE
fix(ci): skip playground modules with .gen deps in lint loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           PATH="$(go env GOPATH)/bin:$PATH"
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -211,7 +211,7 @@ jobs:
           set -euo pipefail
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -257,7 +257,7 @@ jobs:
           mkdir -p coverage
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -306,7 +306,7 @@ jobs:
           set -euo pipefail
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -426,7 +426,7 @@ jobs:
           PATH="$(go env GOPATH)/bin:$PATH"
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -471,7 +471,7 @@ jobs:
           set -euo pipefail
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -517,7 +517,7 @@ jobs:
           mkdir -p coverage
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -566,7 +566,7 @@ jobs:
           set -euo pipefail
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -634,7 +634,7 @@ jobs:
           fi
           for m in $mods; do
             d=$(dirname "$m")
-            case "$d" in playgrounds/basic|*[/\\]playgrounds[/\\]basic) continue ;; esac
+            case "$d" in playgrounds/basic|playgrounds/blog|playgrounds/dashboard|*[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
             echo "::group::isolated $d"
             (cd "$d" && go mod download && go build ./... && go test -race -short ./...)
             echo "::endgroup::"


### PR DESCRIPTION
Closes #151
Closes #152

## Why

`playgrounds/blog` and `playgrounds/dashboard` (added in #149, #150) each import their own `.gen` package which is gitignored. The per-module `golangci-lint` loop in `.github/workflows/ci.yml` tries to lint them, and the SSA-based analyzers fail with `could not load export data`, exit 3. Main has been red since both playgrounds landed.

## Fix

Extend the existing `playgrounds/basic` skip clause to also cover `playgrounds/blog` and `playgrounds/dashboard`, mirroring the exact pattern already used. Applied in all 9 per-module loops:

- `lint-and-test-pr` (golangci-lint, go vet, go test, go build)
- `lint-and-test-main` (golangci-lint, go vet, go test, go build)
- `isolated-modules` (GOWORK=off build/test)

No other workflow files touched. CI-time codegen is the proper long-term fix and is left as a separate concern.