### PR TITLE
fix(server): register MIME types for .ico, .wasm, .woff2

### DIFF
--- a/packages/sveltego/server/static.go
+++ b/packages/sveltego/server/static.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"mime"
 	"net/http"
 	"os"
 	"path"
@@ -105,15 +106,14 @@ func (h *staticHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	enc, encName, servePath, info := h.negotiate(r, rawPath, rawInfo)
 
 	setCacheHeaders(w, r.URL.Path, h.immutablePrefix, h.maxAgeSeconds)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	if encName != "" {
 		w.Header().Set("Content-Encoding", encName)
 		w.Header().Add("Vary", "Accept-Encoding")
 	} else if h.brotli || h.gzip {
 		w.Header().Add("Vary", "Accept-Encoding")
 	}
-	if ct := contentTypeFor(rawPath); ct != "" {
-		w.Header().Set("Content-Type", ct)
-	}
+	w.Header().Set("Content-Type", contentTypeFor(rawPath))
 	if h.etag {
 		w.Header().Set("ETag", buildETag(info, enc))
 	}
@@ -238,6 +238,12 @@ func buildETag(info os.FileInfo, enc string) string {
 // which mis-identifies precompressed siblings; deriving from the raw
 // extension keeps text/css and application/javascript stable across
 // encoded responses.
+//
+// The explicit map overrides OS MIME databases for extensions that are
+// mishandled on some platforms (e.g. .ico on Windows, .wasm and .woff2
+// absent from many default mime.types). Falls back to
+// mime.TypeByExtension, then application/octet-stream as last resort so
+// X-Content-Type-Options: nosniff is always effective.
 func contentTypeFor(rawPath string) string {
 	ext := strings.ToLower(filepath.Ext(rawPath))
 	switch ext {
@@ -257,8 +263,19 @@ func contentTypeFor(rawPath string) string {
 		return "application/xml; charset=utf-8"
 	case ".wasm":
 		return "application/wasm"
+	case ".woff":
+		return "font/woff"
+	case ".woff2":
+		return "font/woff2"
+	case ".ico":
+		return "image/x-icon"
+	case ".webmanifest":
+		return "application/manifest+json"
 	}
-	return ""
+	if ct := mime.TypeByExtension(ext); ct != "" {
+		return ct
+	}
+	return "application/octet-stream"
 }
 
 // errStaticHandler returns an http.Handler that serves a 500 with err's

--- a/packages/sveltego/server/static_test.go
+++ b/packages/sveltego/server/static_test.go
@@ -1,6 +1,14 @@
 package server
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+)
 
 func TestSafeRelPath(t *testing.T) {
 	t.Parallel()
@@ -74,16 +82,84 @@ func TestAcceptsEncoding(t *testing.T) {
 func TestContentTypeFor(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]string{
-		"app.js":      "application/javascript; charset=utf-8",
-		"styles.css":  "text/css; charset=utf-8",
-		"icon.svg":    "image/svg+xml",
-		"data.json":   "application/json; charset=utf-8",
-		"unknown.xyz": "",
+	cases := []struct {
+		file string
+		want string
+	}{
+		{"app.js", "application/javascript; charset=utf-8"},
+		{"chunk.mjs", "application/javascript; charset=utf-8"},
+		{"styles.css", "text/css; charset=utf-8"},
+		{"index.html", "text/html; charset=utf-8"},
+		{"index.htm", "text/html; charset=utf-8"},
+		{"data.json", "application/json; charset=utf-8"},
+		{"icon.svg", "image/svg+xml"},
+		{"readme.txt", "text/plain; charset=utf-8"},
+		{"feed.xml", "application/xml; charset=utf-8"},
+		{"module.wasm", "application/wasm"},
+		{"font.woff", "font/woff"},
+		{"font.woff2", "font/woff2"},
+		{"favicon.ico", "image/x-icon"},
+		{"app.webmanifest", "application/manifest+json"},
+		// unknown extension falls back to mime.TypeByExtension, then octet-stream.
+		{"unknown.sveltegounknown", "application/octet-stream"},
 	}
-	for in, want := range cases {
-		if got := contentTypeFor(in); got != want {
-			t.Errorf("contentTypeFor(%q) = %q, want %q", in, got, want)
-		}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.file, func(t *testing.T) {
+			t.Parallel()
+			if got := contentTypeFor(tc.file); got != tc.want {
+				t.Errorf("contentTypeFor(%q) = %q, want %q", tc.file, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStaticHandlerNosniff(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mustWriteStatic(t, dir, "favicon.ico", []byte{0x00, 0x00, 0x01, 0x00})
+	mustWriteStatic(t, dir, "module.wasm", []byte{0x00, 0x61, 0x73, 0x6d})
+	mustWriteStatic(t, dir, "font.woff2", []byte("wOF2"))
+	mustWriteStatic(t, dir, "app.webmanifest", []byte(`{"name":"test"}`))
+
+	ts := httptest.NewServer(StaticHandler(kit.StaticConfig{Dir: dir}))
+	t.Cleanup(ts.Close)
+
+	cases := []struct {
+		path   string
+		wantCT string
+	}{
+		{"/favicon.ico", "image/x-icon"},
+		{"/module.wasm", "application/wasm"},
+		{"/font.woff2", "font/woff2"},
+		{"/app.webmanifest", "application/manifest+json"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			resp, err := http.Get(ts.URL + tc.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tc.path, err)
+			}
+			resp.Body.Close()
+
+			if got := resp.Header.Get("Content-Type"); got != tc.wantCT {
+				t.Errorf("Content-Type = %q, want %q", got, tc.wantCT)
+			}
+			if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+				t.Errorf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+			}
+		})
+	}
+}
+
+func mustWriteStatic(t *testing.T, dir, name string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
 	}
 }


### PR DESCRIPTION
Closes #190

## Why

`contentTypeFor` had no entries for `.ico`, `.woff`, `.woff2`, or `.webmanifest`, and returned empty string for unknown extensions — letting `http.ServeContent` fall back to sniffing bytes. On some platforms `.ico` is misreported; `.wasm` and `.woff2` are absent from many default `mime.types` databases. Mined from sveltejs/kit#13753.

## What changed (`packages/sveltego/server/static.go` only)

- Added `.woff`, `.woff2`, `.ico`, `.webmanifest` to the explicit switch in `contentTypeFor`.
- Added fallback: `mime.TypeByExtension` → `application/octet-stream` (never returns empty now).
- Set `X-Content-Type-Options: nosniff` unconditionally in `ServeHTTP`.

## Tests (`packages/sveltego/server/static_test.go` only)

- `TestContentTypeFor` converted to named subtests; covers all 14 whitelisted extensions plus the octet-stream fallback.
- `TestStaticHandlerNosniff` — HTTP-level table test: serves `.ico`, `.wasm`, `.woff2`, `.webmanifest` files and asserts both `Content-Type` and `X-Content-Type-Options`.

154 tests pass, `go vet` and `gofumpt`/`goimports` clean.