### PR TITLE
perf(render): pool json encoder, add WriteRawBytes, optimize escape default

### DIFF
--- a/packages/sveltego/render/escape.go
+++ b/packages/sveltego/render/escape.go
@@ -63,6 +63,59 @@ func appendEscapeAttr(dst []byte, s string) []byte {
 	return dst
 }
 
+// appendEscapeTextBytes mirrors appendEscapeText for an existing []byte
+// source. Used by the default branch of WriteEscape so a fmt.Appendf
+// result can be escaped without the extra []byte->string copy.
+func appendEscapeTextBytes(dst, s []byte) []byte {
+	i := indexTextSpecialBytes(s)
+	if i < 0 {
+		return append(dst, s...)
+	}
+	dst = append(dst, s[:i]...)
+	for ; i < len(s); i++ {
+		switch s[i] {
+		case '&':
+			dst = append(dst, escAmp...)
+		case '<':
+			dst = append(dst, escLt...)
+		case '>':
+			dst = append(dst, escGt...)
+		case '"':
+			dst = append(dst, escQuot...)
+		case '\'':
+			dst = append(dst, escApos...)
+		default:
+			dst = append(dst, s[i])
+		}
+	}
+	return dst
+}
+
+// appendEscapeAttrBytes mirrors appendEscapeAttr for an existing []byte
+// source.
+func appendEscapeAttrBytes(dst, s []byte) []byte {
+	i := indexAttrSpecialBytes(s)
+	if i < 0 {
+		return append(dst, s...)
+	}
+	dst = append(dst, s[:i]...)
+	for ; i < len(s); i++ {
+		switch s[i] {
+		case '&':
+			dst = append(dst, escAmp...)
+		case '<':
+			dst = append(dst, escLt...)
+		case '>':
+			dst = append(dst, escGt...)
+		case '"':
+			dst = append(dst, escQuot...)
+		default:
+			dst = append(dst, s[i])
+		}
+	}
+	return dst
+}
+
 func indexTextSpecial(s string) int {
 	for i := range len(s) {
 		switch s[i] {
@@ -74,6 +127,26 @@ func indexTextSpecial(s string) int {
 }
 
 func indexAttrSpecial(s string) int {
+	for i := range len(s) {
+		switch s[i] {
+		case '&', '<', '>', '"':
+			return i
+		}
+	}
+	return -1
+}
+
+func indexTextSpecialBytes(s []byte) int {
+	for i := range len(s) {
+		switch s[i] {
+		case '&', '<', '>', '"', '\'':
+			return i
+		}
+	}
+	return -1
+}
+
+func indexAttrSpecialBytes(s []byte) int {
 	for i := range len(s) {
 		switch s[i] {
 		case '&', '<', '>', '"':

--- a/packages/sveltego/render/render.go
+++ b/packages/sveltego/render/render.go
@@ -7,6 +7,29 @@ import (
 	"sync"
 )
 
+// jsonEncoder pools a json.Encoder bound to a settable target. Encoders
+// retain their writer permanently, so we wrap *Writer in an adapter
+// whose target swaps per Encode call. Reusing the encoder skips per-call
+// allocation of the encoder's internal state.
+type jsonEncoder struct {
+	target *Writer
+	enc    *json.Encoder
+}
+
+func (j *jsonEncoder) Write(p []byte) (int, error) {
+	j.target.buf = append(j.target.buf, p...)
+	return len(p), nil
+}
+
+var jsonPool = sync.Pool{
+	New: func() any {
+		j := &jsonEncoder{}
+		j.enc = json.NewEncoder(j)
+		j.enc.SetEscapeHTML(true)
+		return j
+	},
+}
+
 const defaultBufCap = 4096
 
 // Writer accumulates HTML into an internal buffer. Designed for per-request
@@ -57,9 +80,18 @@ func (w *Writer) WriteRaw(s string) {
 	w.buf = append(w.buf, s...)
 }
 
+// WriteRawBytes appends a pre-trusted []byte. Equivalent to WriteRaw but
+// avoids the []byte->string conversion at call sites that already hold
+// bytes (e.g. the head splice on the render hot path).
+func (w *Writer) WriteRawBytes(p []byte) {
+	w.buf = append(w.buf, p...)
+}
+
 // WriteEscape appends v HTML-escaped for text context. Numeric and bool
 // values bypass fmt to avoid allocations on the hot path. nil emits an
-// empty string.
+// empty string. A value that implements both error and fmt.Stringer is
+// rendered via Error(); types that need Stringer precedence should not
+// also satisfy error.
 func (w *Writer) WriteEscape(v any) {
 	switch x := v.(type) {
 	case nil:
@@ -99,12 +131,13 @@ func (w *Writer) WriteEscape(v any) {
 	case fmt.Stringer:
 		w.buf = appendEscapeText(w.buf, x.String())
 	default:
-		w.buf = appendEscapeText(w.buf, fmt.Sprint(v))
+		w.buf = appendEscapeTextBytes(w.buf, fmt.Appendf(nil, "%v", v))
 	}
 }
 
 // WriteEscapeAttr appends v escaped for an attribute value. Codegen wraps
-// attribute values in double quotes outside this call.
+// attribute values in double quotes outside this call. error precedes
+// fmt.Stringer; see WriteEscape.
 func (w *Writer) WriteEscapeAttr(v any) {
 	switch x := v.(type) {
 	case nil:
@@ -144,7 +177,7 @@ func (w *Writer) WriteEscapeAttr(v any) {
 	case fmt.Stringer:
 		w.buf = appendEscapeAttr(w.buf, x.String())
 	default:
-		w.buf = appendEscapeAttr(w.buf, fmt.Sprint(v))
+		w.buf = appendEscapeAttrBytes(w.buf, fmt.Appendf(nil, "%v", v))
 	}
 }
 
@@ -152,9 +185,12 @@ func (w *Writer) WriteEscapeAttr(v any) {
 // embedding inside a <script> tag. The encoder's default HTML escaping
 // rewrites <, >, &, U+2028, U+2029 inside strings to \u escapes.
 func (w *Writer) WriteJSON(v any) error {
-	enc := json.NewEncoder((*bufWriter)(w))
-	enc.SetEscapeHTML(true)
-	if err := enc.Encode(v); err != nil {
+	j, _ := jsonPool.Get().(*jsonEncoder)
+	j.target = w
+	err := j.enc.Encode(v)
+	j.target = nil
+	jsonPool.Put(j)
+	if err != nil {
 		return fmt.Errorf("render: encode json: %w", err)
 	}
 	if n := len(w.buf); n > 0 && w.buf[n-1] == '\n' {
@@ -178,13 +214,4 @@ func (w *Writer) Len() int {
 // Reset truncates the buffer to zero length, retaining capacity.
 func (w *Writer) Reset() {
 	w.buf = w.buf[:0]
-}
-
-// bufWriter adapts *Writer to io.Writer for json.Encoder without exposing
-// the Write method on the public Writer surface.
-type bufWriter Writer
-
-func (b *bufWriter) Write(p []byte) (int, error) {
-	b.buf = append(b.buf, p...)
-	return len(p), nil
 }

--- a/packages/sveltego/render/render_bench_test.go
+++ b/packages/sveltego/render/render_bench_test.go
@@ -75,3 +75,38 @@ func BenchmarkWriteJSON(b *testing.B) {
 		render.Release(w)
 	}
 }
+
+func BenchmarkWriteRawBytes(b *testing.B) {
+	payload := []byte("<title>page</title><meta name=\"x\" content=\"y\">")
+	b.ReportAllocs()
+	for range b.N {
+		w := render.Acquire()
+		w.WriteRawBytes(payload)
+		render.Release(w)
+	}
+}
+
+type benchStruct struct {
+	A int
+	B string
+}
+
+func BenchmarkWriteEscape_Default(b *testing.B) {
+	v := benchStruct{A: 7, B: "hello"}
+	b.ReportAllocs()
+	for range b.N {
+		w := render.Acquire()
+		w.WriteEscape(v)
+		render.Release(w)
+	}
+}
+
+func BenchmarkWriteEscapeAttr_Default(b *testing.B) {
+	v := benchStruct{A: 7, B: "hello"}
+	b.ReportAllocs()
+	for range b.N {
+		w := render.Acquire()
+		w.WriteEscapeAttr(v)
+		render.Release(w)
+	}
+}

--- a/packages/sveltego/render/render_test.go
+++ b/packages/sveltego/render/render_test.go
@@ -41,6 +41,49 @@ func TestWriteRaw(t *testing.T) {
 	}
 }
 
+func TestWriteRawBytes(t *testing.T) {
+	w := render.New()
+	w.WriteRawBytes([]byte("<script>x()</script>"))
+	if got, want := string(w.Bytes()), "<script>x()</script>"; got != want {
+		t.Errorf("Bytes = %q, want %q", got, want)
+	}
+}
+
+func TestWriteRawBytes_Empty(t *testing.T) {
+	w := render.New()
+	w.WriteRawBytes(nil)
+	w.WriteRawBytes([]byte{})
+	if w.Len() != 0 {
+		t.Errorf("Len = %d, want 0", w.Len())
+	}
+}
+
+type errStringer struct {
+	msg string
+	str string
+}
+
+func (e errStringer) Error() string  { return e.msg }
+func (e errStringer) String() string { return e.str }
+
+func TestWriteEscape_ErrorPrecedesStringer(t *testing.T) {
+	v := errStringer{msg: "boom", str: "polite"}
+	w := render.New()
+	w.WriteEscape(v)
+	if got, want := string(w.Bytes()), "boom"; got != want {
+		t.Errorf("WriteEscape = %q, want %q (error must precede Stringer)", got, want)
+	}
+}
+
+func TestWriteEscapeAttr_ErrorPrecedesStringer(t *testing.T) {
+	v := errStringer{msg: "boom", str: "polite"}
+	w := render.New()
+	w.WriteEscapeAttr(v)
+	if got, want := string(w.Bytes()), "boom"; got != want {
+		t.Errorf("WriteEscapeAttr = %q, want %q (error must precede Stringer)", got, want)
+	}
+}
+
 func TestWriteEscape(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Closes #153
Closes #163
Closes #196

## Summary

Three render-package perf fixes from the Go review pass.

- **#153** — `WriteJSON` now reuses a pooled `*json.Encoder` via a settable adapter. Encoders bind their writer permanently, so a `jsonEncoder` struct holds a swappable `*Writer` target; pool acquisition skips the per-call encoder allocation on the streaming SSR hot path (`emitResolveScript`).
- **#163** — Adds `Writer.WriteRawBytes([]byte)`. Lets future `pipeline.go` callers replace `WriteRaw(string(headBytes))` with a copy-free path. (Wiring in `server/pipeline.go` is intentionally left out of this PR per scope; trivial follow-up.)
- **#196** — `WriteEscape`/`WriteEscapeAttr` default branch routes through `fmt.Appendf(nil, "%v", v)` plus a new `appendEscape{Text,Attr}Bytes` []byte variant. Drops one allocation (the intermediate `string` from `fmt.Sprint`). Godoc now documents the `error`-before-`fmt.Stringer` precedence.

## Bench (Apple M1 Pro)

```
BenchmarkWriteJSON-10                   2,444,260   490 ns/op    224 B/op   7 allocs/op
BenchmarkWriteRawBytes-10             139,156,363   8.8 ns/op      0 B/op   0 allocs/op
BenchmarkWriteEscape_Default-10         8,977,893   138 ns/op     16 B/op   1 allocs/op
BenchmarkWriteEscapeAttr_Default-10     8,822,782   134 ns/op     16 B/op   1 allocs/op
```

Default-branch alloc count dropped from 2 to 1; remaining alloc is the irreducible `fmt.Appendf` []byte. JSON path drops the encoder struct alloc; remaining allocs are inside `encoding/json` reflection.

## Verification

- `gofumpt -l`, `goimports -l -local github.com/binsarjr/sveltego`, `go vet ./...`, `golangci-lint run` — all clean
- `go test -race ./...` (sveltego module) — all packages green
- New tests: `WriteRawBytes` happy path, empty path, error+Stringer precedence regression for both Write Escape variants