### PR TITLE
test(bench): reset timer + per-iter recorder

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -23,10 +23,10 @@ func BenchmarkServeHTTP_Action(b *testing.B) { runScenario(b, mustAction) }
 func runScenario(b *testing.B, build func(*testing.B) scenarios.Scenario) {
 	b.Helper()
 	sc := build(b)
-	rec := httptest.NewRecorder()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
+		rec := httptest.NewRecorder()
 		_ = sc.Run(rec)
 	}
 }
@@ -47,6 +47,7 @@ func BenchmarkRouteResolution(b *testing.B) {
 // trusted and escaped output, mirroring what page handlers emit.
 func BenchmarkRenderWriter(b *testing.B) {
 	b.ReportAllocs()
+	b.ResetTimer()
 	for range b.N {
 		w := render.Acquire()
 		w.WriteString("<article><h1>post ")

--- a/bench/scenarios/scenarios.go
+++ b/bench/scenarios/scenarios.go
@@ -39,8 +39,9 @@ type Scenario struct {
 }
 
 // Run executes one ServeHTTP round-trip and returns the recorded response
-// body length. Callers reset the recorder between iterations so the
-// allocation count stays stable.
+// body length. The body is reset before serving so callers may reuse a
+// recorder across iterations without unbounded growth; testing.B callers
+// pass a fresh recorder per iteration so per-iter alloc counts are honest.
 func (s Scenario) Run(rec *httptest.ResponseRecorder) int {
 	rec.Body.Reset()
 	s.Server.ServeHTTP(rec, s.Request)


### PR DESCRIPTION
Closes #213

## Why
- `BenchmarkRenderWriter` was missing `b.ResetTimer()`, so the first `render.Acquire` pool warmup leaked into the timed loop.
- `runScenario` allocated one shared `httptest.ResponseRecorder` for the whole `b.N` loop. Even with `Body.Reset()`, the recorder's per-iter alloc accounting is amortized — bias source for #105's regression gate.

## Change
- Add `b.ResetTimer()` after setup in `BenchmarkRenderWriter`.
- Allocate a fresh `httptest.NewRecorder()` per iteration in `runScenario`.
- `Scenario.Run` keeps its defensive `Body.Reset()` because `cmd/sveltego-bench/main.go` reuses one recorder across its wall-clock measurement loop. Updated godoc to reflect both call patterns.

## Verification
- `go test -run=^$ -bench=BenchmarkServeHTTP_Hello -benchmem -benchtime=10000x -count=3 .` shows stable 23 allocs/op across runs.
- `gofumpt`, `goimports`, `go vet`, `go build`, `go test -race` all clean.

## Out of scope
Issue #213 also flags `packages/sveltego/render/render_bench_test.go` and `runtime/router/bench_test.go`. Those live outside `bench/` and are deferred to a follow-up to keep this PR scoped.

## Test plan
- [x] `go vet ./bench/...`
- [x] `go test -race ./bench/...`
- [x] `go build ./bench/...`
- [x] `go test -bench=. -benchmem -benchtime=10000x -count=3 ./bench/` — alloc counts stable across runs