### PR TITLE
docs: post-wave-5+6 sync (milestone counts, repo state, file convention)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/core/codegen/CLAUDE
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. No Go source has landed yet — the repo currently holds specs, RFCs, ADRs, and a 105-issue roadmap on GitHub at `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. MVP is shipped — Go source for parser, codegen, runtime, router, hooks, forms, client tooling, and adapters is live in `packages/`. Active development is on v0.5 (SvelteKit parity) and v0.6 (authentication). Roadmap tracked at `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see `tasks/lessons.md` "Pivot to Go-native rewrite"):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,7 @@ When in doubt about a convention: open the relevant issue with `gh issue view <N
 
 ## Repository state
 
-Pre-alpha. **No Go source yet** — repo holds specs, RFCs, and a 105-issue roadmap on GitHub at `binsarjr/sveltego`. The first code lands when foundation RFCs (#95–97) and setup tasks (#98–103) land. Until then, all work happens in:
-
-- `tasks/todo.md` — current execution plan, milestone scope, phase tracking
-- `tasks/lessons.md` — design decisions and self-rules captured per session (append-only journal)
-- GitHub issues on `binsarjr/sveltego` — every concrete unit of work
+Pre-alpha. MVP is shipped — Go source for parser, codegen, runtime, router, server pipeline, hooks, form actions, client-side features, and tooling (LSP, MCP, adapters, init) is live in `packages/`. Active development is on `v0.5` (SvelteKit parity catch-up) and `v0.6` (authentication). GitHub milestone roadmap at `binsarjr/sveltego`.
 
 Always read both `tasks/` files at session start before proposing changes.
 
@@ -200,17 +196,18 @@ If counts, file lists, or roadmap stages disagree across these, the doc set is b
 
 ## Roadmap structure
 
-6 milestones, 105 issues. Issue numbering follows execution order:
+8 milestones. Issue numbering follows execution order:
 
 | Milestone | Issues | Focus |
 |---|---|---|
-| MVP | #1–23, #76, #77, #83, #95–105 | Foundation RFCs + setup, parser, codegen, runtime, router, CLI to render a page |
-| v0.2 | #24–33, #78–82 | Layouts, hooks, error boundaries, form actions, route groups, page options, env |
-| v0.3 | #34–42, #84, #85, #87, #88 | Vite client, hydration, SPA router, `$app/navigation`, Snapshot, kit.Link, kit.Asset |
-| v0.4 | #43–59, #86, #90 | Svelte 5 full coverage, a11y, `<svelte:options>` |
-| v1.0 | #60–69, #89, #91–93 | Bench, docs, streaming, SSG, CSP, sitemap, image opt, deploy adapters |
-| v1.1 | #70–75 | LLM tooling: `llms.txt`, MCP server, AI templates, provenance |
-| Standalone | #94 | RFC: explicit non-goals |
+| MVP | 42 | Foundation RFCs + setup, parser, codegen, runtime, router, CLI to render a page |
+| v0.2 | 15 | Layouts, hooks, error boundaries, form actions, route groups, page options, env |
+| v0.3 | 21 | Vite client, hydration, SPA router, `$app/navigation`, Snapshot, kit.Link, kit.Asset |
+| v0.4 | 19 | Svelte 5 full coverage, a11y, `<svelte:options>` |
+| v0.5 | 23 | SvelteKit parity catch-up: `SSROnly`, `RedirectReload`, `LoadCtx.Header/RawParam`, `Init` error fallbacks, `--release` strip, `HTTPError` interface |
+| v0.6 | 40 | Authentication: cookie-session library, `Handle[T]` middleware, session playground, docs |
+| v1.0 | 25 | Bench, docs, streaming, SSG, CSP, sitemap, image opt, deploy adapters |
+| v1.1 | 6 | LLM tooling: `llms.txt`, MCP server, AI templates, provenance |
 
 ## Issue conventions
 
@@ -252,8 +249,8 @@ through `go/parser` directly. See ADR 0003 amendment (Phase 0i-fix).
 
 ## Workflow notes
 
-- The repo is on `main` only. Push directly after a clean commit; no PR flow yet.
-- Commits use a short imperative subject. Recent style: `docs: track 19 SvelteKit-parity gap issues across milestones`.
+- Work happens on feature branches; PRs merge into `main`. Conventional Commits format per RFC #99.
+- Commits use a short imperative subject. Scope = package name (`sveltego`, `kit`, `codegen`, `router`, `docs`, …).
 - When adding a new lesson to `tasks/lessons.md`, append a dated section — never rewrite older entries.
 - When the issue list expands, also update `README.md` milestones table and `tasks/todo.md` milestone counts in the same commit.
 

--- a/README.md
+++ b/README.md
@@ -62,17 +62,18 @@ Field names are PascalCase (Go exported). `nil` not `null`, `len(x)` not `x.leng
 
 ## Roadmap
 
