### PR TITLE
feat(kit): default Error message to http.StatusText

### DIFF
--- a/packages/sveltego/exports/kit/sentinels.go
+++ b/packages/sveltego/exports/kit/sentinels.go
@@ -1,6 +1,9 @@
 package kit
 
-import "strconv"
+import (
+	"net/http"
+	"strconv"
+)
 
 // RedirectErr signals a redirect short-circuit from Load. Code is the
 // HTTP status (303 for POST->GET, 307/308 to preserve method).
@@ -58,9 +61,14 @@ func Redirect(code int, location string) error {
 }
 
 // Error returns an error that, when returned from Load, makes the
-// pipeline emit an HTTP error response with the given status and message.
-func Error(code int, message string) error {
-	return &HTTPErr{Code: code, Message: message}
+// pipeline emit an HTTP error response with the given status. When message
+// is omitted, Message defaults to http.StatusText(code).
+func Error(code int, message ...string) error {
+	msg := http.StatusText(code)
+	if len(message) > 0 && message[0] != "" {
+		msg = message[0]
+	}
+	return &HTTPErr{Code: code, Message: msg}
 }
 
 // Fail returns an error that, when returned from a form action, makes the

--- a/packages/sveltego/exports/kit/sentinels_test.go
+++ b/packages/sveltego/exports/kit/sentinels_test.go
@@ -35,7 +35,7 @@ func TestRedirect_Helper(t *testing.T) {
 	}
 }
 
-func TestError_Helper(t *testing.T) {
+func TestError_WithMessage(t *testing.T) {
 	t.Parallel()
 
 	err := kit.Error(404, "post not found")
@@ -58,6 +58,45 @@ func TestError_Helper(t *testing.T) {
 	}
 	if herr.Error() != "post not found" {
 		t.Errorf("Error() = %q, want post not found", herr.Error())
+	}
+}
+
+func TestError_DefaultMessage(t *testing.T) {
+	t.Parallel()
+
+	err := kit.Error(404)
+	if err == nil {
+		t.Fatal("Error returned nil")
+	}
+
+	var herr *kit.HTTPErr
+	if !errors.As(err, &herr) {
+		t.Fatalf("errors.As(*HTTPErr) failed: %v", err)
+	}
+	if herr.Code != 404 {
+		t.Errorf("Code = %d, want 404", herr.Code)
+	}
+	if herr.Message != "Not Found" {
+		t.Errorf("Message = %q, want \"Not Found\"", herr.Message)
+	}
+	if herr.HTTPStatus() != 404 {
+		t.Errorf("HTTPStatus = %d, want 404", herr.HTTPStatus())
+	}
+	if herr.Error() != "Not Found" {
+		t.Errorf("Error() = %q, want \"Not Found\"", herr.Error())
+	}
+}
+
+func TestError_DefaultMessage_500(t *testing.T) {
+	t.Parallel()
+
+	err := kit.Error(500)
+	var herr *kit.HTTPErr
+	if !errors.As(err, &herr) {
+		t.Fatalf("errors.As(*HTTPErr) failed: %v", err)
+	}
+	if herr.Message != "Internal Server Error" {
+		t.Errorf("Message = %q, want \"Internal Server Error\"", herr.Message)
 	}
 }
 


### PR DESCRIPTION
Closes #176

## Why

`kit.Error(404)` previously set `Message = ""`, causing blank error pages in `+error.svelte`. Mined from sveltejs/kit#13917.

## What changed

- `Error(code int, message ...string)` — message is now variadic
- When omitted (or empty string passed), `Message` defaults to `http.StatusText(code)`
- Existing callers passing an explicit message see no change

## Tests

- `TestError_WithMessage` — explicit message still wins (`"post not found"`)
- `TestError_DefaultMessage` — `kit.Error(404).Message == "Not Found"`
- `TestError_DefaultMessage_500` — `kit.Error(500).Message == "Internal Server Error"`