### PR TITLE
feat(kit): RawParam for un-decoded route params

### DIFF
--- a/packages/sveltego/exports/kit/ctx.go
+++ b/packages/sveltego/exports/kit/ctx.go
@@ -34,12 +34,22 @@ func (hw *HeaderWriter) Del(key string) {
 // RenderCtx is the request-scoped context handed to generated Render
 // methods across the SSR lifecycle (Load, Render, Hooks).
 type RenderCtx struct {
-	Locals  map[string]any
-	URL     *url.URL
-	Params  map[string]string
-	Cookies *Cookies
-	Request *http.Request
-	Writer  http.ResponseWriter
+	Locals    map[string]any
+	URL       *url.URL
+	Params    map[string]string
+	RawParams map[string]string
+	Cookies   *Cookies
+	Request   *http.Request
+	Writer    http.ResponseWriter
+}
+
+// RawParam returns the un-decoded route parameter value for name exactly
+// as it appears in the request path (e.g. "hello%20world" rather than
+// "hello world"). Returns ("", false) when name is not a capture in the
+// matched route.
+func (c *RenderCtx) RawParam(name string) (string, bool) {
+	v, ok := c.RawParams[name]
+	return v, ok
 }
 
 // LoadCtx is the request-scoped context handed to user-written Load
@@ -49,13 +59,30 @@ type RenderCtx struct {
 // pushes each layout result before invoking the next layer's Load. User
 // code reads only the immediate parent through [LoadCtx.Parent].
 type LoadCtx struct {
-	Locals  map[string]any
-	URL     *url.URL
-	Params  map[string]string
-	Cookies *Cookies
-	Request *http.Request
-	parents []any
-	headers http.Header
+	Locals    map[string]any
+	URL       *url.URL
+	Params    map[string]string
+	RawParams map[string]string
+	Cookies   *Cookies
+	Request   *http.Request
+	parents   []any
+	headers   http.Header
+}
+
+// Param returns the URL-decoded route parameter value for name and
+// whether name is a capture in the matched route.
+func (c *LoadCtx) Param(name string) (string, bool) {
+	v, ok := c.Params[name]
+	return v, ok
+}
+
+// RawParam returns the un-decoded route parameter value for name exactly
+// as it appears in the request path (e.g. "hello%20world" rather than
+// "hello world"). Returns ("", false) when name is not a capture in the
+// matched route.
+func (c *LoadCtx) RawParam(name string) (string, bool) {
+	v, ok := c.RawParams[name]
+	return v, ok
 }
 
 // Parent returns the immediate parent layout's loaded data, or nil when

--- a/packages/sveltego/exports/kit/ctx_test.go
+++ b/packages/sveltego/exports/kit/ctx_test.go
@@ -56,3 +56,90 @@ func TestLoadCtx_PushParent_PreservesOrder(t *testing.T) {
 		t.Fatalf("Parent after three pushes = %v, want \"inner\"", got)
 	}
 }
+
+// TestLoadCtx_Param_DecodesPercent pins that Param returns the
+// URL-decoded value for a percent-encoded route segment.
+func TestLoadCtx_Param_DecodesPercent(t *testing.T) {
+	t.Parallel()
+	ctx := kit.NewLoadCtx(httptest.NewRequest(http.MethodGet, "/", nil), map[string]string{
+		"slug": "hello world",
+	})
+	got, ok := ctx.Param("slug")
+	if !ok {
+		t.Fatal("Param returned ok=false, want true")
+	}
+	if got != "hello world" {
+		t.Fatalf("Param = %q, want %q", got, "hello world")
+	}
+}
+
+// TestLoadCtx_RawParam_ReturnsEncodedSpace pins that RawParam returns
+// the percent-encoded value when the decoded Param contains a space.
+// This mirrors sveltejs/kit#12492: callers that need to forward the raw
+// segment (e.g. building a cache key) must not re-encode a decoded value.
+func TestLoadCtx_RawParam_ReturnsEncodedSpace(t *testing.T) {
+	t.Parallel()
+	ctx := kit.NewLoadCtx(httptest.NewRequest(http.MethodGet, "/", nil), map[string]string{
+		"slug": "hello world",
+	})
+	ctx.RawParams = map[string]string{"slug": "hello%20world"}
+
+	got, ok := ctx.RawParam("slug")
+	if !ok {
+		t.Fatal("RawParam returned ok=false, want true")
+	}
+	if got != "hello%20world" {
+		t.Fatalf("RawParam = %q, want %q", got, "hello%20world")
+	}
+}
+
+// TestLoadCtx_RawParam_ReturnsEncodedSlash pins that RawParam preserves
+// %2F in a segment; the decoded Param sees "/" but callers that need to
+// distinguish a literal slash from a path separator require the raw form.
+func TestLoadCtx_RawParam_ReturnsEncodedSlash(t *testing.T) {
+	t.Parallel()
+	ctx := kit.NewLoadCtx(httptest.NewRequest(http.MethodGet, "/", nil), map[string]string{
+		"path": "a/b",
+	})
+	ctx.RawParams = map[string]string{"path": "a%2Fb"}
+
+	got, ok := ctx.RawParam("path")
+	if !ok {
+		t.Fatal("RawParam returned ok=false, want true")
+	}
+	if got != "a%2Fb" {
+		t.Fatalf("RawParam = %q, want %q", got, "a%2Fb")
+	}
+}
+
+// TestLoadCtx_RawParam_MissingParam pins that RawParam returns ("", false)
+// when the name is not a capture in the matched route.
+func TestLoadCtx_RawParam_MissingParam(t *testing.T) {
+	t.Parallel()
+	ctx := kit.NewLoadCtx(httptest.NewRequest(http.MethodGet, "/", nil), nil)
+	ctx.RawParams = map[string]string{"id": "42"}
+
+	got, ok := ctx.RawParam("missing")
+	if ok {
+		t.Fatalf("RawParam for missing key returned ok=true, value=%q", got)
+	}
+	if got != "" {
+		t.Fatalf("RawParam for missing key = %q, want %q", got, "")
+	}
+}
+
+// TestLoadCtx_RawParam_NilRawParams confirms that RawParam is safe when
+// RawParams is nil (e.g. static routes with no captures).
+func TestLoadCtx_RawParam_NilRawParams(t *testing.T) {
+	t.Parallel()
+	ctx := kit.NewLoadCtx(httptest.NewRequest(http.MethodGet, "/", nil), nil)
+	// RawParams deliberately left nil.
+
+	got, ok := ctx.RawParam("id")
+	if ok {
+		t.Fatalf("RawParam on nil RawParams returned ok=true, value=%q", got)
+	}
+	if got != "" {
+		t.Fatalf("RawParam on nil RawParams = %q, want %q", got, "")
+	}
+}

--- a/packages/sveltego/exports/kit/event.go
+++ b/packages/sveltego/exports/kit/event.go
@@ -31,6 +31,12 @@ type RequestEvent struct {
 	// including on error paths. Lazily initialized by ResponseHeader().
 	responseHeader http.Header
 
+	// RawParams holds the un-decoded route parameter values exactly as
+	// they appear in the request path (e.g. "hello%20world" rather than
+	// "hello world"). Populated by the pipeline after a successful route
+	// match; nil before matching runs.
+	RawParams map[string]string
+
 	// fetcher is the chained HandleFetch implementation. nil means
 	// "use http.DefaultClient.Do".
 	fetcher HandleFetchFn

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -163,6 +163,7 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 	if matchPath == "" {
 		matchPath = ev.URL.Path
 	}
+	matchedPath := matchPath
 	route, params, ok := s.tree.Match(matchPath)
 	if !ok {
 		// Retry with the toggled trailing slash so a Never route hit
@@ -174,6 +175,7 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 		if alt != matchPath {
 			if r2, p2, ok2 := s.tree.Match(alt); ok2 {
 				route, params, ok = r2, p2, ok2
+				matchedPath = alt
 			}
 		}
 	}
@@ -186,6 +188,7 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 	for k, v := range params {
 		ev.Params[k] = v
 	}
+	ev.RawParams = rawParamsFromPath(matchedPath, route.Segments, params)
 
 	if redirect := trailingSlashRedirect(ev.URL, route.Options.TrailingSlash); redirect != "" {
 		return &kit.Response{
@@ -331,6 +334,7 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 		lctx = kit.NewLoadCtx(r, ev.Params)
 		lctx.Locals = ev.Locals
 		lctx.Cookies = ev.Cookies
+		lctx.RawParams = ev.RawParams
 		layoutDatas = make([]any, len(route.LayoutChain))
 		for i, layoutLoad := range route.LayoutLoaders {
 			if layoutLoad == nil {
@@ -367,11 +371,12 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 	}
 
 	rctx := &kit.RenderCtx{
-		Locals:  ev.Locals,
-		URL:     ev.URL,
-		Params:  ev.Params,
-		Cookies: ev.Cookies,
-		Request: r,
+		Locals:    ev.Locals,
+		URL:       ev.URL,
+		Params:    ev.Params,
+		RawParams: ev.RawParams,
+		Cookies:   ev.Cookies,
+		Request:   r,
 	}
 	inner := func(buf *render.Writer) error {
 		return route.Page(buf, rctx, data)
@@ -637,6 +642,69 @@ func indexScriptSpecial(p []byte) int {
 		}
 	}
 	return -1
+}
+
+// rawParamsFromPath extracts un-decoded route parameter values from path
+// using the pattern's segment list and the already-decoded params map
+// (used only to disambiguate optional segments). It splits path on
+// literal '/' bytes without URL-decoding so callers receive the
+// percent-encoded form the client sent (e.g. "hello%20world" rather than
+// "hello world"). Static segments are consumed silently; rest segments
+// join their remaining raw pieces with "/". Returns nil when there are
+// no param segments.
+func rawParamsFromPath(path string, segs []router.Segment, decoded map[string]string) map[string]string {
+	// Strip leading slash so splitting yields uniform segments.
+	if len(path) > 0 && path[0] == '/' {
+		path = path[1:]
+	}
+	// Split on literal '/' — no decoding.
+	var parts []string
+	if path != "" {
+		parts = strings.Split(path, "/")
+	}
+
+	// Count param-like segments to decide whether to allocate.
+	paramCount := 0
+	for _, s := range segs {
+		if s.Kind != router.SegmentStatic {
+			paramCount++
+		}
+	}
+	if paramCount == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, paramCount)
+	pi := 0 // index into parts
+	for _, s := range segs {
+		switch s.Kind {
+		case router.SegmentStatic:
+			pi++
+		case router.SegmentParam:
+			if pi < len(parts) {
+				out[s.Name] = parts[pi]
+				pi++
+			}
+		case router.SegmentOptional:
+			// The decoded params map tells us whether the optional segment
+			// matched a real value ("" means it was absent). Only consume
+			// a raw part when the decoded value is non-empty.
+			if decoded[s.Name] != "" && pi < len(parts) {
+				out[s.Name] = parts[pi]
+				pi++
+			} else {
+				out[s.Name] = ""
+			}
+		case router.SegmentRest:
+			if pi < len(parts) {
+				out[s.Name] = strings.Join(parts[pi:], "/")
+			} else {
+				out[s.Name] = ""
+			}
+			pi = len(parts)
+		}
+	}
+	return out
 }
 
 // writeResponse flushes a Response built by Handle (or its short-circuit


### PR DESCRIPTION
Closes #182

## What

Adds `RawParam(name string) (string, bool)` to both `LoadCtx` and
`RenderCtx`. It returns the percent-encoded route segment exactly as the
client sent it — `"hello%20world"` rather than `"hello world"`.

Also adds a typed `Param(name string) (string, bool)` method on
`LoadCtx` (previously only accessible as direct map indexing).

## Why

Per [sveltejs/kit#12492](https://github.com/sveltejs/kit/issues/12492):
code that builds cache keys, canonicalises URLs, or forwards the raw
segment to a downstream API must not re-encode a decoded value — the
encoding might differ (e.g. `%20` vs `+`). The decoded form is lossy;
callers need the preserved original.

## How

`server.resolve()` calls the new `rawParamsFromPath()` helper after
`tree.Match()` returns. The helper splits the matched path on literal
`'/'` bytes (no `url.PathUnescape`) and aligns raw segments to named
captures using `route.Segments`. Optional segments are disambiguated via
the already-decoded `params` map so no router match logic is duplicated.

No changes to the router package. The only server-package change is in
`pipeline.go`.

## Test plan
- `TestLoadCtx_RawParam_ReturnsEncodedSpace` — `%20` survives
- `TestLoadCtx_RawParam_ReturnsEncodedSlash` — `%2F` survives
- `TestLoadCtx_RawParam_MissingParam` — returns `("", false)`
- `TestLoadCtx_RawParam_NilRawParams` — safe when no captures exist
- All 1 010 existing tests still pass (`go test -race ./packages/sveltego/...`)