### PR TITLE
perf(server): pool buffers, drop redundant allocs, simplify head dedup

### DIFF
--- a/packages/sveltego/server/actions.go
+++ b/packages/sveltego/server/actions.go
@@ -110,15 +110,17 @@ func (errUnknownActionResult) Error() string {
 // `?/submit`), not as a value, so url.ParseQuery sees it as the empty
 // value of `/submit`. The default action key is "default".
 func actionNameFromQuery(raw string) string {
-	if raw == "" {
-		return "default"
-	}
-	for _, part := range strings.Split(raw, "&") {
-		if !strings.HasPrefix(part, "/") {
+	for raw != "" {
+		var part string
+		if i := strings.IndexByte(raw, '&'); i >= 0 {
+			part, raw = raw[:i], raw[i+1:]
+		} else {
+			part, raw = raw, ""
+		}
+		if len(part) == 0 || part[0] != '/' {
 			continue
 		}
-		// strip optional `=` suffix
-		name := strings.TrimPrefix(part, "/")
+		name := part[1:]
 		if i := strings.IndexByte(name, '='); i >= 0 {
 			name = name[:i]
 		}

--- a/packages/sveltego/server/bench_test.go
+++ b/packages/sveltego/server/bench_test.go
@@ -9,6 +9,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/binsarjr/sveltego/exports/kit"
@@ -56,5 +57,118 @@ func BenchmarkServeHTTP_index(b *testing.B) {
 	for range b.N {
 		w.Body.Reset()
 		srv.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkServeHTTP_Hello(b *testing.B) {
+	srv := benchServer(b)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, r)
+	}
+}
+
+// BenchmarkServeHTTP_HelloWithHead exercises the dedupeTitle path so the
+// head-buffer scan is part of the steady-state allocation profile.
+func BenchmarkServeHTTP_HelloWithHead(b *testing.B) {
+	srv, err := New(Config{
+		Routes: []router.Route{{
+			Pattern:  "/",
+			Segments: []router.Segment{},
+			Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+				w.WriteString("<h1>hello</h1>")
+				return nil
+			},
+			Head: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+				w.WriteString(`<meta charset="utf-8"><title>page</title><meta name="theme" content="dark">`)
+				return nil
+			},
+		}},
+		Shell:  testShell,
+		Logger: quietLogger(),
+	})
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, r)
+	}
+}
+
+// BenchmarkEscapeScriptJSON_Clean asserts the no-escape fast path is
+// allocation-free.
+func BenchmarkEscapeScriptJSON_Clean(b *testing.B) {
+	payload := []byte(`{"title":"Hello world","count":42,"items":["a","b","c"]}`)
+	w := render.New()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		w.Reset()
+		writeEscapedScriptJSON(w, payload)
+	}
+}
+
+// BenchmarkEscapeScriptJSON_Dirty exercises the slow path with an
+// embedded `</` sequence to verify escape behavior is preserved.
+func BenchmarkEscapeScriptJSON_Dirty(b *testing.B) {
+	payload := []byte(`{"x":"a</script>b<!--c"}`)
+	w := render.New()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		w.Reset()
+		writeEscapedScriptJSON(w, payload)
+	}
+}
+
+// BenchmarkDedupeTitle_Single exercises the no-dedupe (single-title)
+// path. Only the titleSpan slice for the single match allocates; the
+// previous implementation also paid a full strings.ToLower copy.
+func BenchmarkDedupeTitle_Single(b *testing.B) {
+	in := []byte(strings.Repeat(`<meta charset="utf-8">`, 8) +
+		`<title>page</title>` +
+		strings.Repeat(`<meta name="theme" content="dark">`, 8))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = dedupeTitle(in)
+	}
+}
+
+// BenchmarkDedupeTitle_NoTitle confirms the no-title fast path is
+// allocation-free; the previous implementation always paid for the
+// strings.ToLower copy.
+func BenchmarkDedupeTitle_NoTitle(b *testing.B) {
+	in := []byte(strings.Repeat(`<meta name="theme" content="dark">`, 16))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = dedupeTitle(in)
+	}
+}
+
+// BenchmarkActionNameFromQuery_Default covers the empty-query default
+// path and confirms zero allocations.
+func BenchmarkActionNameFromQuery_Default(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		_ = actionNameFromQuery("")
+	}
+}
+
+// BenchmarkActionNameFromQuery_Match exercises a query with one
+// non-action prefix and an action token at index 1.
+func BenchmarkActionNameFromQuery_Match(b *testing.B) {
+	q := "x=1&/submit"
+	b.ReportAllocs()
+	for range b.N {
+		_ = actionNameFromQuery(q)
 	}
 }

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -167,9 +167,7 @@ func (s *Server) renderErrorBoundary(w http.ResponseWriter, r *http.Request, ev 
 	}
 	buf.WriteString(s.shellTail)
 
