### PR TITLE
feat(codegen): emit typed RouteID constants per route

### DIFF
--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -272,6 +272,12 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	b.Line(")")
 	b.Line("")
 
+	// Emit one RouteID<Slug> constant per linkable route so user code can
+	// reference routes without magic strings.
+	if err := emitRouteIDConsts(&b, entries); err != nil {
+		return nil, err
+	}
+
 	// Per-route Render adapters: widen Page{}.Render's typed PageData
 	// parameter to the `any`-shaped router.PageHandler. Type assertion
 	// happens inside the adapter so a dispatcher mismatch fails fast
@@ -329,6 +335,44 @@ func packageAlias(packagePath string) string {
 	}
 	parts := strings.Split(rel, "/")
 	return "page_" + strings.Join(parts, "_")
+}
+
+// emitRouteIDConsts writes one `RouteID<Slug>` string constant per
+// linkable route (HasPage or HasServer), sorted by pattern. The constant
+// value is the SvelteKit-style canonical pattern ("/posts/[slug]") so
+// user code can pass it directly to kit.Link without a magic string.
+// Collision detection returns an error when two routes produce the same
+// Go identifier; the build gate catches this at codegen time rather than
+// silently shadowing a constant.
+func emitRouteIDConsts(b *Builder, entries []entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	// Detect identifier collisions before emitting anything.
+	seen := make(map[string]string, len(entries))
+	for _, e := range entries {
+		ident := "RouteID" + routeIdent(e.route.Segments)
+		if prev, ok := seen[ident]; ok {
+			return fmt.Errorf(
+				"codegen: RouteID collision: %q and %q both map to %s",
+				prev, e.route.Pattern, ident,
+			)
+		}
+		seen[ident] = e.route.Pattern
+	}
+
+	b.Line("// Route ID constants for type-safe linking. Pass to kit.Link instead of a")
+	b.Line("// raw string so route renames surface as compile errors.")
+	b.Line("const (")
+	b.Indent()
+	for _, e := range entries {
+		ident := "RouteID" + routeIdent(e.route.Segments)
+		b.Linef("%s = %s", ident, quoteGo(e.route.Pattern))
+	}
+	b.Dedent()
+	b.Line(")")
+	b.Line("")
+	return nil
 }
 
 // emitRenderAdapters writes one `render__<alias>` function per Page

--- a/packages/sveltego/internal/codegen/manifest_test.go
+++ b/packages/sveltego/internal/codegen/manifest_test.go
@@ -189,6 +189,54 @@ func TestGenerateManifest_LayoutHead(t *testing.T) {
 	}
 }
 
