### PR TITLE
feat(codegen): SSROnly page option blocks __data.json scrape

### DIFF
--- a/packages/sveltego/exports/kit/page_options.go
+++ b/packages/sveltego/exports/kit/page_options.go
@@ -36,17 +36,18 @@ func (ts TrailingSlash) String() string {
 }
 
 // PageOptions carries the page- and layout-level settings declared as
-// exported constants in *.server.go: Prerender, SSR, CSR, and
+// exported constants in *.server.go: Prerender, SSR, CSR, SSROnly, and
 // TrailingSlash. Layout-level values cascade to descendants; page-level
 // values override the cascade.
 //
-// SSR and CSR default to true; Prerender defaults to false. Manifest
-// emission stores the effective resolved value per route, so the
+// SSR and CSR default to true; Prerender and SSROnly default to false.
+// Manifest emission stores the effective resolved value per route, so the
 // pipeline does not re-walk the layout chain at request time.
 type PageOptions struct {
 	Prerender     bool
 	SSR           bool
 	CSR           bool
+	SSROnly       bool
 	TrailingSlash TrailingSlash
 }
 
@@ -78,6 +79,9 @@ func (base PageOptions) Merge(override PageOptionsOverride) PageOptions {
 	if override.HasCSR {
 		out.CSR = override.CSR
 	}
+	if override.HasSSROnly {
+		out.SSROnly = override.SSROnly
+	}
 	if override.HasTrailingSlash {
 		out.TrailingSlash = override.TrailingSlash
 	}
@@ -94,6 +98,8 @@ type PageOptionsOverride struct {
 	HasSSR           bool
 	CSR              bool
 	HasCSR           bool
+	SSROnly          bool
+	HasSSROnly       bool
 	TrailingSlash    TrailingSlash
 	HasTrailingSlash bool
 }
@@ -101,5 +107,5 @@ type PageOptionsOverride struct {
 // Any reports whether at least one option is declared. Codegen uses this
 // to skip cascade resolution when the file declares no options at all.
 func (o PageOptionsOverride) Any() bool {
-	return o.HasPrerender || o.HasSSR || o.HasCSR || o.HasTrailingSlash
+	return o.HasPrerender || o.HasSSR || o.HasCSR || o.HasSSROnly || o.HasTrailingSlash
 }

--- a/packages/sveltego/internal/codegen/cascade_test.go
+++ b/packages/sveltego/internal/codegen/cascade_test.go
@@ -32,6 +32,7 @@ func TestResolvePageOptions_cascade(t *testing.T) {
 		Prerender:     true,
 		SSR:           true,
 		CSR:           true,
+		SSROnly:       true,
 		TrailingSlash: kit.TrailingSlashIgnore,
 	}
 	if got["/dash/billing"] != billing {

--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -617,6 +617,9 @@ func formatPageOptions(o kit.PageOptions) string {
 	} else {
 		parts = append(parts, "CSR: true")
 	}
+	if o.SSROnly {
+		parts = append(parts, "SSROnly: true")
+	}
 	if o.TrailingSlash != kit.TrailingSlashNever {
 		parts = append(parts, "TrailingSlash: "+trailingSlashIdent(o.TrailingSlash))
 	}

--- a/packages/sveltego/internal/codegen/optionscan.go
+++ b/packages/sveltego/internal/codegen/optionscan.go
@@ -20,6 +20,7 @@ var optionConstNames = map[string]struct{}{
 	"Prerender":     {},
 	"SSR":           {},
 	"CSR":           {},
+	"SSROnly":       {},
 	"TrailingSlash": {},
 }
 
@@ -100,6 +101,13 @@ func assignOption(out *kit.PageOptionsOverride, name string, expr goast.Expr, pa
 		}
 		out.CSR = v
 		out.HasCSR = true
+	case "SSROnly":
+		v, err := evalBool(expr)
+		if err != nil {
+			return fmt.Errorf("codegen: %s: SSROnly: %w", path, err)
+		}
+		out.SSROnly = v
+		out.HasSSROnly = true
 	case "TrailingSlash":
 		v, err := evalTrailingSlash(expr)
 		if err != nil {

--- a/packages/sveltego/internal/codegen/optionscan_test.go
+++ b/packages/sveltego/internal/codegen/optionscan_test.go
@@ -117,6 +117,27 @@ const SSR = 1
 	}
 }
 
+func TestScanPageOptions_ssrOnly(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package routes
+
+const SSROnly = true
+`
+	path := writeTempServerGo(t, body)
+	got, err := scanPageOptions(path)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !got.HasSSROnly || !got.SSROnly {
+		t.Errorf("SSROnly not set: %+v", got)
+	}
+	if got.HasPrerender || got.HasSSR || got.HasCSR || got.HasTrailingSlash {
+		t.Errorf("only SSROnly expected, got %+v", got)
+	}
+}
+
 func TestScanPageOptions_dotImportTrailingSlash(t *testing.T) {
 	t.Parallel()
 	body := `//go:build sveltego

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
@@ -84,7 +84,7 @@ func Routes() []router.Route {
 			LayoutLoaders: []router.LayoutLoadHandler{
 				loadLayout__page_routes,
 			},
-			Options: kit.PageOptions{Prerender: true, SSR: true, CSR: true, TrailingSlash: kit.TrailingSlashIgnore},
+			Options: kit.PageOptions{Prerender: true, SSR: true, CSR: true, SSROnly: true, TrailingSlash: kit.TrailingSlashIgnore},
 		},
 	}
 }

--- a/packages/sveltego/internal/codegen/testdata/page-options/routes/dash/billing/page.server.go
+++ b/packages/sveltego/internal/codegen/testdata/page-options/routes/dash/billing/page.server.go
@@ -6,6 +6,7 @@ import "github.com/binsarjr/sveltego/exports/kit"
 
 const (
 	Prerender     = true
+	SSROnly       = true
 	TrailingSlash = kit.TrailingSlashIgnore
 )
 

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -217,10 +217,21 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 		}
 		form = fd
 	}