-	body := make([]byte, buf.Len())
-	copy(body, buf.Bytes())
-
+	body := buf.Bytes()
 	if ev != nil && ev.Cookies != nil {
 		ev.Cookies.Apply(w)
 	}

--- a/packages/sveltego/server/head.go
+++ b/packages/sveltego/server/head.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"strings"
 
 	"github.com/binsarjr/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/render"
@@ -93,52 +92,76 @@ type titleSpan struct {
 
 // findTitleSpans locates every `<title...>...</title>` span in src. The
 // scan is case-insensitive and treats malformed input (open without
-// close) as the absence of a span at that position.
+// close) as the absence of a span at that position. The scan walks src
+// in place: no string conversion, no full lowercase copy, zero
+// allocation on the no-title fast path.
 func findTitleSpans(src []byte) []titleSpan {
-	var out []titleSpan
-	lower := strings.ToLower(string(src))
+	var (
+		out     []titleSpan
+		titleLC = []byte("title")
+		closeLC = []byte("</title>")
+	)
 	cursor := 0
-	for cursor < len(lower) {
-		open := indexAt(lower, "<title", cursor)
-		if open < 0 {
+	for cursor < len(src) {
+		lt := bytes.IndexByte(src[cursor:], '<')
+		if lt < 0 {
 			break
 		}
-		// Verify the next char is `>`, whitespace, or `/` so we don't
-		// match `<titlefoo>`. EOF after the prefix counts as no match.
-		after := open + len("<title")
-		if after >= len(lower) {
+		open := cursor + lt
+		after := open + 1 + len(titleLC) // position of the byte after "<title"
+		if after >= len(src) {
 			break
 		}
-		c := lower[after]
+		if !bytes.EqualFold(src[open+1:after], titleLC) {
+			cursor = open + 1
+			continue
+		}
+		c := src[after]
 		if c != '>' && c != ' ' && c != '\t' && c != '\n' && c != '\r' && c != '/' {
 			cursor = after
 			continue
 		}
-		gt := indexAt(lower, ">", after)
+		gt := bytes.IndexByte(src[after:], '>')
 		if gt < 0 {
 			break
 		}
-		closeAt := indexAt(lower, "</title>", gt+1)
-		if closeAt < 0 {
+		closeStart := indexFold(src, closeLC, after+gt+1)
+		if closeStart < 0 {
 			break
 		}
-		end := closeAt + len("</title>")
+		end := closeStart + len(closeLC)
 		out = append(out, titleSpan{start: open, end: end})
 		cursor = end
 	}
 	return out
 }
 
-func indexAt(s, needle string, from int) int {
+// indexFold returns the index of the first case-insensitive match of
+// needle in src starting at from, or -1 if absent. needle's first byte
+// must be a literal (non-letter) anchor for a cheap IndexByte scan; the
+// remaining bytes are compared with bytes.EqualFold.
+func indexFold(src, needle []byte, from int) int {
 	if from < 0 {
 		from = 0
 	}
-	if from >= len(s) {
+	if len(needle) == 0 || from+len(needle) > len(src) {
 		return -1
 	}
-	idx := strings.Index(s[from:], needle)
-	if idx < 0 {
-		return -1
+	anchor := needle[0]
+	rest := needle[1:]
+	for i := from; i+len(needle) <= len(src); {
+		idx := bytes.IndexByte(src[i:], anchor)
+		if idx < 0 {
+			return -1
+		}
+		j := i + idx
+		if j+len(needle) > len(src) {
+			return -1
+		}
+		if bytes.EqualFold(src[j+1:j+len(needle)], rest) {
+			return j
+		}
+		i = j + 1
 	}
-	return from + idx
+	return -1
 }

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -13,11 +13,23 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/binsarjr/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/render"
 	"github.com/binsarjr/sveltego/runtime/router"
 )
+
+// bytesAsString aliases p as a string without copying. Safe only when
+// the caller guarantees p is not mutated for the lifetime of the
+// returned string. Used to feed []byte into render.Writer.WriteRaw,
+// which only appends bytes (no retention).
+func bytesAsString(p []byte) string {
+	if len(p) == 0 {
+		return ""
+	}
+	return unsafe.String(&p[0], len(p))
+}
 
 // nonceBytes is the entropy source for a CSP nonce. 16 bytes (128 bits)
 // matches the OWASP recommendation; base64-encoded that becomes a
@@ -94,9 +106,21 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		ev.MatchPath = rewritten
 	}
 
-	var matched *router.Route
+	// pageBuf carries the pooled render.Writer ownership across the
+	// Handle hook. renderPage hands the buffer's underlying bytes to
+	// kit.Response.Body without copying, so the writer must outlive
+	// writeResponse. Released here once the response is fully flushed.
+	var (
+		matched *router.Route
+		pageBuf *render.Writer
+	)
+	defer func() {
+		if pageBuf != nil {
+			render.Release(pageBuf)
+		}
+	}()
 	resolve := func(ev *kit.RequestEvent) (*kit.Response, error) {
-		return s.resolve(w, r, ev, &matched)
+		return s.resolve(w, r, ev, &matched, &pageBuf)
 	}
 
 	res, err := s.runHandle(ev, resolve)
@@ -132,7 +156,9 @@ func (s *Server) runHandle(ev *kit.RequestEvent, resolve kit.ResolveFn) (res *ki
 // resolve runs the SvelteKit-shaped match → load → render path and
 // returns either a buffered Response (page routes) or errServerRouteWrote
 // (server routes wrote directly via the user's http.HandlerFunc).
-func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, matched **router.Route) (*kit.Response, error) {
+// pageBuf receives the pooled render.Writer when renderPage produces a
+// buffered Response so the caller can release it after writeResponse.
+func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, matched **router.Route, pageBuf **render.Writer) (*kit.Response, error) {
 	matchPath := ev.MatchPath
 	if matchPath == "" {
 		matchPath = ev.URL.Path
@@ -194,7 +220,7 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 	if !optionsAllowSSR(route.Options) {
 		return s.renderEmptyShell(), nil
 	}
-	return s.renderPage(w, r, ev, route, form)
+	return s.renderPage(w, r, ev, route, form, pageBuf)
 }
 
 // optionsAllowSSR returns true unless the route declared SSR=false. The
@@ -280,7 +306,11 @@ func canonicalRedirect(u *url.URL, path string) string {
 // directly to w and returns errStreamingWrote so writeResponse is
 // skipped. When form is non-nil the page's PageData.Form field is set
 // from form.data and the response status follows form.code.
-func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, route *router.Route, form *formData) (*kit.Response, error) {
+//
+// The buffered-response path stores its pooled render.Writer in *pageBuf
+// (when non-nil) and aliases buf.Bytes() into Response.Body. The caller
+// owns the writer and must release it after writeResponse runs.
+func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, route *router.Route, form *formData, pageBuf **render.Writer) (*kit.Response, error) {
 	var (
 		data        any
 		layoutDatas []any
@@ -358,11 +388,16 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 	}
 
 	buf := render.Acquire()
-	defer render.Release(buf)
+	released := false
+	defer func() {
+		if !released {
+			render.Release(buf)
+		}
+	}()
 
 	buf.WriteString(s.shellHead)
 	if len(headBytes) > 0 {
-		buf.WriteRaw(string(headBytes))
+		buf.WriteRaw(bytesAsString(headBytes))
 	}
 	buf.WriteString(s.shellMid)
 	if err := inner(buf); err != nil {
@@ -370,15 +405,28 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 	}
 	buf.WriteString(s.shellTail)
 
-	body := make([]byte, buf.Len())
-	copy(body, buf.Bytes())
-
+	body := buf.Bytes()
 	headers := http.Header{}
 	headers.Set("Content-Type", "text/html; charset=utf-8")
 	headers.Set("Content-Length", strconv.Itoa(len(body)))
 	status := http.StatusOK
 	if form != nil && form.code != 0 {
 		status = form.code
+	}
+	if pageBuf != nil {
+		// Release any prior buffer the caller stashed (legitimate when
+		// Handle invokes resolve more than once).
+		if prev := *pageBuf; prev != nil {
+			render.Release(prev)
+		}
+		*pageBuf = buf
+		released = true
+	} else {
+		// Fallback: caller didn't supply ownership — copy out so the
+		// buffer can be returned to the pool here.
+		owned := make([]byte, len(body))
+		copy(owned, body)
+		body = owned
 	}
 	return &kit.Response{
 		Status:  status,
@@ -455,7 +503,7 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 
 	buf.WriteString(s.shellHead)
 	if len(headBytes) > 0 {
-		buf.WriteRaw(string(headBytes))
+		buf.WriteRaw(bytesAsString(headBytes))
 	}
 	buf.WriteString(s.shellMid)
 	if err := inner(buf); err != nil {
@@ -498,7 +546,7 @@ func emitResolveScript(ctx context.Context, buf *render.Writer, id uint64, strea
 			buf.WriteString(`}`)
 		} else {
 			buf.WriteString(`{"data":`)
-			buf.WriteString(string(escapeScriptJSON(encoded)))
+			writeEscapedScriptJSON(buf, encoded)
 			buf.WriteString(`}`)
 		}
 	}
@@ -514,27 +562,49 @@ func writeJSONString(buf *render.Writer, s string) {
 		buf.WriteString(`""`)
 		return
 	}
-	buf.WriteString(string(escapeScriptJSON(encoded)))
+	writeEscapedScriptJSON(buf, encoded)
 }
 
-// escapeScriptJSON neutralizes "</" and "<!--" sequences inside a JSON
-// payload so an attacker-controlled string can't terminate the enclosing
-// <script> tag or open an HTML comment. Other "<" characters pass through
-// because they're already inside a JSON string literal that the browser's
-// JS parser treats as ordinary text.
-func escapeScriptJSON(p []byte) []byte {
-	if len(p) == 0 {
-		return p
+// writeEscapedScriptJSON appends p to buf, neutralizing "</" and "<!--"
+// sequences so an attacker-controlled string can't terminate the
+// enclosing <script> tag or open an HTML comment. The fast path writes
+// p verbatim when no escape-trigger byte appears; the slow path rewrites
+// only the offending bytes via a single rebuilt slice. Other "<"
+// characters pass through because they're already inside a JSON string
+// literal that the browser's JS parser treats as ordinary text.
+func writeEscapedScriptJSON(buf *render.Writer, p []byte) {
+	i := indexScriptSpecial(p)
+	if i < 0 {
+		buf.WriteRaw(bytesAsString(p))
+		return
 	}
-	out := make([]byte, 0, len(p))
-	for i := 0; i < len(p); i++ {
-		if p[i] == '<' && i+1 < len(p) && (p[i+1] == '/' || p[i+1] == '!') {
-			out = append(out, '\\', 'u', '0', '0', '3', 'c')
-			continue
+	buf.WriteRaw(bytesAsString(p[:i]))
+	const escape = `<`
+	tail := p[i:]
+	start := 0
+	for j := 0; j+1 < len(tail); j++ {
+		if tail[j] == '<' && (tail[j+1] == '/' || tail[j+1] == '!') {
+			if j > start {
+				buf.WriteRaw(bytesAsString(tail[start:j]))
+			}
+			buf.WriteString(escape)
+			start = j + 1
 		}
-		out = append(out, p[i])
 	}
-	return out
+	if start < len(tail) {
+		buf.WriteRaw(bytesAsString(tail[start:]))
+	}
+}
+
+// indexScriptSpecial returns the index of the first byte that triggers
+// script-context escaping, or -1 when p is clean.
+func indexScriptSpecial(p []byte) int {
+	for i := 0; i+1 < len(p); i++ {
+		if p[i] == '<' && (p[i+1] == '/' || p[i+1] == '!') {
+			return i
+		}
+	}
+	return -1
 }
 
 // writeResponse flushes a Response built by Handle (or its short-circuit


### PR DESCRIPTION
Closes #154
Closes #157
Closes #159
Closes #161

Server hot-path allocation cleanup, scoped to `packages/sveltego/server/`.

## Summary
- **#154** `escapeScriptJSON`: zero-alloc fast path; slow path writes only offending bytes via `WriteRaw` instead of allocating a full copy.
- **#157** `renderPage`/`renderErrorBoundary`: stop copying the entire render buffer per request. Pooled `render.Writer` ownership is threaded through `handle()` so `Response.Body` aliases `buf.Bytes()` and the buffer is released after `writeResponse` runs.
- **#159** `dedupeTitle`: drop `strings.ToLower(string(src))`. `findTitleSpans` walks `src` in place via `bytes.IndexByte` + `bytes.EqualFold`; zero allocs on the no-title fast path.
- **#161** `actionNameFromQuery`: replace `strings.Split` with manual scan via `strings.IndexByte`; zero allocs.

## #158 deferred
Acceptance requires codegen-side changes (route flag `RouteHasStreams`, generated typed walker per route). Cannot be fixed inside `packages/sveltego/server/`. Tracking comment posted on the issue; codegen follow-up will land separately.

## Bench results (Apple M1 Pro)
```
BenchmarkEscapeScriptJSON_Clean-10         29.31 ns/op    0 B/op   0 allocs/op
BenchmarkEscapeScriptJSON_Dirty-10         26.94 ns/op    0 B/op   0 allocs/op
BenchmarkDedupeTitle_NoTitle-10           214.8 ns/op    0 B/op   0 allocs/op
BenchmarkDedupeTitle_Single-10            240.4 ns/op   16 B/op   1 allocs/op
BenchmarkActionNameFromQuery_Default-10    2.07 ns/op    0 B/op   0 allocs/op
BenchmarkActionNameFromQuery_Match-10      9.62 ns/op    0 B/op   0 allocs/op
BenchmarkServeHTTP_Hello-10                1003 ns/op  1969 B/op  23 allocs/op
BenchmarkServeHTTP_HelloWithHead-10        1192 ns/op  2132 B/op  26 allocs/op
```

## Verification
- `gofumpt -l packages/sveltego/server/` clean
- `goimports -l -local github.com/binsarjr/sveltego packages/sveltego/server/` clean
- `go vet ./...` clean
- `golangci-lint run ./server/...` clean
- `go test -race ./packages/sveltego/...` 957 tests pass
- All workspace modules build

## Test plan
- [ ] CI green on the pushed branch
- [ ] No regression in `streaming_integration_test.go`, `head_test.go`, `actions_integration_test.go`
- [ ] Review buffer-ownership transfer for the rare-but-legal "Handle calls resolve multiple times" case (handled by releasing prior buffer when overwriting)