### PR TITLE
feat(hooks): HandleError can short-circuit with redirect/response

### DIFF
--- a/packages/sveltego/exports/kit/hooks.go
+++ b/packages/sveltego/exports/kit/hooks.go
@@ -46,7 +46,14 @@ type HandleFn func(ev *RequestEvent, resolve ResolveFn) (*Response, error)
 // pipeline calls it whenever Handle, Load, Render, or a +server.go
 // handler returns an error and converts the SafeError into the user-
 // facing HTTP response.
-type HandleErrorFn func(ev *RequestEvent, err error) SafeError
+//
+// Returning a non-nil error short-circuits the error boundary entirely.
+// The returned error is handled by the same sentinel logic as pipeline
+// errors: a *RedirectErr produces a redirect, a *HTTPErr produces a
+// plain HTTP response. This lets a HandleError hook redirect
+// unauthenticated users to /login instead of rendering +error.svelte.
+// The short-circuit does NOT re-enter HandleError (no infinite loop).
+type HandleErrorFn func(ev *RequestEvent, err error) (SafeError, error)
 
 // HandleFetchFn is the signature of the optional HandleFetch hook. The
 // pipeline plugs it into RequestEvent.Fetch so outbound HTTP traffic
@@ -107,8 +114,8 @@ func IdentityHandle(ev *RequestEvent, resolve ResolveFn) (*Response, error) {
 
 // IdentityHandleError is the default HandleError hook. It maps any error
 // to a generic 500 SafeError without exposing internal detail.
-func IdentityHandleError(_ *RequestEvent, _ error) SafeError {
-	return SafeError{Code: http.StatusInternalServerError, Message: http.StatusText(http.StatusInternalServerError)}
+func IdentityHandleError(_ *RequestEvent, _ error) (SafeError, error) {
+	return SafeError{Code: http.StatusInternalServerError, Message: http.StatusText(http.StatusInternalServerError)}, nil
 }
 
 // IdentityHandleFetch is the default HandleFetch hook. It dispatches req

--- a/packages/sveltego/exports/kit/hooks_test.go
+++ b/packages/sveltego/exports/kit/hooks_test.go
@@ -176,7 +176,10 @@ func TestIdentityReroute_returnsEmpty(t *testing.T) {
 
 func TestIdentityHandleError_returns500(t *testing.T) {
 	t.Parallel()
-	se := kit.IdentityHandleError(newEvent(t), errors.New("x"))
+	se, err := kit.IdentityHandleError(newEvent(t), errors.New("x"))
+	if err != nil {
+		t.Fatalf("IdentityHandleError returned unexpected error: %v", err)
+	}
 	if se.Code != http.StatusInternalServerError {
 		t.Errorf("Code = %d, want 500", se.Code)
 	}

--- a/packages/sveltego/internal/codegen/hooks_build_test.go
+++ b/packages/sveltego/internal/codegen/hooks_build_test.go
@@ -50,8 +50,8 @@ func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) 
 	return resolve(ev)
 }
 
-func HandleError(ev *kit.RequestEvent, err error) kit.SafeError {
-	return kit.SafeError{Code: 500}
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) {
+	return kit.SafeError{Code: 500}, nil
 }
 
 func HandleFetch(ev *kit.RequestEvent, req *http.Request) (*http.Response, error) {

--- a/packages/sveltego/internal/codegen/hookscan.go
+++ b/packages/sveltego/internal/codegen/hookscan.go
@@ -138,7 +138,7 @@ func resultCount(fn *goast.FuncDecl) int {
 // strings. Sentinel errors keep tests stable across formatting changes.
 var (
 	errBadHandleSig      = errors.New("Handle must have signature func(*kit.RequestEvent, kit.ResolveFn) (*kit.Response, error)")
-	errBadHandleErrorSig = errors.New("HandleError must have signature func(*kit.RequestEvent, error) kit.SafeError")
+	errBadHandleErrorSig = errors.New("HandleError must have signature func(*kit.RequestEvent, error) (kit.SafeError, error)")
 	errBadHandleFetchSig = errors.New("HandleFetch must have signature func(*kit.RequestEvent, *http.Request) (*http.Response, error)")
 	errBadRerouteSig     = errors.New("Reroute must have signature func(*url.URL) string")
 	errBadInitSig        = errors.New("Init must have signature func(context.Context) error")
@@ -155,7 +155,7 @@ func validateHandleSig(fn *goast.FuncDecl) error {
 }
 
 func validateHandleErrorSig(fn *goast.FuncDecl) error {
-	if paramCount(fn) != 2 || resultCount(fn) != 1 {
+	if paramCount(fn) != 2 || resultCount(fn) != 2 {
 		return errBadHandleErrorSig
 	}
 	return nil

--- a/packages/sveltego/internal/codegen/hookscan_test.go
+++ b/packages/sveltego/internal/codegen/hookscan_test.go
@@ -52,8 +52,8 @@ func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) 
 	return resolve(ev)
 }
 
-func HandleError(ev *kit.RequestEvent, err error) kit.SafeError {
-	return kit.SafeError{Code: 500}
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) {
+	return kit.SafeError{Code: 500}, nil
 }
 
 func HandleFetch(ev *kit.RequestEvent, req *http.Request) (*http.Response, error) {

--- a/packages/sveltego/server/csp_integration_test.go
+++ b/packages/sveltego/server/csp_integration_test.go
@@ -138,8 +138,8 @@ func TestCSP_ReportOnlyUsesReportOnlyHeader(t *testing.T) {
 func TestCSP_HeaderPresentOnErrorPath(t *testing.T) {
 	t.Parallel()
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, _ error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusBadGateway, Message: "upstream"}
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusBadGateway, Message: "upstream"}, nil
 		},
 	}
 	srv := newCSPServer(t, kit.CSPConfig{Mode: kit.CSPStrict}, []router.Route{{

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -112,7 +112,46 @@ func (s *Server) handlePipelineError(w http.ResponseWriter, r *http.Request, ev 
 		return
 	}
 
-	safe := s.hooks.HandleError(ev, err)
+	safe, shortCircuit := s.hooks.HandleError(ev, err)
+
+	// HandleError may short-circuit with a redirect or custom HTTP
+	// response instead of rendering the error boundary.
+	if shortCircuit != nil {
+		var redir *kit.RedirectErr
+		if errors.As(shortCircuit, &redir) {
+			s.Logger.Info("server: handleerror redirect",
+				logKeyMethod, r.Method,
+				logKeyPath, r.URL.Path,
+				logKeyStatus, redir.Code,
+				logKeyLocation, redir.Location)
+			if ev != nil && ev.Cookies != nil {
+				ev.Cookies.Apply(w)
+			}
+			http.Redirect(w, r, redir.Location, redir.Code)
+			return
+		}
+		var herr *kit.HTTPErr
+		if errors.As(shortCircuit, &herr) {
+			s.Logger.Info("server: handleerror http error",
+				logKeyMethod, r.Method,
+				logKeyPath, r.URL.Path,
+				logKeyStatus, herr.Code,
+				logKeyError, herr.Message)
+			if ev != nil && ev.Cookies != nil {
+				ev.Cookies.Apply(w)
+			}
+			writePlain(w, herr.Code, herr.Message+"\n")
+			return
+		}
+		// Unknown short-circuit error type: treat as 500 to avoid a
+		// silent no-op. Do not re-enter HandleError.
+		s.Logger.Error("server: handleerror returned unknown short-circuit error",
+			logKeyMethod, r.Method,
+			logKeyPath, r.URL.Path,
+			logKeyError, shortCircuit.Error())
+		writePlain(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)+"\n")
+		return
+	}
 
 	// Preserve the legacy httpStatuser observation: when the user did
 	// not author HandleError, the identity default returns 500 — but

--- a/packages/sveltego/server/errors_integration_test.go
+++ b/packages/sveltego/server/errors_integration_test.go
@@ -71,8 +71,8 @@ func TestErrorBoundary_RouteLocalOverridesGlobal(t *testing.T) {
 	})
 
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, err error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusInternalServerError, Message: err.Error()}
+		HandleError: func(_ *kit.RequestEvent, err error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusInternalServerError, Message: err.Error()}, nil
 		},
 	}
 	srv.hooks = hooks.WithDefaults()
@@ -118,8 +118,8 @@ func TestErrorBoundary_OuterLayoutsRetained(t *testing.T) {
 	}})
 
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, err error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusBadGateway, Message: err.Error()}
+		HandleError: func(_ *kit.RequestEvent, err error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusBadGateway, Message: err.Error()}, nil
 		},
 	}
 	srv.hooks = hooks.WithDefaults()
