### PR TITLE
docs: post-wave-1 sync (milestones, packages, labels)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -11,13 +11,13 @@ Per-tool entry points:
 - GitHub Copilot → `.github/copilot-instructions.md` (auto-generated).
 - Aider / generic agents → this file.
 
-If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/core/codegen/CLAUDE.md`), it wins for that package's scope. Cross-cutting rules live here.
+If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CLAUDE.md` once it lands), it wins for that package's scope. Cross-cutting rules live here.
 
 ---
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. No Go source has landed yet — the repo currently holds specs, RFCs, ADRs, and a 105-issue roadmap on GitHub at `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see `tasks/lessons.md` "Pivot to Go-native rewrite"):
 
@@ -224,7 +224,7 @@ Generated output lives under `.gen/` (gitignored). Every `.gen/*.go` starts with
 ## 6. Issue and PR workflow
 
 - **Issue body contract:** Summary · Background · Goals · Non-Goals · Detailed Design (with code) · Acceptance Criteria · Testing Strategy · Out of Scope · Risks & Open Questions · Dependencies (Blocks / Blocked by) · References.
-- **Required labels per issue:** one `area:*`, one `type:*`, one `priority:*` (`p0` blocker / `p1` important / `p2` nice-to-have). Areas in use: `codegen`, `router`, `runtime`, `cli`, `client`, `forms`, `hooks`, `perf`, `docs`, `infra`, `design`, `llm`. The `blocked` label flags cross-issue waits.
+- **Required labels per issue:** one `area:*`, one `type:*`, one `priority:*` (`priority:p0` blocker / `priority:p1` important / `priority:p2` nice-to-have). Areas in use: `auth`, `cli`, `client`, `codegen`, `design`, `docs`, `forms`, `hooks`, `infra`, `llm`, `perf`, `router`, `runtime`, `tooling`. The `blocked` label flags cross-issue waits.
 - Author/edit issues with `gh issue create --body-file` or `gh issue edit --body-file`. **Never** inline `--body` (heredoc avoids quoting traps).
 - Definition of Done: see `.github/PULL_REQUEST_TEMPLATE.md` (RFC #102).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,13 +11,13 @@ Per-tool entry points:
 - GitHub Copilot → `.github/copilot-instructions.md` (auto-generated).
 - Aider / generic agents → this file.
 
-If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/core/codegen/CLAUDE.md`), it wins for that package's scope. Cross-cutting rules live here.
+If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CLAUDE.md` once it lands), it wins for that package's scope. Cross-cutting rules live here.
 
 ---
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. No Go source has landed yet — the repo currently holds specs, RFCs, ADRs, and a 105-issue roadmap on GitHub at `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see `tasks/lessons.md` "Pivot to Go-native rewrite"):
 
@@ -224,7 +224,7 @@ Generated output lives under `.gen/` (gitignored). Every `.gen/*.go` starts with
 ## 6. Issue and PR workflow
 
 - **Issue body contract:** Summary · Background · Goals · Non-Goals · Detailed Design (with code) · Acceptance Criteria · Testing Strategy · Out of Scope · Risks & Open Questions · Dependencies (Blocks / Blocked by) · References.
-- **Required labels per issue:** one `area:*`, one `type:*`, one `priority:*` (`p0` blocker / `p1` important / `p2` nice-to-have). Areas in use: `codegen`, `router`, `runtime`, `cli`, `client`, `forms`, `hooks`, `perf`, `docs`, `infra`, `design`, `llm`. The `blocked` label flags cross-issue waits.
+- **Required labels per issue:** one `area:*`, one `type:*`, one `priority:*` (`priority:p0` blocker / `priority:p1` important / `priority:p2` nice-to-have). Areas in use: `auth`, `cli`, `client`, `codegen`, `design`, `docs`, `forms`, `hooks`, `infra`, `llm`, `perf`, `router`, `runtime`, `tooling`. The `blocked` label flags cross-issue waits.
 - Author/edit issues with `gh issue create --body-file` or `gh issue edit --body-file`. **Never** inline `--body` (heredoc avoids quoting traps).
 - Definition of Done: see `.github/PULL_REQUEST_TEMPLATE.md` (RFC #102).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,13 @@ Per-tool entry points:
 - GitHub Copilot → `.github/copilot-instructions.md` (auto-generated).
 - Aider / generic agents → this file.
 
-If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/core/codegen/CLAUDE.md`), it wins for that package's scope. Cross-cutting rules live here.
+If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CLAUDE.md` once it lands), it wins for that package's scope. Cross-cutting rules live here.
 
 ---
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. No Go source has landed yet — the repo currently holds specs, RFCs, ADRs, and a 105-issue roadmap on GitHub at `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see `tasks/lessons.md` "Pivot to Go-native rewrite"):
 
@@ -222,7 +222,7 @@ Generated output lives under `.gen/` (gitignored). Every `.gen/*.go` starts with
 ## 6. Issue and PR workflow
 
 - **Issue body contract:** Summary · Background · Goals · Non-Goals · Detailed Design (with code) · Acceptance Criteria · Testing Strategy · Out of Scope · Risks & Open Questions · Dependencies (Blocks / Blocked by) · References.
-- **Required labels per issue:** one `area:*`, one `type:*`, one `priority:*` (`p0` blocker / `p1` important / `p2` nice-to-have). Areas in use: `codegen`, `router`, `runtime`, `cli`, `client`, `forms`, `hooks`, `perf`, `docs`, `infra`, `design`, `llm`. The `blocked` label flags cross-issue waits.
+- **Required labels per issue:** one `area:*`, one `type:*`, one `priority:*` (`priority:p0` blocker / `priority:p1` important / `priority:p2` nice-to-have). Areas in use: `auth`, `cli`, `client`, `codegen`, `design`, `docs`, `forms`, `hooks`, `infra`, `llm`, `perf`, `router`, `runtime`, `tooling`. The `blocked` label flags cross-issue waits.
 - Author/edit issues with `gh issue create --body-file` or `gh issue edit --body-file`. **Never** inline `--body` (heredoc avoids quoting traps).
 - Definition of Done: see `.github/PULL_REQUEST_TEMPLATE.md` (RFC #102).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ To avoid hallucinating conventions, layout, or APIs, read **in this order** befo
 6. `AGENTS.md` — master AI rules synced to `.cursorrules` and copilot instructions per RFC #103.
 7. `CONTRIBUTING.md` — code style, error handling, logging, ctx propagation.
 8. `STABILITY.md` per package — what's safe to change (RFC #97).
-9. Any package-local `CLAUDE.md` for scope-specific patterns (e.g. `packages/sveltego/core/codegen/CLAUDE.md`).
+9. Any package-local `CLAUDE.md` for scope-specific patterns (e.g. `packages/sveltego/internal/codegen/CLAUDE.md` once it lands).
 
 If a doc is missing, check the corresponding issue body — body-files in `/tmp/setup-bodies/*.md` exist locally during the bootstrap phase.
 
@@ -38,11 +38,11 @@ When in doubt about a convention: open the relevant issue with `gh issue view <N
 
 ## Repository state
 
-Pre-alpha. **No Go source yet** — repo holds specs, RFCs, and a 105-issue roadmap on GitHub at `binsarjr/sveltego`. The first code lands when foundation RFCs (#95–97) and setup tasks (#98–103) land. Until then, all work happens in:
+Pre-alpha. MVP closed; v0.2, v0.4, and v1.1 shipped; v0.3, v0.5, v0.6, and v1.0 in flight. The Go workspace already hosts the core (`packages/sveltego`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates (`templates/ai/`), and end-to-end playgrounds. New work continues to flow through:
 
 - `tasks/todo.md` — current execution plan, milestone scope, phase tracking
 - `tasks/lessons.md` — design decisions and self-rules captured per session (append-only journal)
-- GitHub issues on `binsarjr/sveltego` — every concrete unit of work
+- GitHub issues on `binsarjr/sveltego` — every concrete unit of work (see milestone counts below for live totals)
 
 Always read both `tasks/` files at session start before proposing changes.
 
@@ -200,17 +200,20 @@ If counts, file lists, or roadmap stages disagree across these, the doc set is b
 
 ## Roadmap structure
 
-6 milestones, 105 issues. Issue numbering follows execution order:
+8 milestones. Counts below match the live `gh api repos/binsarjr/sveltego/milestones` output — re-verify with `gh issue list --milestone <N> --state all --json number | jq length` whenever you edit this table.
 
 | Milestone | Issues | Focus |
 |---|---|---|
-| MVP | #1–23, #76, #77, #83, #95–105 | Foundation RFCs + setup, parser, codegen, runtime, router, CLI to render a page |
-| v0.2 | #24–33, #78–82 | Layouts, hooks, error boundaries, form actions, route groups, page options, env |
-| v0.3 | #34–42, #84, #85, #87, #88 | Vite client, hydration, SPA router, `$app/navigation`, Snapshot, kit.Link, kit.Asset |
-| v0.4 | #43–59, #86, #90 | Svelte 5 full coverage, a11y, `<svelte:options>` |
-| v1.0 | #60–69, #89, #91–93 | Bench, docs, streaming, SSG, CSP, sitemap, image opt, deploy adapters |
-| v1.1 | #70–75 | LLM tooling: `llms.txt`, MCP server, AI templates, provenance |
-| Standalone | #94 | RFC: explicit non-goals |
+| MVP | 42 (#1–23, #76, #77, #83, #95–110) | Foundation RFCs + setup, parser, codegen, runtime, router, CLI to render a page |
+| v0.2 | 15 (#24–33, #78–82) | Layouts, hooks, error boundaries, form actions, route groups, page options, env |
+| v0.3 | 21 (#34–42, #84, #85, #87, #88, plus #123, #172, #181, #183, #204, #206–208) | Vite client, hydration, SPA router, `$app/navigation`, Snapshot, kit.Link, kit.Asset |
+| v0.4 | 19 (#43–59, #86, #90) | Svelte 5 full coverage, a11y, `<svelte:options>` |
+| v0.5 | 23 (SvelteKit-parity catch-up + cookie-session core) | Upstream-tracked enhancements (`kit.After`, `HandleAction`, `RawParam`, `RouteID`, …) and the cookie-session auth core |
+| v0.6 | 40 (auth track) | `sveltego-auth` master plan (#155), storage adapters, sessions, password / magic-link / OTP / OAuth |
+| v1.0 | 25 (#60–69, #89, #91–93, plus post-merge code-quality follow-ups) | Bench, docs, streaming, SSG, CSP, sitemap, image opt, deploy adapters, post-Wave-1 hardening |
+| v1.1 | 6 (#70–75) | LLM tooling: `llms.txt`, MCP server, AI templates, provenance |
+
+Closed standalone issues (e.g. #94 non-goals RFC) live unmilestoned — search `gh issue list --search "no:milestone state:closed"` if needed.
 
 ## Issue conventions
 
@@ -218,7 +221,7 @@ Every issue body follows the same contract — keep it when authoring or editing
 
 `Summary · Background · Goals · Non-Goals · Detailed Design (with code) · Acceptance Criteria · Testing Strategy · Out of Scope · Risks & Open Questions · Dependencies (Blocks / Blocked by) · References`
 
-Required labels per issue: one `area:*`, one `type:*`, one `priority:*` (`p0` blocker / `p1` important / `p2` nice-to-have). Areas in use: `codegen`, `router`, `runtime`, `cli`, `client`, `forms`, `hooks`, `perf`, `docs`, `infra`, `design`, `llm`. The `blocked` label flags cross-issue waits.
+Required labels per issue: one `area:*`, one `type:*`, one `priority:*` (`priority:p0` blocker / `priority:p1` important / `priority:p2` nice-to-have). Areas in use: `auth`, `cli`, `client`, `codegen`, `design`, `docs`, `forms`, `hooks`, `infra`, `llm`, `perf`, `router`, `runtime`, `tooling`. The `blocked` label flags cross-issue waits.
 
 Author/edit issues with `gh issue create --body-file` or `gh issue edit --body-file`, never inline `--body` (heredoc avoids quoting traps). Recent batch scripts (`/tmp/sveltego-issues-*.sh`) show the helper pattern.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Rewritten from scratch in Go. File layout and DX mirror SvelteKit (file-based ro
 
 ## Status
 
-🚧 Pre-alpha. Spec and RFC phase. See [GitHub issues](https://github.com/binsarjr/sveltego/issues) for the roadmap.
+🚧 Pre-alpha. MVP closed; v0.2 (form actions, hooks), v0.4 (Svelte 5 runes), and v1.1 (LLM tooling) shipped. v0.3 (client SPA + hydration), v0.5 (SvelteKit-parity catch-up), v0.6 (auth), and v1.0 (production hardening) in flight. See [GitHub issues](https://github.com/binsarjr/sveltego/issues) for the live roadmap.
 
 ## Goals
 
@@ -29,10 +29,10 @@ Full enumerated list with reasoning: [ADR 0005 — Non-goals](tasks/decisions/00
 ```
 .svelte (UI)            ──┬─→ codegen → .gen/*.go    (server SSR)
                           └─→ Vite build → JS bundle (client hydration)
-page.server.go          ──→  Load(), Actions()           (// +build sveltego)
-layout.server.go        ──→  Load() with parent data flow (// +build sveltego)
+page.server.go          ──→  Load(), Actions()           (//go:build sveltego)
+layout.server.go        ──→  Load() with parent data flow (//go:build sveltego)
 hooks.server.go         ──→  Handle, HandleError, HandleFetch
-server.go               ──→  REST endpoints              (// +build sveltego)
+server.go               ──→  REST endpoints              (//go:build sveltego)
                           ↓
                   sveltego CLI (pure Go)
                           ↓
@@ -62,17 +62,46 @@ Field names are PascalCase (Go exported). `nil` not `null`, `len(x)` not `x.leng
 
 ## Roadmap
 
-6 milestones, 105 issues tracked on GitHub:
+8 milestones tracked on GitHub (counts as of the latest doc-drift sync):
 
 | Milestone | Issues | Scope |
 |-----------|--------|-------|
-| **MVP** | 37 | Foundation RFCs (#95–97) + setup (#98–105: lint, hooks, release-please, CI, PR template, AI sync, golden tests, bench gate), parser, codegen, runtime, router (incl. param matchers, optional/rest), `$lib` alias, CLI |
+| **MVP** | 42 | Foundation RFCs (#95–97) + setup (#98–105: lint, hooks, release-please, CI, PR template, AI sync, golden tests, bench gate), parser, codegen, runtime, router (incl. param matchers, optional/rest), `$lib` alias, CLI, Phase 0i-fix bugs (#106–110) |
 | **v0.2** | 15 | Layouts, hooks (incl. `Reroute`/`Init`), error boundaries, form actions, cookies, route groups, page options, `$env` |
-| **v0.3** | 13 | Vite client bundle, hydration, SPA router, full `$app/navigation`, Snapshot, typed `kit.Link`, hashed `kit.Asset`, dev server |
+| **v0.3** | 21 | Vite client bundle, hydration, SPA router, full `$app/navigation`, Snapshot, typed `kit.Link`, hashed `kit.Asset`, dev server |
 | **v0.4** | 19 | Svelte 5 runes, slots, snippets, special elements, `<svelte:options>`, scoped CSS, a11y warnings |
-| **v1.0** | 14 | Benchmarks, docs, examples, streaming/SSG/CSP, sitemap, image opt, deploy adapters, CI/release/LSP, service worker |
+| **v0.5** | 23 | SvelteKit-parity catch-up: upstream-tracked enhancements (`kit.After`, `HandleAction`, `RawParam`, `RouteID`, etc.) and the cookie-session auth core |
+| **v0.6** | 40 | Authentication: `sveltego-auth` master plan (#155), storage adapters, sessions, password / magic-link / OTP / OAuth flows |
+| **v1.0** | 25 | Benchmarks, docs, examples, streaming/SSG/CSP, sitemap, image opt, deploy adapters, CI/release/LSP, service worker, post-merge code-quality follow-ups |
 | **v1.1** | 6 | LLM tooling: `llms.txt`, MCP server, copy-for-LLM, AI templates, provenance |
-| Standalone | 1 | RFC #94: explicit non-goals (universal load, WS, vercel adapter) |
+
+## Repository layout
+
+This is a Go workspace (`go.work`) with one module per package:
+
+```
+packages/
+  sveltego/             # Core: parser, codegen, runtime, kit, router, server, CLI
+  init/                 # `sveltego init` scaffolder
+  lsp/                  # Language server for `.svelte` with Go expressions
+  mcp/                  # Model Context Protocol server (search_docs, lookup_api, …)
+  enhanced-img/         # Image optimization helpers
+  create-sveltego/      # `npm create sveltego` bridge
+  adapter-server/       # Bare HTTP binary deploy
+  adapter-docker/       # Multi-stage Dockerfile + distroless runtime
+  adapter-lambda/       # AWS Lambda via aws-lambda-go-api-proxy
+  adapter-static/       # SSG output (stub; tracks #65)
+  adapter-cloudflare/   # Cloudflare Workers (stub; tracks Workers Go runtime)
+  adapter-auto/         # Dispatch by env / target name + standalone CLI
+bench/                  # Benchmark harness vs adapter-bun (RFC #105)
+benchmarks/             # Per-package microbenchmarks
+playgrounds/            # End-to-end example apps (basic, blog, dashboard, …)
+templates/ai/           # Embedded AGENTS.md / CLAUDE.md / .cursorrules / copilot
+docs/                   # VitePress site (guide + reference)
+tasks/                  # Execution plan, lessons, ADRs
+```
+
+Per-package `STABILITY.md` and `CHANGELOG.md` are the authoritative source for what is safe to import.
 
 ## See also
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -31,7 +31,7 @@ hello/
   src/
     routes/
       +page.svelte
-      +page.server.go      # //go:build sveltego
+      page.server.go       # //go:build sveltego (no `+` prefix on user .go files)
     hooks.server.go        # //go:build sveltego (optional)
     lib/                   # $lib alias target
   go.mod
@@ -53,7 +53,7 @@ hello/
 <h1>{Data.Greeting}</h1>
 ```
 
-`src/routes/+page.server.go`:
+`src/routes/page.server.go` (no `+` prefix — user `.go` files use the `//go:build sveltego` tag instead, so the standard Go toolchain ignores them):
 
 ```go
 //go:build sveltego

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
   - title: Pure Go server
     details: .svelte templates compile to .gen/*.go. No goja, v8go, or Bun on the request path.
   - title: Familiar conventions
-    details: +page.svelte, +page.server.go, +layout.svelte, +error.svelte, hooks.server.go. Same shape as SvelteKit.
+    details: +page.svelte, page.server.go, +layout.svelte, +error.svelte, hooks.server.go. Same shape as SvelteKit.
   - title: Go expressions
     details: '{Data.User.Name}, {len(Data.Posts)}, nil not null. Validated at codegen via go/parser.'
   - title: Svelte 5 runes

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,7 +22,7 @@ The effort is comparable but the rewrite trade buys us performance, deploy simpl
 
 Tracked as GitHub milestones at `binsarjr/sveltego`. Each issue carries Summary, Background, Goals, Non-Goals, Detailed Design, Acceptance Criteria, Testing Strategy, Risks, Dependencies, References.
 
-### MVP (37 issues) — minimum to render a page
+### MVP (42 issues) — minimum to render a page
 
 Foundation layer first: monorepo layout RFC (#95), code style + stability RFCs (#96, #97), lint + hooks + release-please + CI + PR template + AI doc sync + golden tests + bench gate (#98–105). Then technical RFCs (parser strategy, expression syntax, file convention, codegen layout — #1–4), then bootstrap (Go module, CLI), then the core pipeline:
 
@@ -39,7 +39,7 @@ Foundation layer first: monorepo layout RFC (#95), code style + stability RFCs (
 
 Layout chain rendering, `layout.server.go` parent data flow, `Handle` / `HandleError` / `HandleFetch` / `Reroute` / `Init`, `+error.svelte` boundaries, `server.go` REST endpoints, `Actions()` map with form binding (urlencoded + multipart), `kit.Cookies`, `kit.Redirect / Fail / Error` sentinel helpers, route groups `(group)/` + layout reset `@`, page options (`Prerender`, `SSR`, `CSR`, `TrailingSlash`), env var convention (`$env/static`, `$env/dynamic`).
 
-### v0.3 (13 issues) — Client SPA & Hydration
+### v0.3 (21 issues) — Client SPA & Hydration
 
 Vite integration for the Svelte client bundle, `window.__sveltego__` hydration payload, client hydrate runtime, SPA router (link interception + history), `__data.json` per-route endpoint, `use:enhance` for forms, prefetch on hover/viewport, precompressed static asset serving, `sveltego dev` with HMR. Full `$app/navigation` API (`goto`, `invalidate`, `preload`, `pushState`), Snapshot API for cross-nav state, typed `kit.Link` with route params, `kit.Asset` with hashed static URLs.
 
@@ -47,7 +47,7 @@ Vite integration for the Svelte client bundle, `window.__sveltego__` hydration p
 
 Runes: `$props`, `$state`, `$derived`, `$effect`, `$bindable`. Snippets and `{@render}`. Legacy slots (default + named, with slot props). Special elements: `<svelte:head>`, `<svelte:body>` / `<svelte:window>` / `<svelte:document>`, `<svelte:component>`, `<svelte:options>`. CSS scope hash matching upstream. `{@html}`, `{@const}`, `{#await}`, `{#key}`. Nested component import and rendering. Compile-time a11y warnings.
 
-### v1.0 (14 issues) — Production Ready
+### v1.0 (25 issues) — Production Ready
 
 Benchmark suite vs adapter-bun with nightly regression gate. Docs site (Vitepress). Blog and dashboard examples. Streaming responses. Prerender / SSG mode. CSP nonce injection. CI (GitHub Actions). Release pipeline (release-please + GoReleaser). LSP for `.svelte` with Go expressions. Sitemap/robots helpers, image optimization (`<Image>`), service worker convention, deploy adapters (server, docker, static, lambda, cloudflare).
 
@@ -55,9 +55,17 @@ Benchmark suite vs adapter-bun with nightly regression gate. Docs site (Vitepres
 
 `llms.txt` + `llms-full.txt` for AI agents. `sveltego mcp` Model Context Protocol server (`search_docs`, `lookup_api`, `validate_template`, `scaffold_route`). Markdown-first docs with copy-for-LLM buttons. AI assistant project templates (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, copilot instructions) wired into `sveltego init --ai`. Provenance comments in generated `.gen/*.go`. AI-assisted development guide page.
 
+### v0.5 (23 issues) — SvelteKit-parity catch-up
+
+Tracks upstream `sveltejs/kit` enhancements that landed after the initial roadmap snapshot: `kit.After()`, `HandleAction` global middleware, `Init()` error fallback, short-circuiting `HandleError`, `LoadCtx.Speculative()`, typed `kit.HTTPError`, headers/cookies on error responses, `kit.RedirectReload`, `LoadCtx.RawParam()`, codegen `RouteID` constants, dev-only code stripping, etc. Also includes the cookie-session auth core (`auth/cookiesession`) — separate package modeled on `svelte-kit-cookie-session`.
+
+### v0.6 (40 issues) — Authentication
+
+Full `sveltego-auth` package modeled on the better-auth feature set: master plan (#155), package scaffold, storage adapters (memory, `database/sql`, pgx), session token format + DB-backed strategy, encrypted-cookie session strategy, password hashing (argon2id), email/password flows, email verification, password reset, mailer + SMS adapters, magic-link, OTP, TOTP, OAuth core + provider adapters, RBAC primitives, audit log, 2FA, account linking, etc.
+
 ### Standalone
 
-- #94 RFC: explicit non-goals (universal load, WS server, vercel-style adapter, etc.) — sets boundaries before contributors propose them.
+- #94 (closed) — non-goals RFC retained as ADR 0005; the GitHub issue is unmilestoned.
 
 ## Decision log (high-level)
 
@@ -74,7 +82,7 @@ Benchmark suite vs adapter-bun with nightly regression gate. Docs site (Vitepres
 - [x] Direction confirmed (Go-native rewrite, not JS embed)
 - [x] Repo created at `binsarjr/sveltego`
 - [x] Issue templates (feature, RFC, bug)
-- [x] 20 labels, 6 milestones, 105 issues created
+- [x] 20 labels, 6 milestones, 105 issues created (initial roadmap snapshot; live counts now 8 milestones / 221 issues — see milestone table above)
 - [x] All 69 original issues rewritten in English with industry-standard detail
 - [x] v1.1 milestone added — LLM & AI tooling (#70–75)
 - [x] SvelteKit-parity gap audit + 19 issues filed with priorities (#76–94)


### PR DESCRIPTION
## Summary

Doc-drift audit after Wave 1 (PRs #259, #260, #261, #262, #263, #264, #266, #267 merged). Live audit cross-checked against `gh api repos/binsarjr/sveltego/milestones` and `gh label list`.

## What changed per file

- **README.md**
  - Status line refreshed: MVP closed, v0.2/v0.4/v1.1 shipped, v0.3/v0.5/v0.6/v1.0 in flight (replaces stale "Spec and RFC phase").
  - Milestone table corrected against live counts: MVP 37→42, v0.3 13→21, v1.0 14→25; new rows for v0.5 (23) and v0.6 (40).
  - Dropped closed unmilestoned `Standalone` row (#94 lives unmilestoned).
  - **New Repository layout section** listing every package on disk: `sveltego`, `init`, `lsp`, `mcp`, `enhanced-img`, `create-sveltego`, all five adapters + `adapter-auto`, `bench/`, `benchmarks/`, `playgrounds/`, `templates/ai/`, `docs/`, `tasks/`.
  - Architecture diagram: `// +build sveltego` → `//go:build sveltego` (Go pre-1.17 syntax was a stale carry-over).

- **CLAUDE.md**
  - Repository state: dropped "No Go source yet" claim; replaced with current package inventory and milestone status.
  - Phantom path `packages/sveltego/core/codegen/CLAUDE.md` → `packages/sveltego/internal/codegen/CLAUDE.md` (no `core/` directory exists).
  - Roadmap structure table: synced to 8 milestones with live counts; added v0.5 and v0.6 rows; cited `gh issue list --milestone <N>` as the verification command.
  - Areas-in-use list: added `auth` and `tooling` (both new since Wave 1); switched `p0/p1/p2` shorthand to canonical `priority:p0/p1/p2`.

- **AGENTS.md**
  - Same phantom-path, project-shape, and label-list fixes as CLAUDE.md.
  - `.cursorrules` and `.github/copilot-instructions.md` regenerated via `scripts/sync-ai-docs.sh` (CI verifies sync).

- **tasks/todo.md**
  - Section headers: MVP 37→42, v0.3 13→21, v1.0 14→25.
  - Added v0.5 (23 issues, SvelteKit-parity catch-up + cookie-session core) and v0.6 (40 issues, full auth track) sections.
  - Standalone bullet rephrased to reflect closed-and-unmilestoned reality.
  - Phase tracking line annotated to flag the historical 105-issue / 6-milestone snapshot vs current 221 / 8.

- **docs/index.md**
  - "Familiar conventions" feature: `+page.server.go` → `page.server.go` per ADR 0003 amendment (user `.go` files have no `+` prefix; the on-disk playground truth confirms this).

- **docs/guide/quickstart.md**
  - Scaffold tree and code-example header use `page.server.go` (no `+`); annotated why so a fresh reader does not assume the convention matches `.svelte` files.

## What did NOT change (verified clean)

- `tasks/lessons.md`: orphan conflict marker is gone post-#259; no duplicate entry. Mandate criteria met.
- `docs/reference/kit.md`: every documented kit symbol still exists in `packages/sveltego/exports/kit/*.go`.
- Other `docs/guide/*.md` and `docs/reference/*.md` files have similar `+page.server.go` references but are out of scope for this single-PR audit; flagged below as follow-up.

## Cross-references checked

| Source | Live value | Doc value before | Doc value after |
|---|---|---|---|
| MVP issues | 42 | 37 | 42 |
| v0.2 issues | 15 | 15 | 15 |
| v0.3 issues | 21 | 13 | 21 |
| v0.4 issues | 19 | 19 | 19 |
| v0.5 issues | 23 | (missing) | 23 |
| v0.6 issues | 40 | (missing) | 40 |
| v1.0 issues | 25 | 14 | 25 |
| v1.1 issues | 6 | 6 | 6 |
| Total milestones | 8 | 6 | 8 |
| Areas | 14 (auth, tooling added) | 12 | 14 |

## Follow-ups (not in this PR)

- Several `docs/guide/*.md` and `docs/reference/*.md` pages still reference `+page.server.go` / `+layout.server.go` / `+server.go` with the `+` prefix. Sweep deferred to a focused docs-site PR; this PR keeps scope to the highest-traffic entry points (`index.md`, `quickstart.md`).
- Per-package `CLAUDE.md` files referenced in CLAUDE.md/AGENTS.md still do not exist on disk; the language was softened to "once it lands" rather than removed, so the door stays open for the next codegen-deep-dive PR.

## Test plan

- [x] `git diff --stat` shows only docs/markdown changes; no `.go`, `.svelte`, `.yml`, `.json`, `.ts` touched.
- [x] H1 count per top-level doc unchanged (1 each); markdown tables remain well-formed (`awk` pipe-count check).
- [x] No orphan conflict markers introduced.
- [x] `scripts/sync-ai-docs.sh` runs clean and reproduces the committed `.cursorrules` / `copilot-instructions.md`.
- [ ] CI green on PR (lint + agents-sync + docs-only path filters).

No issue closure — pure doc maintenance.