### PR TITLE
feat(kit): LoadCtx.Speculative() to distinguish preload from real nav

### DIFF
--- a/packages/sveltego/exports/kit/ctx.go
+++ b/packages/sveltego/exports/kit/ctx.go
@@ -3,6 +3,7 @@ package kit
 import (
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // HeaderWriter exposes Set/Add/Del on a response header map. Returned by
@@ -119,6 +120,32 @@ func (c *LoadCtx) Header() *HeaderWriter {
 // this directly.
 func (c *LoadCtx) CollectHeaders() http.Header {
 	return c.headers
+}
+
+// Speculative reports whether this Load was triggered by a speculative
+// prefetch rather than a real navigation. Use it to skip expensive work
+// (analytics recording, rate-limit counters, cache warming) that should
+// not fire on hover-triggered preloads.
+//
+// The server detects speculation via two headers, both treated as hints
+// (not security boundaries — a caller can forge them):
+//
+//   - X-Sveltego-Preload: 1  — emitted by the sveltego client SPA router
+//     on every __data.json preload fetch (#40).
+//   - Sec-Purpose: prefetch   — standardized HTTP hint emitted by browsers
+//     on speculative preload requests (RFC 8941 / Fetch spec).
+func (c *LoadCtx) Speculative() bool {
+	if c.Request == nil {
+		return false
+	}
+	if c.Request.Header.Get("X-Sveltego-Preload") == "1" {
+		return true
+	}
+	// Sec-Purpose may carry multiple tokens; "prefetch" is sufficient.
+	if strings.Contains(c.Request.Header.Get("Sec-Purpose"), "prefetch") {
+		return true
+	}
+	return false
 }
 
 // NewRenderCtx builds a RenderCtx for the given request, response, and

--- a/packages/sveltego/exports/kit/ctx_test.go
+++ b/packages/sveltego/exports/kit/ctx_test.go
@@ -143,3 +143,61 @@ func TestLoadCtx_RawParam_NilRawParams(t *testing.T) {
 		t.Fatalf("RawParam on nil RawParams = %q, want %q", got, "")
 	}
 }
+
+// TestLoadCtx_Speculative_FalseForRealNav pins the common case: a plain
+// GET with no preload header must return false.
+func TestLoadCtx_Speculative_FalseForRealNav(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	ctx := kit.NewLoadCtx(r, nil)
+	if ctx.Speculative() {
+		t.Fatal("Speculative() = true for plain GET, want false")
+	}
+}
+
+// TestLoadCtx_Speculative_TrueForSveltegoHeader pins the sveltego-specific
+// client header: X-Sveltego-Preload: 1 must flip Speculative to true.
+func TestLoadCtx_Speculative_TrueForSveltegoHeader(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/dashboard/__data.json", nil)
+	r.Header.Set("X-Sveltego-Preload", "1")
+	ctx := kit.NewLoadCtx(r, nil)
+	if !ctx.Speculative() {
+		t.Fatal("Speculative() = false with X-Sveltego-Preload: 1, want true")
+	}
+}
+
+// TestLoadCtx_Speculative_TrueForSecPurposePrefetch pins the standard HTTP
+// browser hint: Sec-Purpose containing "prefetch" must flip Speculative to true.
+func TestLoadCtx_Speculative_TrueForSecPurposePrefetch(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/dashboard/__data.json", nil)
+	r.Header.Set("Sec-Purpose", "prefetch")
+	ctx := kit.NewLoadCtx(r, nil)
+	if !ctx.Speculative() {
+		t.Fatal("Speculative() = false with Sec-Purpose: prefetch, want true")
+	}
+}
+
+// TestLoadCtx_Speculative_TrueForSecPurposeWithTokens confirms that
+// Sec-Purpose carrying extra tokens (e.g. "prefetch;prerender") still
+// triggers Speculative, matching the "contains prefetch" substring rule.
+func TestLoadCtx_Speculative_TrueForSecPurposeWithTokens(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodGet, "/dashboard/__data.json", nil)
+	r.Header.Set("Sec-Purpose", "prefetch;prerender")
+	ctx := kit.NewLoadCtx(r, nil)
+	if !ctx.Speculative() {
+		t.Fatal("Speculative() = false with Sec-Purpose: prefetch;prerender, want true")
+	}
+}
+
+// TestLoadCtx_Speculative_FalseWithNilRequest guards the nil-request edge
+// case (e.g. direct construction in unit tests) — must return false, not panic.
+func TestLoadCtx_Speculative_FalseWithNilRequest(t *testing.T) {
+	t.Parallel()
+	ctx := kit.NewLoadCtx(nil, nil)
+	if ctx.Speculative() {
+		t.Fatal("Speculative() = true with nil request, want false")
+	}
+}


### PR DESCRIPTION
Closes #173

## What

Adds `LoadCtx.Speculative() bool` so user-written `Load` functions can distinguish a hover/focus prefetch from a real navigation and skip expensive work (analytics recording, rate-limit counters, cache warming) that must not fire on speculative requests.

## Detection mechanism

Two request headers are checked, both treated as hints (not security boundaries — a forged header is harmless; this is a hint to skip work, not a gate):

- `X-Sveltego-Preload: 1` — emitted by the sveltego client SPA router on every `__data.json` preload fetch (#40).
- `Sec-Purpose: prefetch` — standardized HTTP hint emitted by browsers on speculative preload requests (RFC 8941 / Fetch spec).

Upstream motivation: sveltejs/kit#12559.

## Files touched

- `packages/sveltego/exports/kit/ctx.go` — `Speculative()` method + `strings` import.
- `packages/sveltego/exports/kit/ctx_test.go` — five new pinning tests.

No server/pipeline changes needed: the method reads directly from `c.Request.Header`, which is already populated by `NewLoadCtx`.

## Test plan

- `TestLoadCtx_Speculative_FalseForRealNav` — plain GET returns false.
- `TestLoadCtx_Speculative_TrueForSveltegoHeader` — `X-Sveltego-Preload: 1` returns true.
- `TestLoadCtx_Speculative_TrueForSecPurposePrefetch` — `Sec-Purpose: prefetch` returns true.
- `TestLoadCtx_Speculative_TrueForSecPurposeWithTokens` — `Sec-Purpose: prefetch;prerender` returns true.
- `TestLoadCtx_Speculative_FalseWithNilRequest` — nil request returns false without panic.

All 1023 existing tests continue to pass (`go test -race ./packages/sveltego/...`).