### PR TITLE
fix(lsp): recover from panics in JSON-RPC dispatch

### DIFF
--- a/packages/lsp/internal/server/server.go
+++ b/packages/lsp/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 )
@@ -91,6 +92,17 @@ func (s *Server) dispatch(msg *Message) {
 type handlerFn func(params json.RawMessage) (any, *RPCError)
 
 func (s *Server) handle(msg *Message, fn handlerFn) {
+	defer func() {
+		rec := recover()
+		if rec == nil {
+			return
+		}
+		s.logf("handler panic: method=%s id=%s panic=%v\n%s",
+			msg.Method, idString(msg.ID), rec, debug.Stack())
+		if msg.ID != nil {
+			s.respondError(msg.ID, ErrInternal, fmt.Sprintf("internal error: %v", rec))
+		}
+	}()
 	if msg.ID == nil {
 		// Notification dispatched to a request handler — best-effort run, drop result.
 		_, _ = fn(msg.Params)
@@ -102,6 +114,13 @@ func (s *Server) handle(msg *Message, fn handlerFn) {
 		return
 	}
 	s.respondResult(msg.ID, result)
+}
+
+func idString(id *json.RawMessage) string {
+	if id == nil {
+		return "<nil>"
+	}
+	return string(*id)
 }
 
 func (s *Server) respondResult(id *json.RawMessage, result any) {

--- a/packages/lsp/internal/server/server_test.go
+++ b/packages/lsp/internal/server/server_test.go
@@ -184,3 +184,68 @@ func TestServer_ProxyDisabled(t *testing.T) {
 		t.Fatalf("expected ErrProxyDisabled, got nil")
 	}
 }
+
+func TestServer_HandlePanicRequestRecoversAndResponds(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	var logs bytes.Buffer
+	srv := New(strings.NewReader(""), &out, &logs)
+
+	panicking := func(json.RawMessage) (any, *RPCError) {
+		panic("boom: handler exploded")
+	}
+	srv.handle(&Message{ID: rawID(t, 99), Method: "textDocument/hover"}, panicking)
+
+	resp, err := ReadMessage(bufio.NewReader(&out))
+	if err != nil {
+		t.Fatalf("read response after panic: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatalf("expected RPC error response after panic, got result %s", string(resp.Result))
+	}
+	if resp.Error.Code != ErrInternal {
+		t.Errorf("expected code %d, got %d", ErrInternal, resp.Error.Code)
+	}
+	if !strings.Contains(resp.Error.Message, "boom") {
+		t.Errorf("expected panic value in error message, got %q", resp.Error.Message)
+	}
+	if !strings.Contains(logs.String(), "handler panic") {
+		t.Errorf("expected panic log line, got %q", logs.String())
+	}
+
+	ok := func(params json.RawMessage) (any, *RPCError) {
+		return map[string]string{"hi": "there"}, nil
+	}
+	srv.handle(&Message{ID: rawID(t, 100), Method: "textDocument/hover"}, ok)
+
+	reader := bufio.NewReader(&out)
+	resp2, err := ReadMessage(reader)
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+	if resp2.Error != nil {
+		t.Fatalf("post-panic request returned error: %+v", resp2.Error)
+	}
+	if !strings.Contains(string(resp2.Result), `"hi":"there"`) {
+		t.Errorf("post-panic result missing payload: %s", string(resp2.Result))
+	}
+}
+
+func TestServer_HandlePanicNotificationDropsResponse(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	var logs bytes.Buffer
+	srv := New(strings.NewReader(""), &out, &logs)
+
+	panicking := func(json.RawMessage) (any, *RPCError) {
+		panic("notification panic")
+	}
+	srv.handle(&Message{Method: "textDocument/didOpen"}, panicking)
+
+	if out.Len() != 0 {
+		t.Errorf("expected no response for panicking notification, got %q", out.String())
+	}
+	if !strings.Contains(logs.String(), "handler panic") {
+		t.Errorf("expected panic log line, got %q", logs.String())
+	}
+}

--- a/packages/lsp/internal/server/server_test.go
+++ b/packages/lsp/internal/server/server_test.go
@@ -213,7 +213,7 @@ func TestServer_HandlePanicRequestRecoversAndResponds(t *testing.T) {
 		t.Errorf("expected panic log line, got %q", logs.String())
 	}
 
-	ok := func(params json.RawMessage) (any, *RPCError) {
+	ok := func(json.RawMessage) (any, *RPCError) {
 		return map[string]string{"hi": "there"}, nil
 	}
 	srv.handle(&Message{ID: rawID(t, 100), Method: "textDocument/hover"}, ok)


### PR DESCRIPTION
Closes #184

## Summary

`Server.handle` now wraps the request/notification dispatch in a deferred
`recover()`. A panic inside any handler is logged (with stack via
`runtime/debug.Stack`) through `s.logf` and, for request messages,
returned to the client as a JSON-RPC `InternalError` (-32603). Previously
a single panicking handler would unwind through `Serve` and drop the
editor connection.

## Why

`packages/lsp/internal/server/server.go` had no recovery boundary. The
issue (#184) calls out that the parallel `runHandle` in
`packages/sveltego/server/pipeline.go` already does this for the SSR
pipeline; the LSP server lacked the same guard.

## Test plan
- [x] `gofumpt -l packages/lsp/` clean
- [x] `goimports -l -local github.com/binsarjr/sveltego packages/lsp/` clean
- [x] `go vet ./packages/lsp/...`
- [x] `go test -race ./packages/lsp/...` (18 tests pass, 2 new)
- [x] `go build ./...`
- [x] New tests: `TestServer_HandlePanicRequestRecoversAndResponds` proves
      a panicking handler yields an `ErrInternal` reply and a subsequent
      valid request still succeeds.
      `TestServer_HandlePanicNotificationDropsResponse` proves
      notification-shaped panics log but emit nothing on the wire.