@@ -174,8 +174,8 @@ func TestErrorBoundary_StatusFollowsSafeError(t *testing.T) {
 	}})
 
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, _ error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusTeapot, Message: "i am a teapot", ID: "rid-42"}
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusTeapot, Message: "i am a teapot", ID: "rid-42"}, nil
 		},
 	}
 	srv.hooks = hooks.WithDefaults()
@@ -209,8 +209,8 @@ func TestErrorBoundary_NoBoundaryFallsBackToPlain(t *testing.T) {
 	}})
 
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, err error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusServiceUnavailable, Message: err.Error()}
+		HandleError: func(_ *kit.RequestEvent, err error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusServiceUnavailable, Message: err.Error()}, nil
 		},
 	}
 	srv.hooks = hooks.WithDefaults()
@@ -251,8 +251,8 @@ func TestErrorBoundary_BoundaryRenderFailureFallsBack(t *testing.T) {
 	}})
 
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, err error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusInternalServerError, Message: err.Error()}
+		HandleError: func(_ *kit.RequestEvent, err error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusInternalServerError, Message: err.Error()}, nil
 		},
 	}
 	srv.hooks = hooks.WithDefaults()
@@ -340,8 +340,8 @@ func TestErrorPreservesHeadersAndCookies_BoundaryPath(t *testing.T) {
 		Error: errorBoundary("root"),
 	}})
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, _ error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusUnauthorized, Message: "unauthorized"}
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusUnauthorized, Message: "unauthorized"}, nil
 		},
 	}
 	srv.hooks = hooks.WithDefaults()
