### PR TITLE
refactor(ci): centralize playground skip list via shared script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,10 @@ jobs:
         run: |
           set -euo pipefail
           PATH="$(go env GOPATH)/bin:$PATH"
+          . scripts/ci/skip-playgrounds.sh
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -209,9 +210,10 @@ jobs:
           TEST_UTILS: ${{ needs.changes.outputs.test-utils }}
         run: |
           set -euo pipefail
+          . scripts/ci/skip-playgrounds.sh
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -255,9 +257,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p coverage
+          . scripts/ci/skip-playgrounds.sh
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -304,9 +307,10 @@ jobs:
           TEST_UTILS: ${{ needs.changes.outputs.test-utils }}
         run: |
           set -euo pipefail
+          . scripts/ci/skip-playgrounds.sh
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -424,9 +428,10 @@ jobs:
         run: |
           set -euo pipefail
           PATH="$(go env GOPATH)/bin:$PATH"
+          . scripts/ci/skip-playgrounds.sh
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -469,9 +474,10 @@ jobs:
           TEST_UTILS: ${{ needs.changes.outputs.test-utils }}
         run: |
           set -euo pipefail
+          . scripts/ci/skip-playgrounds.sh
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -515,9 +521,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p coverage
+          . scripts/ci/skip-playgrounds.sh
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -564,9 +571,10 @@ jobs:
           TEST_UTILS: ${{ needs.changes.outputs.test-utils }}
         run: |
           set -euo pipefail
+          . scripts/ci/skip-playgrounds.sh
           dirs=$(go list -m -f '{{.Dir}}')
           for d in $dirs; do
-            case "$d" in *[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             if [[ "$SHARED" != "true" ]]; then
               case "$d" in
                 */packages/sveltego)             [[ "$SVELTEGO" == "true" ]]            || continue ;;
@@ -627,6 +635,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          . scripts/ci/skip-playgrounds.sh
           mods=$(find packages playgrounds benchmarks test-utils -maxdepth 2 -name go.mod 2>/dev/null || true)
           if [ -z "$mods" ]; then
             echo "no go.mod files found under packages/playgrounds/benchmarks/test-utils"
@@ -634,7 +643,7 @@ jobs:
           fi
           for m in $mods; do
             d=$(dirname "$m")
-            case "$d" in playgrounds/basic|playgrounds/blog|playgrounds/dashboard|*[/\\]playgrounds[/\\]basic|*[/\\]playgrounds[/\\]blog|*[/\\]playgrounds[/\\]dashboard) continue ;; esac
+            should_skip_playground "$d" && continue
             echo "::group::isolated $d"
             (cd "$d" && go mod download && go build ./... && go test -race -short ./...)
             echo "::endgroup::"

--- a/scripts/ci/skip-playgrounds.sh
+++ b/scripts/ci/skip-playgrounds.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Single source of truth for playgrounds the per-module CI loops skip.
+#
+# These playgrounds import their own gitignored .gen/ packages (produced
+# by `sveltego compile`). Generic per-module loops in ci.yml don't run
+# codegen, so SSA-based analyzers (golangci-lint, go vet, go build, go
+# test) fail to load export data. The dedicated `playground-smoke` job
+# runs codegen first and exercises the basic playground end-to-end.
+#
+# Adding a new playground = one line below.
+#
+# Usage in a ci.yml `run:` block (shell: bash):
+#   . scripts/ci/skip-playgrounds.sh
+#   for d in $dirs; do
+#     should_skip_playground "$d" && continue
+#     ...
+#   done
+#
+# `should_skip_playground` accepts both relative paths (e.g.
+# `playgrounds/basic`, used by isolated-modules where $d comes from
+# `dirname go.mod`) and absolute module paths from `go list -m`
+# (e.g. `/home/runner/work/sveltego/sveltego/playgrounds/basic` or, on
+# Windows runners, `D:\a\sveltego\sveltego\playgrounds\basic`).
+
+SKIP_PLAYGROUNDS=(
+  playgrounds/basic
+  playgrounds/blog
+  playgrounds/dashboard
+)
+
+should_skip_playground() {
+  local module="$1"
+  local sp
+  for sp in "${SKIP_PLAYGROUNDS[@]}"; do
+    # Normalize backslashes to forward slashes for the comparison so a
+    # single glob covers both Unix and Windows paths from `go list -m`.
+    local norm="${module//\\//}"
+    case "$norm" in
+      "$sp"|*/"$sp")
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}


### PR DESCRIPTION
Closes #257

Replaces 9 hardcoded `case "$d" in *playgrounds/…) continue` blocks across `.github/workflows/ci.yml` (4 PR-matrix steps + 4 main-matrix steps + isolated-modules) with one sourced script at `scripts/ci/skip-playgrounds.sh`.

New playgrounds = 1-line edit in `SKIP_PLAYGROUNDS`.

## Detail

- `should_skip_playground` accepts both relative paths (used in `isolated-modules` where `$d=dirname go.mod` -> `playgrounds/basic`) and absolute paths from `go list -m -f '{{.Dir}}'` on Unix and Windows runners (backslashes normalized).
- Each `run:` block sources the script once before the loop, then calls `should_skip_playground "$d" && continue` at the top of the loop body.
- All steps that touched the case pattern are `shell: bash`, so `.` (POSIX-portable, equivalent to `source`) works on Linux, macOS, and Windows Git Bash.

## Test plan

- [ ] CI green on this PR (lite matrix on PR).
- [ ] After merge: full matrix on main (3 OS × 2 Go) green, including Windows runner.
- [ ] Local sanity run reproduced the filter against `go list -m`: only the 3 playground modules drop out.