### PR TITLE
feat(codegen): strip src/lib/dev/ in release builds

### DIFF
--- a/packages/sveltego/cmd/sveltego/build.go
+++ b/packages/sveltego/cmd/sveltego/build.go
@@ -16,6 +16,7 @@ func newBuildCmd() *cobra.Command {
 	var (
 		outPath string
 		mainPkg string
+		release bool
 	)
 	cmd := &cobra.Command{
 		Use:   "build",
@@ -29,6 +30,7 @@ func newBuildCmd() *cobra.Command {
 			result, err := codegen.Build(codegen.BuildOptions{
 				ProjectRoot: root,
 				Verbose:     verbose,
+				Release:     release || os.Getenv("SVELTEGO_RELEASE") == "1",
 			})
 			if err != nil {
 				return err
@@ -67,6 +69,7 @@ func newBuildCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&outPath, "out", "build/app", "output binary path (relative to project root or absolute)")
 	cmd.Flags().StringVar(&mainPkg, "main", "./cmd/app", "main package import path or directory")
+	cmd.Flags().BoolVar(&release, "release", false, "production build: reject $lib/dev/** imports (also set by SVELTEGO_RELEASE=1)")
 	return cmd
 }
 

--- a/packages/sveltego/cmd/sveltego/compile.go
+++ b/packages/sveltego/cmd/sveltego/compile.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -9,6 +10,7 @@ import (
 )
 
 func newCompileCmd() *cobra.Command {
+	var release bool
 	cmd := &cobra.Command{
 		Use:   "compile",
 		Short: "Compile .svelte templates to Go source",
@@ -21,6 +23,7 @@ func newCompileCmd() *cobra.Command {
 			result, err := codegen.Build(codegen.BuildOptions{
 				ProjectRoot: root,
 				Verbose:     verbose,
+				Release:     release || os.Getenv("SVELTEGO_RELEASE") == "1",
 			})
 			if err != nil {
 				return err
@@ -35,5 +38,6 @@ func newCompileCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&release, "release", false, "production build: reject $lib/dev/** imports (also set by SVELTEGO_RELEASE=1)")
 	return cmd
 }

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -32,10 +32,14 @@ const genFileMode = 0o600
 // BuildOptions configures [Build]. ProjectRoot must be an absolute path
 // that contains a go.mod file and a src/routes/ directory; OutDir is the
 // gen-output root relative to ProjectRoot and defaults to ".gen".
+//
+// Release, when true, activates production-build restrictions: imports of
+// $lib/dev/** are rejected as fatal errors, mirroring sveltejs/kit#13078.
 type BuildOptions struct {
 	ProjectRoot string
 	OutDir      string
 	Verbose     bool
+	Release     bool
 	Logger      *slog.Logger
 }
 
@@ -128,7 +132,7 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 		}
 		switch {
 		case route.HasPage:
-			refs, hasHead, err := emitPage(opts.ProjectRoot, outDir, modulePath, route)
+			refs, hasHead, err := emitPage(opts.ProjectRoot, outDir, modulePath, route, opts.Release)
 			if err != nil {
 				return nil, err
 			}
@@ -158,7 +162,7 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 			if i < len(route.LayoutServerFiles) {
 				serverFile = route.LayoutServerFiles[i]
 			}
-			hasHead, err := emitLayout(opts.ProjectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile)
+			hasHead, err := emitLayout(opts.ProjectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile, opts.Release)
 			if err != nil {
 				return nil, err
 			}
@@ -238,8 +242,9 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 // in this file, 0 otherwise — the caller aggregates across routes to
 // decide whether the missing-lib warning fires. The bool reports
 // whether the page contributed a Head method (drives manifest
-// HeadFn wiring).
-func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRoute) (int, bool, error) {
+// HeadFn wiring). When release is true, any $lib/dev/** import is a
+// fatal error.
+func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRoute, release bool) (int, bool, error) {
 	pageName := "+page.svelte"
 	if route.HasReset {
 		pageName = "+page@" + route.ResetTarget + ".svelte"
@@ -248,6 +253,11 @@ func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRou
 	src, err := os.ReadFile(pagePath) //nolint:gosec // path comes from scanner walk under projectRoot
 	if err != nil {
 		return 0, false, fmt.Errorf("codegen: read %s: %w", pagePath, err)
+	}
+	if release {
+		if err := checkLibDevImports(string(src), pagePath); err != nil {
+			return 0, false, err
+		}
 	}
 	rewritten, hits := rewriteLibImports(string(src), modulePath)
 	src = []byte(rewritten)
@@ -465,8 +475,9 @@ func emitErrorPage(projectRoot, outDir, errorDir, pkgPath, pkgName string) error
 // The leading character must not be "_" because Go's build system
 // silently ignores files whose name starts with "_". serverFile, when
 // non-empty, points at a sibling layout.server.go whose Load() inline
-// struct return is used to infer LayoutData fields.
-func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile string) (bool, error) {
+// struct return is used to infer LayoutData fields. When release is true,
+// any $lib/dev/** import is a fatal error.
+func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile string, release bool) (bool, error) {
 	layoutPath, err := resolveLayoutSource(layoutDir)
 	if err != nil {
 		return false, err
@@ -474,6 +485,11 @@ func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile str
 	src, err := os.ReadFile(layoutPath) //nolint:gosec // path comes from scanner walk under projectRoot
 	if err != nil {
 		return false, fmt.Errorf("codegen: read %s: %w", layoutPath, err)
+	}
+	if release {
+		if err := checkLibDevImports(string(src), layoutPath); err != nil {
+			return false, err
+		}
 	}
 	frag, perrs := parser.Parse(src)
 	if len(perrs) > 0 {

--- a/packages/sveltego/internal/codegen/build_test.go
+++ b/packages/sveltego/internal/codegen/build_test.go
@@ -466,6 +466,86 @@ func TestBuild_EmbedSkippedWhenNoAssets(t *testing.T) {
 	}
 }
 
+// TestBuild_ReleaseRejectsLibDevImport verifies that a +page.svelte
+// importing "$lib/dev/..." causes Build to return an error in release
+// mode but succeeds in dev mode.
+func TestBuild_ReleaseRejectsLibDevImport(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "+page.svelte"),
+		`<script lang="go">
+import "$lib/dev/panel"
+</script>
+<h1>Hello</h1>
+`)
+	writeFile(t, filepath.Join(root, "src", "lib", "dev", "panel", "panel.go"),
+		"package panel\n\nfunc Show() string { return \"dev\" }\n")
+	writeFile(t, filepath.Join(root, "src", "lib", "util.go"),
+		"package lib\n")
+
+	// Dev mode: succeeds — $lib/dev imports are allowed.
+	if _, err := Build(BuildOptions{ProjectRoot: root}); err != nil {
+		t.Fatalf("dev Build: unexpected error: %v", err)
+	}
+
+	// Release mode: must fail with a meaningful message.
+	_, err := Build(BuildOptions{ProjectRoot: root, Release: true})
+	if err == nil {
+		t.Fatal("release Build: expected error on $lib/dev import, got nil")
+	}
+	if !strings.Contains(err.Error(), "$lib/dev") {
+		t.Errorf("release Build: error should mention $lib/dev, got: %v", err)
+	}
+}
+
+// TestBuild_ReleaseAllowsNonDevLibImport verifies that $lib imports that
+// are not under dev/ pass through release mode unchanged.
+func TestBuild_ReleaseAllowsNonDevLibImport(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "+page.svelte"),
+		`<script lang="go">
+import "$lib/util"
+</script>
+<h1>Hello</h1>
+`)
+	writeFile(t, filepath.Join(root, "src", "lib", "util", "util.go"),
+		"package util\n\nfunc Name() string { return \"lib\" }\n")
+
+	if _, err := Build(BuildOptions{ProjectRoot: root, Release: true}); err != nil {
+		t.Fatalf("release Build on non-dev $lib: unexpected error: %v", err)
+	}
+}
+
+// TestCheckLibDevImports exercises the low-level helper directly.
+func TestCheckLibDevImports(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{"no-lib", `import "fmt"`, false},
+		{"lib-util", `import "$lib/util"`, false},
+		{"lib-bare", `import "$lib"`, false},
+		{"lib-dev-exact", `import "$lib/dev"`, true},
+		{"lib-dev-sub", `import "$lib/dev/panel"`, true},
+		{"lib-developer", `import "$lib/developer"`, false}, // must NOT match
+		{"lib-devtools", `import "$lib/devtools/x"`, false}, // must NOT match
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkLibDevImports(tc.body, "test.svelte")
+			if (err != nil) != tc.wantErr {
+				t.Errorf("checkLibDevImports(%q) error=%v wantErr=%v", tc.body, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func snapshotGen(t *testing.T, root string) map[string][]byte {
 	t.Helper()
 	out := map[string][]byte{}

--- a/packages/sveltego/internal/codegen/lib.go
+++ b/packages/sveltego/internal/codegen/lib.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -34,4 +35,24 @@ func rewriteLibImports(body, modulePath string) (string, bool) {
 		return `"` + modulePath + "/lib" + tail + `"`
 	})
 	return out, hit
+}
+
+// checkLibDevImports returns an error when body contains a `$lib/dev`
+// import. Called only in release mode: src/lib/dev/ is a dev-only
+// subtree (mirrors sveltejs/kit#13078) and must not appear in
+// production builds.
+func checkLibDevImports(body, srcPath string) error {
+	matches := libImportRe.FindAllStringSubmatch(body, -1)
+	for _, m := range matches {
+		tail := ""
+		if len(m) > 1 {
+			tail = m[1]
+		}
+		// tail is either empty or starts with "/". A match of "/dev" or
+		// "/dev/<anything>" is the forbidden pattern.
+		if tail == "/dev" || strings.HasPrefix(tail, "/dev/") {
+			return fmt.Errorf("codegen: %s: $lib/dev imports are not allowed in release builds (sveltejs/kit#13078)", srcPath)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `Release bool` to `codegen.BuildOptions`; when true, any `$lib/dev` or `$lib/dev/**` import in a `.svelte` file is a fatal codegen error
- Threads the flag into `emitPage` and `emitLayout` via the new `checkLibDevImports` helper in `lib.go`
- Exposes `--release` flag on both `sveltego build` and `sveltego compile`; also honoured via `SVELTEGO_RELEASE=1` env var
- Mirrors the [sveltejs/kit#13078](https://github.com/sveltejs/kit/issues/13078) convention: `src/lib/dev/` is a dev-only subtree, stripped at production build time

Flag introduced: `--release` (both `build` and `compile` subcommands) / `SVELTEGO_RELEASE=1` env var

## Test plan

- `TestBuild_ReleaseRejectsLibDevImport` — dev build passes with `$lib/dev/...`, release build returns a fatal error mentioning `$lib/dev`
- `TestBuild_ReleaseAllowsNonDevLibImport` — `$lib/util` passes in release mode unchanged
- `TestCheckLibDevImports` — low-level table-driven test; validates exact boundary (`$lib/dev` and `$lib/dev/x` fail; `$lib/developer` and `$lib/devtools/x` must not false-positive)
- Full suite: 1015 tests pass, `gofumpt` clean, `go vet` clean, `go build` clean

Closes #194