@@ -380,9 +380,9 @@ func TestErrorPreservesHeaders_HandleError(t *testing.T) {
 		},
 	}})
 	hooks := kit.Hooks{
-		HandleError: func(ev *kit.RequestEvent, _ error) kit.SafeError {
+		HandleError: func(ev *kit.RequestEvent, _ error) (kit.SafeError, error) {
 			ev.ResponseHeader().Set("X-Error-ID", "err-42")
-			return kit.SafeError{Code: http.StatusInternalServerError, Message: "internal server error"}
+			return kit.SafeError{Code: http.StatusInternalServerError, Message: "internal server error"}, nil
 		},
 	}
 	srv.hooks = hooks.WithDefaults()

--- a/packages/sveltego/server/hooks_integration_test.go
+++ b/packages/sveltego/server/hooks_integration_test.go
@@ -140,8 +140,8 @@ func TestHooks_ShortCircuitSkipsRoute(t *testing.T) {
 func TestHooks_HandleErrorTransformsLoadError(t *testing.T) {
 	t.Parallel()
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, _ error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusBadGateway, Message: "upstream", ID: "rid-1"}
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusBadGateway, Message: "upstream", ID: "rid-1"}, nil
 		},
 	}
 	srv := newHookServer(t, hooks, []router.Route{{
@@ -320,8 +320,8 @@ func TestHooks_InitErrorServesFallback(t *testing.T) {
 func TestHooks_HandleErrorIDPropagates(t *testing.T) {
 	t.Parallel()
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, _ error) kit.SafeError {
-			return kit.SafeError{Code: 503, Message: "down", ID: "rid-x"}
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{Code: 503, Message: "down", ID: "rid-x"}, nil
 		},
 	}
 	srv := newHookServer(t, hooks, []router.Route{{
@@ -350,8 +350,8 @@ func TestHooks_HandleErrorCatchesHandleErrors(t *testing.T) {
 		Handle: func(_ *kit.RequestEvent, _ kit.ResolveFn) (*kit.Response, error) {
 			return nil, errors.New("handle exploded")
 		},
-		HandleError: func(_ *kit.RequestEvent, _ error) kit.SafeError {
-			return kit.SafeError{Code: 502, Message: "handle bad"}
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{Code: 502, Message: "handle bad"}, nil
 		},
 	}
 	srv := newHookServer(t, hooks, []router.Route{{
@@ -377,8 +377,8 @@ func TestHooks_HandleErrorCatchesHandleErrors(t *testing.T) {
 func TestHooks_PanicInLoadFlowsToHandleError(t *testing.T) {
 	t.Parallel()
 	hooks := kit.Hooks{
-		HandleError: func(_ *kit.RequestEvent, err error) kit.SafeError {
-			return kit.SafeError{Code: http.StatusInternalServerError, Message: "sanitized: " + err.Error(), ID: "rid-9"}
+		HandleError: func(_ *kit.RequestEvent, err error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusInternalServerError, Message: "sanitized: " + err.Error(), ID: "rid-9"}, nil
 		},
 	}
 	srv := newHookServer(t, hooks, []router.Route{{
@@ -420,5 +420,105 @@ func TestHooks_DefaultHooks_passthrough(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK || !strings.Contains(string(body), "home") {
 		t.Errorf("status=%d body=%q", resp.StatusCode, body)
+	}
+}
+
+func TestHandleError_RedirectShortCircuit(t *testing.T) {
+	t.Parallel()
+	hooks := kit.Hooks{
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{}, kit.Redirect(302, "/login")
+		},
+	}
+	srv := newHookServer(t, hooks, []router.Route{{
+		Pattern: "/", Segments: segmentsFor("/"),
+		Page: staticPage("secret"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, errors.New("unauthenticated")
+		},
+	}})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status = %d, want 302", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); got != "/login" {
+		t.Errorf("Location = %q, want /login", got)
+	}
+}
+
+func TestHandleError_HTTPErrShortCircuit(t *testing.T) {
+	t.Parallel()
+	hooks := kit.Hooks{
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{}, kit.Error(http.StatusPaymentRequired, "subscribe to unlock")
+		},
+	}
+	srv := newHookServer(t, hooks, []router.Route{{
+		Pattern: "/about", Segments: segmentsFor("/about"),
+		Page: staticPage("premium"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, errors.New("paywall")
+		},
+	}})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/about")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want 402", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "subscribe to unlock") {
+		t.Errorf("body = %q, want subscribe to unlock", body)
+	}
+}
+
+func TestHandleError_PlainErrorFallsThroughToBoundary(t *testing.T) {
+	t.Parallel()
+	hooks := kit.Hooks{
+		HandleError: func(_ *kit.RequestEvent, _ error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusInternalServerError, Message: "boundary reached"}, nil
+		},
+	}
+	srv := newHookServer(t, hooks, []router.Route{{
+		Pattern: "/", Segments: segmentsFor("/"),
+		Page: staticPage("x"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, errors.New("plain error")
+		},
+	}})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "boundary reached") {
+		t.Errorf("body = %q, want boundary reached", body)
 	}
 }


### PR DESCRIPTION
Closes #167

## Summary

- `HandleErrorFn` signature changes from `func(*RequestEvent, error) SafeError` to `func(*RequestEvent, error) (SafeError, error)` — backward-compatible at the type level; all existing user hooks return `nil` as the second value.
- When HandleError returns a non-nil error, the pipeline short-circuits before the error boundary: `*kit.RedirectErr` → 302/303 redirect; `*kit.HTTPErr` → plain HTTP response; unknown → 500.
- The short-circuit does **not** re-enter HandleError, preventing infinite loops.
- `hookscan.go` validator updated to require 2 result values (was 1); error message updated.
- 3 new integration tests: redirect, HTTPErr, and plain-error-falls-through-to-boundary (regression).

## Test plan

- `TestHandleError_RedirectShortCircuit` — Load error → HandleError returns `kit.Redirect(302, "/login")` → 302 + Location: /login
- `TestHandleError_HTTPErrShortCircuit` — Load error → HandleError returns `kit.Error(402, ...)` → 402 response body
- `TestHandleError_PlainErrorFallsThroughToBoundary` — HandleError returns `(SafeError, nil)` → existing error boundary path unchanged
- All 960 tests pass, `go vet` clean, `gofumpt` clean