-6 milestones, 105 issues tracked on GitHub:
+8 milestones tracked on GitHub:
 
 | Milestone | Issues | Scope |
 |-----------|--------|-------|
-| **MVP** | 37 | Foundation RFCs (#95–97) + setup (#98–105: lint, hooks, release-please, CI, PR template, AI sync, golden tests, bench gate), parser, codegen, runtime, router (incl. param matchers, optional/rest), `$lib` alias, CLI |
+| **MVP** | 42 | Foundation RFCs (#95–97) + setup (#98–105: lint, hooks, release-please, CI, PR template, AI sync, golden tests, bench gate), parser, codegen, runtime, router (incl. param matchers, optional/rest), `$lib` alias, CLI |
 | **v0.2** | 15 | Layouts, hooks (incl. `Reroute`/`Init`), error boundaries, form actions, cookies, route groups, page options, `$env` |
-| **v0.3** | 13 | Vite client bundle, hydration, SPA router, full `$app/navigation`, Snapshot, typed `kit.Link`, hashed `kit.Asset`, dev server |
+| **v0.3** | 21 | Vite client bundle, hydration, SPA router, full `$app/navigation`, Snapshot, typed `kit.Link`, hashed `kit.Asset`, dev server |
 | **v0.4** | 19 | Svelte 5 runes, slots, snippets, special elements, `<svelte:options>`, scoped CSS, a11y warnings |
-| **v1.0** | 14 | Benchmarks, docs, examples, streaming/SSG/CSP, sitemap, image opt, deploy adapters, CI/release/LSP, service worker |
+| **v0.5** | 23 | SvelteKit parity catch-up: `SSROnly`, `RedirectReload`, `LoadCtx.Header/RawParam`, `Init` error fallbacks, `--release` strip, `HTTPError` interface |
+| **v0.6** | 40 | Authentication: cookie-session library, `Handle[T]` middleware, session playground, docs |
+| **v1.0** | 25 | Benchmarks, docs, examples, streaming/SSG/CSP, sitemap, image opt, deploy adapters, CI/release/LSP, service worker |
 | **v1.1** | 6 | LLM tooling: `llms.txt`, MCP server, copy-for-LLM, AI templates, provenance |
-| Standalone | 1 | RFC #94: explicit non-goals (universal load, WS, vercel adapter) |
 
 ## See also
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -31,7 +31,7 @@ hello/
   src/
     routes/
       +page.svelte
-      +page.server.go      # //go:build sveltego
+      page.server.go       # //go:build sveltego
     hooks.server.go        # //go:build sveltego (optional)
     lib/                   # $lib alias target
   go.mod
@@ -53,7 +53,7 @@ hello/
 <h1>{Data.Greeting}</h1>
 ```
 
-`src/routes/+page.server.go`:
+`src/routes/page.server.go`:
 
 ```go
 //go:build sveltego

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
   - title: Pure Go server
     details: .svelte templates compile to .gen/*.go. No goja, v8go, or Bun on the request path.
   - title: Familiar conventions
-    details: +page.svelte, +page.server.go, +layout.svelte, +error.svelte, hooks.server.go. Same shape as SvelteKit.
+    details: +page.svelte, page.server.go, +layout.svelte, +error.svelte, hooks.server.go. Same shape as SvelteKit.
   - title: Go expressions
     details: '{Data.User.Name}, {len(Data.Posts)}, nil not null. Validated at codegen via go/parser.'
   - title: Svelte 5 runes

--- a/docs/reference/kit.md
+++ b/docs/reference/kit.md
@@ -16,7 +16,7 @@ This page summarises the surface. Source is the canonical spec; godoc is generat
 |---|---|---|
 | `RequestEvent` | hooks, `+server.go`, actions | Request-scoped state with `URL`, `Params`, `Locals`, `Cookies`. |
 | `RenderCtx` | generated render code | SSR-time context passed into templates. |
-| `LoadCtx` | `Load` in `+page.server.go`, `+layout.server.go` | Load-time context with `Parent()` for layout chain. |
+| `LoadCtx` | `Load` in `page.server.go`, `layout.server.go` | Load-time context with `Parent()` for layout chain. |
 
 `RequestEvent.Fetch(req)` dispatches outbound HTTP through `HandleFetch`.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,7 +22,7 @@ The effort is comparable but the rewrite trade buys us performance, deploy simpl
 
 Tracked as GitHub milestones at `binsarjr/sveltego`. Each issue carries Summary, Background, Goals, Non-Goals, Detailed Design, Acceptance Criteria, Testing Strategy, Risks, Dependencies, References.
 
-### MVP (37 issues) — minimum to render a page
+### MVP (42 issues) — minimum to render a page
 
 Foundation layer first: monorepo layout RFC (#95), code style + stability RFCs (#96, #97), lint + hooks + release-please + CI + PR template + AI doc sync + golden tests + bench gate (#98–105). Then technical RFCs (parser strategy, expression syntax, file convention, codegen layout — #1–4), then bootstrap (Go module, CLI), then the core pipeline:
 
@@ -39,7 +39,7 @@ Foundation layer first: monorepo layout RFC (#95), code style + stability RFCs (
 
 Layout chain rendering, `layout.server.go` parent data flow, `Handle` / `HandleError` / `HandleFetch` / `Reroute` / `Init`, `+error.svelte` boundaries, `server.go` REST endpoints, `Actions()` map with form binding (urlencoded + multipart), `kit.Cookies`, `kit.Redirect / Fail / Error` sentinel helpers, route groups `(group)/` + layout reset `@`, page options (`Prerender`, `SSR`, `CSR`, `TrailingSlash`), env var convention (`$env/static`, `$env/dynamic`).
 
-### v0.3 (13 issues) — Client SPA & Hydration
+### v0.3 (21 issues) — Client SPA & Hydration
 
 Vite integration for the Svelte client bundle, `window.__sveltego__` hydration payload, client hydrate runtime, SPA router (link interception + history), `__data.json` per-route endpoint, `use:enhance` for forms, prefetch on hover/viewport, precompressed static asset serving, `sveltego dev` with HMR. Full `$app/navigation` API (`goto`, `invalidate`, `preload`, `pushState`), Snapshot API for cross-nav state, typed `kit.Link` with route params, `kit.Asset` with hashed static URLs.
 
@@ -47,9 +47,17 @@ Vite integration for the Svelte client bundle, `window.__sveltego__` hydration p
 
 Runes: `$props`, `$state`, `$derived`, `$effect`, `$bindable`. Snippets and `{@render}`. Legacy slots (default + named, with slot props). Special elements: `<svelte:head>`, `<svelte:body>` / `<svelte:window>` / `<svelte:document>`, `<svelte:component>`, `<svelte:options>`. CSS scope hash matching upstream. `{@html}`, `{@const}`, `{#await}`, `{#key}`. Nested component import and rendering. Compile-time a11y warnings.
 
-### v1.0 (14 issues) — Production Ready
+### v0.5 (23 issues) — SvelteKit Parity Catch-up
 
-Benchmark suite vs adapter-bun with nightly regression gate. Docs site (Vitepress). Blog and dashboard examples. Streaming responses. Prerender / SSG mode. CSP nonce injection. CI (GitHub Actions). Release pipeline (release-please + GoReleaser). LSP for `.svelte` with Go expressions. Sitemap/robots helpers, image optimization (`<Image>`), service worker convention, deploy adapters (server, docker, static, lambda, cloudflare).
+Parity issues backported from upstream SvelteKit: `SSROnly` page option (forbid `__data.json` scrape), `RedirectReload` force-reload redirect, `LoadCtx.Header()` Set/Add semantics, `LoadCtx.RawParam()` for un-decoded params, `Init()` error with pending fallback pages, `--release` / `SVELTEGO_RELEASE=1` to strip `src/lib/dev/`, `kit.HTTPError` interface for typed status mapping, `kit.Error` default message via `http.StatusText`, route scanner ignoring test files, preserve headers/cookies on error responses. Also: cookie-session auth library foundations (#195–#203).
+
+### v0.6 (40 issues) — Authentication
+
+`packages/auth/cookiesession`: crypto core (AES-256-GCM, secret rotation), `Session[T]` struct, `Handle[T]` middleware factory, `From[T]` accessor, counter playground, docs page (API + threat model + rotation playbook). Full bench harness vs upstream better-auth.
+
+### v1.0 (25 issues) — Production Ready
+
+Benchmark suite vs adapter-bun with nightly regression gate. Docs site (Vitepress). Blog and dashboard examples. Streaming responses. Prerender / SSG mode. CSP nonce injection. CI (GitHub Actions). Release pipeline (release-please + GoReleaser). LSP for `.svelte` with Go expressions. Sitemap/robots helpers, image optimization (`<Image>`), service worker convention, deploy adapters (server, docker, static, lambda, cloudflare). Tailwind v4 migration for examples.
 
 ### v1.1 (6 issues) — LLM & AI Tooling
 
@@ -74,7 +82,7 @@ Benchmark suite vs adapter-bun with nightly regression gate. Docs site (Vitepres
 - [x] Direction confirmed (Go-native rewrite, not JS embed)
 - [x] Repo created at `binsarjr/sveltego`
 - [x] Issue templates (feature, RFC, bug)
-- [x] 20 labels, 6 milestones, 105 issues created
+- [x] 20 labels, 8 milestones created (v0.5 + v0.6 added post-MVP)
 - [x] All 69 original issues rewritten in English with industry-standard detail
 - [x] v1.1 milestone added — LLM & AI tooling (#70–75)
 - [x] SvelteKit-parity gap audit + 19 issues filed with priorities (#76–94)


### PR DESCRIPTION
## Drift fixes per file

### README.md
- Milestone table: 37→42 (MVP), 13→21 (v0.3), 14→25 (v1.0); removed stale Standalone row; added v0.5 (23 issues — SvelteKit parity) and v0.6 (40 issues — authentication)
- "6 milestones, 105 issues" → "8 milestones" (no total count claim; GitHub is authoritative)

### CLAUDE.md
- "Repository state: No Go source yet" — replaced with accurate description (MVP shipped, v0.5/v0.6 active)
- Roadmap table: same count fixes + v0.5/v0.6 rows added
- Workflow notes: "repo is on main only, push directly" → PR flow is now the norm

### AGENTS.md
- §1: "No Go source has landed yet" — replaced with accurate repo state

### tasks/todo.md
- Milestone headers: MVP 37→42, v0.3 13→21, v1.0 14→25
- Phase tracking: "6 milestones, 105 issues" → "8 milestones"
- Added v0.5 and v0.6 milestone scope sections

### docs/guide/quickstart.md
- Scaffold tree and code block: `+page.server.go` → `page.server.go` (Go server files have no `+` prefix per Phase 0i-fix; only `.svelte` files use the `+` prefix)

### docs/index.md
- Feature details: `+page.server.go` → `page.server.go`

### docs/reference/kit.md
- `LoadCtx` context table: `+page.server.go`, `+layout.server.go` → `page.server.go`, `layout.server.go`

## Files verified clean (no drift)
- `tasks/lessons.md` — still the monolithic journal on main; #287 split hasn't landed on main yet. No change needed.
- `docs/reference/kit.md` API surface — matches actual `packages/sveltego/exports/kit/` on main.
- Wave 5+6 new APIs (HTTPError, RawParam, SSROnly, HeaderWriter, RedirectReload, Init error, --release) are NOT on main yet; docs correctly omit them.

No issue closure — pure doc maintenance.