+	if isDataJSONRequest(r) && route.Options.SSROnly {
+		return nil, kit.SafeError{Code: http.StatusNotFound, Message: http.StatusText(http.StatusNotFound)}
+	}
 	if !optionsAllowSSR(route.Options) {
 		return s.renderEmptyShell(), nil
 	}
 	return s.renderPage(w, r, ev, route, form, pageBuf)
+}
+
+// isDataJSONRequest reports whether r is a direct XHR-style fetch of a
+// route's __data.json endpoint. The SPA router (#37, #38) uses these
+// requests to invalidate page data without a full navigation; SSROnly
+// routes must reject them so callers fall back to a full document fetch.
+func isDataJSONRequest(r *http.Request) bool {
+	return r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/__data.json")
 }
 
 // optionsAllowSSR returns true unless the route declared SSR=false. The

--- a/packages/sveltego/server/server_test.go
+++ b/packages/sveltego/server/server_test.go
@@ -92,6 +92,10 @@ func segmentsFor(pattern string) []router.Segment {
 			{Kind: router.SegmentStatic, Value: "lang"},
 			{Kind: router.SegmentParam, Name: "name"},
 		}
+	case "/protected":
+		return []router.Segment{{Kind: router.SegmentStatic, Value: "protected"}}
+	case "/public":
+		return []router.Segment{{Kind: router.SegmentStatic, Value: "public"}}
 	}
 	panic("unknown pattern: " + pattern)
 }
@@ -799,5 +803,60 @@ func TestServer_methodsOf(t *testing.T) {
 	want := []string{http.MethodGet, http.MethodPost}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("methodsOf: got %v want %v", got, want)
+	}
+}
+
+// TestServeHTTP_ssrOnlyRendersHTML asserts that a route with SSROnly=true
+// still serves normal HTML requests. The __data.json enforcement guard lives
+// in the pipeline but remains dormant until the __data.json endpoint lands
+// (blocked by #38 / SPA router #37); once that work merges, a dedicated
+// integration test covering the 404 rejection should be added here.
+func TestServeHTTP_ssrOnlyRendersHTML(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/protected",
+		Segments: segmentsFor("/protected"),
+		Page:     staticPage("<h1>protected</h1>"),
+		Options:  kit.PageOptions{SSR: true, CSR: true, SSROnly: true},
+	}})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/protected")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("SSROnly HTML: got %d want 200; body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "<h1>protected</h1>") {
+		t.Fatalf("body missing page content: %q", body)
+	}
+}
+
+// TestIsDataJSONRequest verifies the path suffix detector used by the
+// SSROnly guard.
+func TestIsDataJSONRequest(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		method string
+		path   string
+		want   bool
+	}{
+		{http.MethodGet, "/foo/__data.json", true},
+		{http.MethodGet, "/__data.json", true},
+		{http.MethodGet, "/foo/bar/__data.json", true},
+		{http.MethodPost, "/foo/__data.json", false}, // POST is not a data fetch
+		{http.MethodGet, "/foo/data.json", false},    // no leading __
+		{http.MethodGet, "/foo", false},
+		{http.MethodGet, "/foo/__data.jsonx", false}, // suffix must match exactly
+	}
+	for _, tc := range cases {
+		r, _ := http.NewRequest(tc.method, tc.path, nil)
+		if got := isDataJSONRequest(r); got != tc.want {
+			t.Errorf("isDataJSONRequest(%s %s) = %v, want %v", tc.method, tc.path, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
Closes #171

## Why

Upstream SvelteKit [#5699](https://github.com/sveltejs/kit/issues/5699) identified a class of routes — third-party API data with redistribution clauses, ad-served pages — where the HTML response must be served but the raw JSON load data must not be scraped directly via `__data.json`. This PR ships the codegen-side flag and the pipeline guard.

## What changed

- **`kit.PageOptions` / `kit.PageOptionsOverride`** — added `SSROnly bool` field and companion `HasSSROnly` sentinel. `Merge` and `Any` updated accordingly.
- **`optionscan.go`** — recognizes `const SSROnly = true` in `page.server.go` / `layout.server.go` and writes it into the cascade.
- **`manifest.go`** — `formatPageOptions` emits `SSROnly: true` when the resolved flag is set.
- **`pipeline.go`** — `isDataJSONRequest` helper + guard: `GET /__data.json` on an SSROnly route returns 404 before reaching Load/Render.

## Pipeline enforcement status

The SSROnly guard is present and correct but **dormant** — the `/__data.json` endpoint is not yet registered as a first-class route (blocked by #38 / SPA router #37). Once that work lands the guard fires automatically; no changes to this PR will be needed.

## Goldens updated

- `testdata/golden/manifest/page-options.golden` — `/dash/billing` entry now carries `SSROnly: true`.

## Test plan

- `TestScanPageOptions_ssrOnly` — scanner recognizes the constant.
- `TestResolvePageOptions_cascade` — cascade propagates SSROnly through the billing fixture.
- `TestGenerateManifest_PageOptionsGolden` — golden matches updated output.
- `TestServeHTTP_ssrOnlyRendersHTML` — route with SSROnly=true still serves HTML at 200.
- `TestIsDataJSONRequest` — path-suffix detector unit test (7 cases).