### PR TITLE
refactor(codegen): index manifest lookups, single-pass emitOpenTag

### DIFF
--- a/packages/sveltego/internal/codegen/element.go
+++ b/packages/sveltego/internal/codegen/element.go
@@ -89,26 +89,20 @@ func emitOpenTag(b *Builder, e *ast.Element) {
 	head.WriteByte('<')
 	head.WriteString(e.Name)
 
-	staticClass, hasStaticClass := extractStaticClass(e.Attributes)
-	classDirectives := collectClassDirectives(e.Attributes)
-	wantClassWrap := len(classDirectives) > 0
-	styleDirectives := collectStyleDirectives(e.Attributes)
+	parts := partitionAttrs(e.Attributes)
+	wantClassWrap := len(parts.classDirs) > 0
 
-	for i := range e.Attributes {
-		a := &e.Attributes[i]
-		if shouldSkipAttr(a, wantClassWrap) {
-			continue
-		}
+	for _, a := range parts.emit {
 		emitAttribute(b, &head, a)
 	}
 
 	if wantClassWrap {
 		head.WriteString(` class="`)
-		if hasStaticClass {
-			head.WriteString(staticClass)
+		if parts.hasStaticClass {
+			head.WriteString(parts.staticClass)
 		}
 		flushHead(b, &head)
-		for _, d := range classDirectives {
+		for _, d := range parts.classDirs {
 			b.Linef("if %s {", d.Expr)
 			b.Indent()
 			b.Linef("w.WriteString(%s)", quoteGo(" "+d.Modifier))
@@ -118,10 +112,10 @@ func emitOpenTag(b *Builder, e *ast.Element) {
 		head.WriteString(`"`)
 	}
 
-	if len(styleDirectives) > 0 {
+	if len(parts.styleDirs) > 0 {
 		head.WriteString(` style="`)
 		flushHead(b, &head)
-		for _, d := range styleDirectives {
+		for _, d := range parts.styleDirs {
 			b.Linef("if %s != \"\" {", d.Expr)
 			b.Indent()
 			b.Linef("w.WriteString(%s)", quoteGo(d.Modifier+":"))
@@ -205,36 +199,50 @@ type directive struct {
 	Expr     string
 }
 
-func collectClassDirectives(attrs []ast.Attribute) []directive {
-	var out []directive
-	for i := range attrs {
-		a := &attrs[i]
-		if a.Kind != ast.AttrClassDirective {
-			continue
-		}
-		expr := dynamicExpr(a.Value)
-		if expr == "" {
-			continue
-		}
-		out = append(out, directive{Modifier: a.Modifier, Expr: expr})
-	}
-	return out
+// attrPartition bins an element's attribute list into the slices and
+// flags emitOpenTag needs in a single pass. emit holds attributes
+// destined for the head buffer in source order, with class:/style:
+// directives stripped.
+type attrPartition struct {
+	emit           []*ast.Attribute
+	classDirs      []directive
+	styleDirs      []directive
+	staticClass    string
+	hasStaticClass bool
 }
 
-func collectStyleDirectives(attrs []ast.Attribute) []directive {
-	var out []directive
+func partitionAttrs(attrs []ast.Attribute) attrPartition {
+	p := attrPartition{emit: make([]*ast.Attribute, 0, len(attrs))}
+	staticClassIdx := -1
 	for i := range attrs {
 		a := &attrs[i]
-		if a.Kind != ast.AttrStyleDirective {
+		switch a.Kind {
+		case ast.AttrClassDirective:
+			if expr := dynamicExpr(a.Value); expr != "" {
+				p.classDirs = append(p.classDirs, directive{Modifier: a.Modifier, Expr: expr})
+			}
+			continue
+		case ast.AttrStyleDirective:
+			if expr := dynamicExpr(a.Value); expr != "" {
+				p.styleDirs = append(p.styleDirs, directive{Modifier: a.Modifier, Expr: expr})
+			}
 			continue
 		}
-		expr := dynamicExpr(a.Value)
-		if expr == "" {
-			continue
+		if a.Name == "class" && a.Kind == ast.AttrStatic && !p.hasStaticClass {
+			if s, ok := a.Value.(*ast.StaticValue); ok {
+				p.staticClass = s.Value
+				p.hasStaticClass = true
+				staticClassIdx = len(p.emit)
+			}
 		}
-		out = append(out, directive{Modifier: a.Modifier, Expr: expr})
+		p.emit = append(p.emit, a)
 	}
-	return out
+	// When class directives wrap the class attribute, the literal class=
+	// emit is folded into the wrapper; drop it from the head pass.
+	if len(p.classDirs) > 0 && staticClassIdx >= 0 {
+		p.emit = append(p.emit[:staticClassIdx], p.emit[staticClassIdx+1:]...)
+	}
+	return p
 }
 
 func dynamicExpr(v ast.AttributeValue) string {
@@ -243,40 +251,6 @@ func dynamicExpr(v ast.AttributeValue) string {
 		return ""
 	}
 	return d.Expr
-}
-
-// extractStaticClass returns the literal value of a static class="..."
-// attribute when present so a class directive can append to it inside the
-// same class quote pair.
-func extractStaticClass(attrs []ast.Attribute) (string, bool) {
-	for i := range attrs {
-		a := &attrs[i]
-		if a.Name != "class" || a.Kind != ast.AttrStatic {
-			continue
-		}
-		s, ok := a.Value.(*ast.StaticValue)
-		if !ok {
-			return "", false
-		}
-		return s.Value, true
-	}
-	return "", false
-}
-
-// shouldSkipAttr decides whether to emit an attribute directly. When class
-// directives wrap the class attribute, the literal class= attribute is
-// folded into the wrapper instead of emitted on its own.
-func shouldSkipAttr(a *ast.Attribute, wantClassWrap bool) bool {
-	switch a.Kind {
-	case ast.AttrClassDirective, ast.AttrStyleDirective:
-		return true
-	}
-	if wantClassWrap && a.Name == "class" && a.Kind == ast.AttrStatic {
-		if _, ok := a.Value.(*ast.StaticValue); ok {
-			return true
-		}
-	}
-	return false
 }
 
 func flushHead(b *Builder, head *strings.Builder) {

--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -290,24 +290,16 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	} else {
 		b.Line("return []router.Route{")
 		b.Indent()
-		layoutInfoFor := func(pkgPath string) (alias string, hasServer, hasHead bool) {
-			for _, li := range layoutImports {
-				if li.pkgPath == pkgPath {
-					return li.alias, li.hasServer, li.hasHead
-				}
-			}
-			return "", false, false
+		layoutByPath := make(map[string]layoutImport, len(layoutImports))
+		for _, li := range layoutImports {
+			layoutByPath[li.pkgPath] = li
 		}
-		errorAliasFor := func(pkgPath string) string {
-			for _, ei := range errorImports {
-				if ei.pkgPath == pkgPath {
-					return ei.alias
-				}
-			}
-			return ""
+		errorAliasByPath := make(map[string]string, len(errorImports))
+		for _, ei := range errorImports {
+			errorAliasByPath[ei.pkgPath] = ei.alias
 		}
 		for _, e := range entries {
-			emitRouteEntry(&b, e.route, e.alias, layoutInfoFor, errorAliasFor, opts.RouteOptions, opts.PageHeads)
+			emitRouteEntry(&b, e.route, e.alias, layoutByPath, errorAliasByPath, opts.RouteOptions, opts.PageHeads)
 		}
 		b.Dedent()
 		b.Line("}")
@@ -496,7 +488,7 @@ func emitErrorAdapters(b *Builder, imports []errorImport) {
 	}
 }
 
-func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutInfoFor func(string) (string, bool, bool), errorAliasFor func(string) string, routeOptions map[string]kit.PageOptions, pageHeads map[string]bool) {
+func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutByPath map[string]layoutImport, errorAliasByPath map[string]string, routeOptions map[string]kit.PageOptions, pageHeads map[string]bool) {
 	b.Line("{")
 	b.Indent()
 	b.Linef("Pattern: %s,", quoteGo(r.Pattern))
@@ -518,11 +510,11 @@ func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutIn
 		b.Line("LayoutChain: []router.LayoutHandler{")
 		b.Indent()
 		for _, p := range r.LayoutPackagePaths {
-			la, _, _ := layoutInfoFor(p)
-			if la == "" {
+			li, ok := layoutByPath[p]
+			if !ok {
 				continue
 			}
-			b.Linef("render__layout__%s,", la)
+			b.Linef("render__layout__%s,", li.alias)
 		}
 		b.Dedent()
 		b.Line("},")
@@ -530,11 +522,14 @@ func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutIn
 		anyServer := false
 		anyHead := false
 		for _, p := range r.LayoutPackagePaths {
-			_, hs, hh := layoutInfoFor(p)
-			if hs {
+			li, ok := layoutByPath[p]
+			if !ok {
+				continue
+			}
+			if li.hasServer {
 				anyServer = true
 			}
-			if hh {
+			if li.hasHead {
 				anyHead = true
 			}
 		}
@@ -542,12 +537,12 @@ func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutIn
 			b.Line("LayoutLoaders: []router.LayoutLoadHandler{")
 			b.Indent()
 			for _, p := range r.LayoutPackagePaths {
-				la, hs, _ := layoutInfoFor(p)
-				if la == "" {
+				li, ok := layoutByPath[p]
+				if !ok {
 					continue
 				}
-				if hs {
-					b.Linef("loadLayout__%s,", la)
+				if li.hasServer {
+					b.Linef("loadLayout__%s,", li.alias)
 				} else {
 					b.Line("nil,")
 				}
@@ -559,12 +554,12 @@ func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutIn
 			b.Line("LayoutHeads: []router.LayoutHeadHandler{")
 			b.Indent()
 			for _, p := range r.LayoutPackagePaths {
-				la, _, hh := layoutInfoFor(p)
-				if la == "" {
+				li, ok := layoutByPath[p]
+				if !ok {
 					continue
 				}
-				if hh {
-					b.Linef("head__layout__%s,", la)
+				if li.hasHead {
+					b.Linef("head__layout__%s,", li.alias)
 				} else {
 					b.Line("nil,")
 				}
@@ -575,7 +570,7 @@ func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutIn
 	}
 	emitOptionsField(b, r.Pattern, routeOptions)
 	if r.ErrorBoundaryPackagePath != "" {
-		if ea := errorAliasFor(r.ErrorBoundaryPackagePath); ea != "" {
+		if ea, ok := errorAliasByPath[r.ErrorBoundaryPackagePath]; ok && ea != "" {
 			b.Linef("Error: renderError__%s,", ea)
 			if r.ErrorBoundaryLayoutDepth > 0 {
 				b.Linef("ErrorLayoutDepth: %d,", r.ErrorBoundaryLayoutDepth)


### PR DESCRIPTION
Closes #201
Closes #205

## Why

- `GenerateManifest` walked `layoutImports` / `errorImports` linearly inside `emitRouteEntry` for every route layout — O(R x L^2) on the manifest-write phase. Now indexed by `map[string]layoutImport` and `map[string]string`, so each lookup is O(1).
- `emitOpenTag` walked `e.Attributes` four times (`extractStaticClass`, `collectClassDirectives`, `collectStyleDirectives`, main emit). One `partitionAttrs` pass now collects static-class, class directives, style directives, and the head-emit list in source order. The static-class fold into the class-directive wrapper happens at partition time, removing the per-attribute skip predicate.

## Golden diff

No. All 362 codegen tests pass byte-for-byte against existing goldens — output is unchanged.

## Gates

- `gofumpt -l` clean
- `goimports -l -local github.com/binsarjr/sveltego` clean
- `go vet ./...` clean
- `go test -race ./packages/sveltego/...` green
- `go build` green for every workspace module except the three playground apps that pre-existing main also fails to build (their `.gen/` output is not committed; this PR does not touch them).