+// TestGenerateManifest_RouteIDConsts verifies that the manifest contains the
+// expected RouteID constants for the nested fixture.
+func TestGenerateManifest_RouteIDConsts(t *testing.T) {
+	t.Parallel()
+	scan := scanFixture(t, "nested")
+	out, err := GenerateManifest(scan, ManifestOptions{
+		PackageName: "gen",
+		ModulePath:  "myapp",
+		GenRoot:     ".gen",
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifest: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		"RouteIDIndex",
+		"RouteIDAbout",
+		"RouteIDPostsSlug",
+		`RouteIDIndex     = ` + "`/`",
+		`RouteIDAbout     = ` + "`/about`",
+		`RouteIDPostsSlug = ` + "`/posts/[slug]`",
+	} {
+		if !bytes.Contains(out, []byte(want)) {
+			t.Errorf("missing %q in:\n%s", want, s)
+		}
+	}
+}
+
+// TestRouteIDCollision verifies that emitRouteIDConsts errors when two entries
+// produce the same Go identifier. Two routes with nil Segments both lower to
+// "Index" via routeIdent, triggering the collision guard.
+func TestRouteIDCollision(t *testing.T) {
+	t.Parallel()
+	// Both entries have nil Segments → routeIdent returns "Index" for both.
+	entries := []entry{
+		{route: routescan.ScannedRoute{Pattern: "/", HasPage: true}, alias: "a"},
+		{route: routescan.ScannedRoute{Pattern: "/mirror", HasPage: true}, alias: "b"},
+	}
+	var b Builder
+	err := emitRouteIDConsts(&b, entries)
+	if err == nil {
+		t.Fatal("expected collision error, got nil")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("RouteID collision")) {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
 func scanFixture(t *testing.T, name string) *routescan.ScanResult {
 	t.Helper()
 	abs, err := filepath.Abs(filepath.Join("..", "routescan", "testdata", name))

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/error-chain.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/error-chain.golden
@@ -13,6 +13,14 @@ import (
 	page_routes_admin_users "myapp/.gen/routes/admin/users"
 )
 
+// Route ID constants for type-safe linking. Pass to kit.Link instead of a
+// raw string so route renames surface as compile errors.
+const (
+	RouteIDIndex      = `/`
+	RouteIDAdmin      = `/admin`
+	RouteIDAdminUsers = `/admin/users`
+)
+
 // render__page_routes adapts page_routes.Page{}.Render to router.PageHandler.
 func render__page_routes(w *render.Writer, ctx *kit.RenderCtx, data any) error {
 	var typed page_routes.PageData

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/groups.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/groups.golden
@@ -11,6 +11,12 @@ import (
 	page_routes__g_marketing_about "myapp/.gen/routes/_g_marketing/about"
 )
 
+// Route ID constants for type-safe linking. Pass to kit.Link instead of a
+// raw string so route renames surface as compile errors.
+const (
+	RouteIDAbout = `/about`
+)
+
 // render__page_routes__g_marketing_about adapts page_routes__g_marketing_about.Page{}.Render to router.PageHandler.
 func render__page_routes__g_marketing_about(w *render.Writer, ctx *kit.RenderCtx, data any) error {
 	var typed page_routes__g_marketing_about.PageData

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/layout-chain.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/layout-chain.golden
@@ -14,6 +14,12 @@ import (
 	page_routes_dash_team_billing "myapp/.gen/routes/dash/team/billing"
 )
 
+// Route ID constants for type-safe linking. Pass to kit.Link instead of a
+// raw string so route renames surface as compile errors.
+const (
+	RouteIDDashTeamBilling = `/dash/team/billing`
+)
+
 // render__page_routes_dash_team_billing adapts page_routes_dash_team_billing.Page{}.Render to router.PageHandler.
 func render__page_routes_dash_team_billing(w *render.Writer, ctx *kit.RenderCtx, data any) error {
 	var typed page_routes_dash_team_billing.PageData

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/nested.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/nested.golden
@@ -13,6 +13,14 @@ import (
 	page_routes_posts__slug_ "myapp/.gen/routes/posts/_slug_"
 )
 
+// Route ID constants for type-safe linking. Pass to kit.Link instead of a
+// raw string so route renames surface as compile errors.
+const (
+	RouteIDIndex     = `/`
+	RouteIDAbout     = `/about`
+	RouteIDPostsSlug = `/posts/[slug]`
+)
+
 // render__page_routes adapts page_routes.Page{}.Render to router.PageHandler.
 func render__page_routes(w *render.Writer, ctx *kit.RenderCtx, data any) error {
 	var typed page_routes.PageData

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/optional.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/optional.golden
@@ -11,6 +11,12 @@ import (
 	page_routes___lang___about "myapp/.gen/routes/__lang__/about"
 )
 
+// Route ID constants for type-safe linking. Pass to kit.Link instead of a
+// raw string so route renames surface as compile errors.
+const (
+	RouteIDLangAbout = `/[[lang]]/about`
+)
+
 // render__page_routes___lang___about adapts page_routes___lang___about.Page{}.Render to router.PageHandler.
 func render__page_routes___lang___about(w *render.Writer, ctx *kit.RenderCtx, data any) error {
 	var typed page_routes___lang___about.PageData

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
@@ -12,6 +12,13 @@ import (
 	page_routes_dash_billing "myapp/.gen/routes/dash/billing"
 )
 
+// Route ID constants for type-safe linking. Pass to kit.Link instead of a
+// raw string so route renames surface as compile errors.
+const (
+	RouteIDIndex       = `/`
+	RouteIDDashBilling = `/dash/billing`
+)
+
 // render__page_routes adapts page_routes.Page{}.Render to router.PageHandler.
 func render__page_routes(w *render.Writer, ctx *kit.RenderCtx, data any) error {
 	var typed page_routes.PageData

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/rest.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/rest.golden
@@ -11,6 +11,12 @@ import (
 	page_routes_docs____path "myapp/.gen/routes/docs/___path"
 )
 
+// Route ID constants for type-safe linking. Pass to kit.Link instead of a
+// raw string so route renames surface as compile errors.
+const (
+	RouteIDDocsPath = `/docs/[...path]`
+)
+
 // render__page_routes_docs____path adapts page_routes_docs____path.Page{}.Render to router.PageHandler.
 func render__page_routes_docs____path(w *render.Writer, ctx *kit.RenderCtx, data any) error {
 	var typed page_routes_docs____path.PageData

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/simple.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/simple.golden
@@ -11,6 +11,12 @@ import (
 	page_routes "myapp/.gen/routes"
 )
 
+// Route ID constants for type-safe linking. Pass to kit.Link instead of a
+// raw string so route renames surface as compile errors.
+const (
+	RouteIDIndex = `/`
+)
+
 // render__page_routes adapts page_routes.Page{}.Render to router.PageHandler.
 func render__page_routes(w *render.Writer, ctx *kit.RenderCtx, data any) error {
 	var typed page_routes.PageData


### PR DESCRIPTION
Closes #189

## Why

Removes magic strings from route references. Instead of `kit.Link("/dash/team/billing", params)`, user code can now write `kit.Link(gen.RouteIDDashTeamBilling, params)`. Route renames surface as compile errors rather than silent 404s at runtime.

Motivated by sveltejs/kit#13253.

## What

- `emitRouteIDConsts` added to `manifest.go` — emits one `RouteID<Slug>` string constant per linkable route in the manifest `const (...)` block.
- Slugs derived from the existing `routeIdent` helper (PascalCase from segments): root → `RouteIDIndex`, `/about` → `RouteIDAbout`, `/dash/team/billing` → `RouteIDDashTeamBilling`, `/docs/[...path]` → `RouteIDDocsPath`.
- Collision detection: `emitRouteIDConsts` returns an error when two routes produce the same identifier, surfaced as a codegen build failure.
- Constants sorted in scanner (route table) order; output passes through `go/format` for determinism.
- All 8 manifest golden files updated (`GOLDEN_UPDATE=1`).
- Two new tests: `TestGenerateManifest_RouteIDConsts` (golden content) and `TestRouteIDCollision` (collision guard).

No other packages touched. `kit.Link` signature unchanged — constants are plain `string`s, so existing callers work without modification.

## Golden files updated

- `testdata/golden/manifest/simple.golden`
- `testdata/golden/manifest/nested.golden`
- `testdata/golden/manifest/groups.golden`
- `testdata/golden/manifest/optional.golden`
- `testdata/golden/manifest/rest.golden`
- `testdata/golden/manifest/layout-chain.golden`
- `testdata/golden/manifest/error-chain.golden`
- `testdata/golden/manifest/page-options.golden`

## Gates

- `gofumpt -l .` — clean
- `goimports -l -local github.com/binsarjr/sveltego .` — clean
- `go vet ./...` — clean
- `go test -race ./packages/sveltego/internal/codegen/...` — 364 passed
- `go build ./...` — success