### PR TITLE
feat(kit): RedirectReload for force-reload redirects

### DIFF
--- a/packages/sveltego/exports/kit/sentinels.go
+++ b/packages/sveltego/exports/kit/sentinels.go
@@ -2,11 +2,29 @@ package kit
 
 import "strconv"
 
+// RedirectOption configures a RedirectErr. Apply options via the variadic
+// argument to Redirect; the zero set leaves all flags at their default.
+type RedirectOption func(*RedirectErr)
+
+// RedirectReload returns an option that marks the redirect as requiring a
+// full document reload. The pipeline sets X-Sveltego-Reload: 1 on the
+// response so the client router performs location.assign() instead of an
+// in-place SPA navigation. Use this for auth state changes, locale
+// switches, or any flow where the SPA shell may hold stale hydration data.
+//
+// Client-side honor of the header lands with the SPA router (#37).
+func RedirectReload() RedirectOption {
+	return func(r *RedirectErr) { r.ForceReload = true }
+}
+
 // RedirectErr signals a redirect short-circuit from Load. Code is the
 // HTTP status (303 for POST->GET, 307/308 to preserve method).
+// ForceReload, when true, instructs the client router to perform a full
+// document fetch rather than an SPA navigation.
 type RedirectErr struct {
-	Code     int
-	Location string
+	Code        int
+	Location    string
+	ForceReload bool
 }
 
 // Error implements error.
@@ -48,13 +66,18 @@ func (f *FailErr) HTTPStatus() int { return f.Code }
 
 // Redirect returns an error that, when returned from Load, makes the
 // pipeline emit an HTTP redirect with the given status and Location.
+// Pass kit.RedirectReload() to force a full document reload on the client.
 //
 // Idiomatic Go: use an error return rather than panic. Callers write
 // `return data, kit.Redirect(303, "/login")`. SvelteKit's `throw redirect`
 // is JS-flavored; Go uses explicit error returns to keep stack traces
 // honest and avoid panic-as-control-flow.
-func Redirect(code int, location string) error {
-	return &RedirectErr{Code: code, Location: location}
+func Redirect(code int, location string, opts ...RedirectOption) error {
+	r := &RedirectErr{Code: code, Location: location}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
 }
 
 // Error returns an error that, when returned from Load, makes the

--- a/packages/sveltego/exports/kit/sentinels_test.go
+++ b/packages/sveltego/exports/kit/sentinels_test.go
@@ -113,3 +113,37 @@ func TestSentinels_DistinctTypes(t *testing.T) {
 		t.Error("Fail must match only *FailErr")
 	}
 }
+
+func TestRedirectReload_SetsForceReload(t *testing.T) {
+	t.Parallel()
+
+	err := kit.Redirect(303, "/login", kit.RedirectReload())
+
+	var redir *kit.RedirectErr
+	if !errors.As(err, &redir) {
+		t.Fatalf("errors.As(*RedirectErr) failed")
+	}
+	if !redir.ForceReload {
+		t.Error("ForceReload = false, want true")
+	}
+	if redir.Code != 303 {
+		t.Errorf("Code = %d, want 303", redir.Code)
+	}
+	if redir.Location != "/login" {
+		t.Errorf("Location = %q, want /login", redir.Location)
+	}
+}
+
+func TestRedirect_WithoutReload_ForceReloadFalse(t *testing.T) {
+	t.Parallel()
+
+	err := kit.Redirect(303, "/login")
+
+	var redir *kit.RedirectErr
+	if !errors.As(err, &redir) {
+		t.Fatalf("errors.As(*RedirectErr) failed")
+	}
+	if redir.ForceReload {
+		t.Error("ForceReload = true, want false for plain Redirect")
+	}
+}

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -54,6 +54,9 @@ func (s *Server) handlePipelineError(w http.ResponseWriter, r *http.Request, ev 
 		if ev != nil && ev.Cookies != nil {
 			ev.Cookies.Apply(w)
 		}
+		if redir.ForceReload {
+			w.Header().Set("X-Sveltego-Reload", "1")
+		}
 		http.Redirect(w, r, redir.Location, redir.Code)
 		return
 	}

--- a/packages/sveltego/server/sentinels_integration_test.go
+++ b/packages/sveltego/server/sentinels_integration_test.go
@@ -156,3 +156,82 @@ func TestPipeline_LoadReturnsRedirect_307PreservesMethod(t *testing.T) {
 		t.Errorf("Location = %q, want /elsewhere", got)
 	}
 }
+
+func TestPipeline_RedirectReload_SetsReloadHeader(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, kit.Redirect(303, "/login", kit.RedirectReload())
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("should not render")
+			return nil
+		},
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != 303 {
+		t.Errorf("status = %d, want 303", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); got != "/login" {
+		t.Errorf("Location = %q, want /login", got)
+	}
+	if got := resp.Header.Get("X-Sveltego-Reload"); got != "1" {
+		t.Errorf("X-Sveltego-Reload = %q, want 1", got)
+	}
+}
+
+func TestPipeline_PlainRedirect_NoReloadHeader(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, kit.Redirect(303, "/login")
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("should not render")
+			return nil
+		},
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != 303 {
+		t.Errorf("status = %d, want 303", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Sveltego-Reload"); got != "" {
+		t.Errorf("X-Sveltego-Reload = %q, want empty for plain Redirect", got)
+	}
+}


### PR DESCRIPTION
Closes #180

## Summary

- Adds `kit.RedirectReload()` as a variadic option to `kit.Redirect()`, matching the API from sveltejs/kit#12626: `kit.Redirect(303, "/login", kit.RedirectReload())`
- Adds `ForceReload bool` field to `RedirectErr`
- Pipeline (`server/errors.go`) sets `X-Sveltego-Reload: 1` header when `ForceReload` is true, alongside the normal `Location` header
- Plain `kit.Redirect()` without the option is unchanged and emits no reload header

## Design rationale

Variadic option pattern keeps the existing `Redirect(code, location)` call sites untouched (backward-compatible). `RedirectReload()` returns a `func(*RedirectErr)` — the smallest possible blast radius, no new type hierarchy.

## Follow-up

Client runtime support — the SPA router (#37) must check `X-Sveltego-Reload: 1` and perform `location.assign()` instead of in-place navigation. File a separate issue when #37 lands.

## Test plan

- [x] `TestRedirectReload_SetsForceReload` — kit package unit test
- [x] `TestRedirect_WithoutReload_ForceReloadFalse` — kit package unit test  
- [x] `TestPipeline_RedirectReload_SetsReloadHeader` — integration test: server returns `X-Sveltego-Reload: 1` for `RedirectReload()` redirect
- [x] `TestPipeline_PlainRedirect_NoReloadHeader` — integration test: plain `Redirect` does NOT set the header
- [x] `go test -race ./packages/sveltego/...` — 266 tests pass
- [x] `go build ./packages/sveltego/...` — clean build
- [x] `gofumpt -l` — no formatting issues
- [x] `go vet ./...` — no issues