### PR TITLE
feat(kit): HTTPError interface for typed status mapping

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -19,7 +19,7 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 `sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
-Hard invariants (do not reopen without new evidence — see `tasks/lessons.md` "Pivot to Go-native rewrite"):
+Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
 
 - **No JS runtime on the server.** `.svelte` compiles to Go source via codegen (`.gen/*.go`) for SSR. Vite produces the client bundle for hydration only.
 - **Mustache expressions are Go, not JS.** `{Data.User.Name}`, `{len(Data.Posts)}`, `nil` not `null`. PascalCase fields. Validated at codegen via `go/parser.ParseExpr`.
@@ -119,11 +119,12 @@ A task is **not done** when bytes hit disk. It is done when proven correct.
 
 ### 3.6 Mistake logging
 
-- After **any user correction**, append a dated section to `tasks/lessons.md`:
-  - Date heading.
+- After **any user correction**, create a new file `tasks/lessons/YYYY-MM-DD-<topic>.md` with:
+  - `## YYYY-MM-DD — <topic>` heading.
   - "Insight" — what was wrong, with the underlying pattern named.
   - "Self-rules" — numbered, future-tense, prevent the category.
-- Never rewrite older entries. Append-only journal.
+- Add a bullet to the top of `tasks/lessons.md` index pointing at the new file.
+- Never rewrite or delete existing lesson files. Append-only journal.
 - After fixing a bug, write an autopsy: why did it happen? What category is it? Add a self-rule.
 
 ### 3.7 No over-engineering

--- a/packages/sveltego/exports/kit/sentinels.go
+++ b/packages/sveltego/exports/kit/sentinels.go
@@ -100,3 +100,27 @@ func Error(code int, message ...string) error {
 func Fail(code int, data any) error {
 	return &FailErr{Code: code, Data: data}
 }
+
+// HTTPError is implemented by user-defined error types that want to carry
+// their own HTTP status code and a safe public message into the pipeline.
+// When the pipeline encounters an error satisfying this interface (via
+// errors.As), it converts it to a kit.Error automatically — so handlers
+// can return rich domain errors directly without manual rewrapping.
+//
+// Example:
+//
+//	type NotFoundError struct{ ID string }
+//
+//	func (e *NotFoundError) Error() string  { return "not found: " + e.ID }
+//	func (e *NotFoundError) Status() int    { return http.StatusNotFound }
+//	func (e *NotFoundError) Public() string { return "The requested item does not exist." }
+//
+//	// In Load:
+//	return nil, &NotFoundError{ID: id}  // pipeline renders +error.svelte with 404
+type HTTPError interface {
+	error
+	// Status returns the HTTP status code for this error (e.g. 404, 409).
+	Status() int
+	// Public returns a message safe to expose to end users.
+	Public() string
+}

--- a/packages/sveltego/exports/kit/sentinels_test.go
+++ b/packages/sveltego/exports/kit/sentinels_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/binsarjr/sveltego/exports/kit"
 )
 
+// wrapErr is a minimal error wrapper used by tests to avoid the fmt import.
+type wrapErr struct {
+	msg string
+	err error
+}
+
+func (w *wrapErr) Error() string { return w.msg + ": " + w.err.Error() }
+func (w *wrapErr) Unwrap() error { return w.err }
+
 func TestRedirect_Helper(t *testing.T) {
 	t.Parallel()
 
@@ -184,5 +193,50 @@ func TestRedirect_WithoutReload_ForceReloadFalse(t *testing.T) {
 	}
 	if redir.ForceReload {
 		t.Error("ForceReload = true, want false for plain Redirect")
+	}
+}
+
+// userNotFoundError is a domain error type that implements kit.HTTPError.
+type userNotFoundError struct {
+	ID string
+}
+
+func (e *userNotFoundError) Error() string  { return "not found: " + e.ID }
+func (e *userNotFoundError) Status() int    { return 404 }
+func (e *userNotFoundError) Public() string { return "The requested item does not exist." }
+
+func TestHTTPError_InterfaceSatisfied(t *testing.T) {
+	t.Parallel()
+
+	var _ kit.HTTPError = (*userNotFoundError)(nil)
+
+	err := &userNotFoundError{ID: "abc"}
+	var he kit.HTTPError
+	if !errors.As(err, &he) {
+		t.Fatal("errors.As(kit.HTTPError) failed")
+	}
+	if he.Status() != 404 {
+		t.Errorf("Status = %d, want 404", he.Status())
+	}
+	if he.Public() != "The requested item does not exist." {
+		t.Errorf("Public = %q, unexpected", he.Public())
+	}
+	if he.Error() != "not found: abc" {
+		t.Errorf("Error() = %q, want 'not found: abc'", he.Error())
+	}
+}
+
+func TestHTTPError_WrappedErrorDetected(t *testing.T) {
+	t.Parallel()
+
+	inner := &userNotFoundError{ID: "xyz"}
+	wrapped := &wrapErr{msg: "load failed", err: inner}
+
+	var he kit.HTTPError
+	if !errors.As(wrapped, &he) {
+		t.Fatal("errors.As through wrapping failed")
+	}
+	if he.Status() != 404 {
+		t.Errorf("Status = %d, want 404 through wrapping", he.Status())
 	}
 }

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -92,6 +92,16 @@ func (s *Server) handlePipelineError(w http.ResponseWriter, r *http.Request, ev 
 		return
 	}
 
+	// User-defined types implementing kit.HTTPError carry their own status
+	// and safe public message. Convert them before falling through to
+	// HandleError so the error boundary sees the right code.
+	var httpErr kit.HTTPError
+	if errors.As(err, &httpErr) {
+		safe := kit.SafeError{Code: httpErr.Status(), Message: httpErr.Public()}
+		s.respondWithError(w, r, ev, route, safe, err)
+		return
+	}
+
 	safe := s.hooks.HandleError(ev, err)
 
 	// Preserve the legacy httpStatuser observation: when the user did

--- a/packages/sveltego/server/sentinels_integration_test.go
+++ b/packages/sveltego/server/sentinels_integration_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +13,12 @@ import (
 	"github.com/binsarjr/sveltego/render"
 	"github.com/binsarjr/sveltego/runtime/router"
 )
+
+type notFoundErr struct{ Resource string }
+
+func (e *notFoundErr) Error() string  { return "not found: " + e.Resource }
+func (e *notFoundErr) Status() int    { return http.StatusNotFound }
+func (e *notFoundErr) Public() string { return e.Resource + " does not exist" }
 
 func TestPipeline_LoadReturnsRedirect_303WithLocation(t *testing.T) {
 	t.Parallel()
@@ -233,5 +241,143 @@ func TestPipeline_PlainRedirect_NoReloadHeader(t *testing.T) {
 	}
 	if got := resp.Header.Get("X-Sveltego-Reload"); got != "" {
 		t.Errorf("X-Sveltego-Reload = %q, want empty for plain Redirect", got)
+	}
+}
+
+func TestPipeline_UserHTTPError_RendersStatus(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, &notFoundErr{Resource: "post"}
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("<p>should not render</p>")
+			return nil
+		},
+		Error: errorBoundary("user-http-error"),
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+	if strings.Contains(s, "should not render") {
+		t.Errorf("page content leaked into error response: %s", s)
+	}
+	if !strings.Contains(s, "code=404") {
+		t.Errorf("error boundary missing code=404: %s", s)
+	}
+	if !strings.Contains(s, "post does not exist") {
+		t.Errorf("error boundary missing public message: %s", s)
+	}
+}
+
+func TestPipeline_UserHTTPError_WrappedDetected(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, fmt.Errorf("load: %w", &notFoundErr{Resource: "article"})
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("nope")
+			return nil
+		},
+		Error: errorBoundary("wrapped"),
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 through wrapping", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "code=404") {
+		t.Errorf("error boundary missing code=404: %s", body)
+	}
+}
+
+func TestPipeline_PlainError_DefaultsTo500(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, errors.New("something internal")
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("nope")
+			return nil
+		},
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 for plain errors", resp.StatusCode)
+	}
+}
+
+func TestPipeline_ExistingKitError_Regression(t *testing.T) {
+	t.Parallel()
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, kit.Error(403, "forbidden")
+		},
+		Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+			w.WriteString("nope")
+			return nil
+		},
+	}}
+	srv := newTestServer(t, routes)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (kit.Error regression)", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "forbidden") {
+		t.Errorf("body missing message: %s", body)
 	}
 }


### PR DESCRIPTION
Closes #175

## Summary

- Adds `kit.HTTPError` interface (`Status() int`, `Public() string`, `error`) to `packages/sveltego/exports/kit/sentinels.go`
- Pipeline (`server/errors.go`) detects user errors satisfying the interface via `errors.As` and converts them to a `kit.SafeError`, routing through `respondWithError` (error boundary) with the correct status and safe public message
- Explicit kit sentinels (redirect, `kit.Error`, `kit.Fail`) still take priority — `kit.HTTPError` only fires after those checks

## Why

From sveltejs/kit#14442: user code should be able to raise typed domain errors (e.g. `NotFoundError`, `ConflictError`) and have the pipeline map them to the right HTTP status without manual `kit.Error(404, …)` rewrapping in every handler.

## Test coverage

- `sentinels_test.go`: compile-time interface satisfaction + `errors.As` through wrapping
- `sentinels_integration_test.go`: 404 via user `HTTPError`, wrapped detection, plain errors default to 500, `kit.Error` regression (403 still works)