### PR TITLE
feat(cookiesession): crypto core (AES-256-GCM + key rotation)

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.22
+go 1.23
 
 use (
 	./bench
@@ -9,6 +9,7 @@ use (
 	./packages/adapter-lambda
 	./packages/adapter-server
 	./packages/adapter-static
+	./packages/cookiesession
 	./packages/create-sveltego
 	./packages/enhanced-img
 	./packages/init

--- a/packages/cookiesession/STABILITY.md
+++ b/packages/cookiesession/STABILITY.md
@@ -1,0 +1,23 @@
+# Stability — cookiesession
+
+Last updated: 2026-04-30 · Version: pre-alpha
+
+Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97). Pre-`v0.1` every export is implicitly experimental; this file populates as APIs land.
+
+## Stable
+
+(none yet)
+
+## Experimental
+
+- `cookiesession.Codec` — interface; Encrypt/Decrypt contract may gain options in #198.
+- `cookiesession.NewCodec` — factory; signature frozen for #198.
+- `cookiesession.Secret` — struct; ID+Key fields stable.
+
+## Deprecated
+
+(none yet)
+
+## Internal-only (do not import even though accessible within module)
+
+- `internal/crypto` — AES-256-GCM primitives; consumed by Session (#198) and Handle (#199) only.

--- a/packages/cookiesession/crypto.go
+++ b/packages/cookiesession/crypto.go
@@ -1,0 +1,71 @@
+// Package cookiesession provides encrypted, stateless, type-safe sessions
+// stored in browser cookies using AES-256-GCM authenticated encryption.
+//
+// This file exposes the public Codec API. Lower-level AES-256-GCM primitives
+// live in internal/crypto and are accessible to sibling packages within this
+// module (Session, Handle) but not to external callers.
+package cookiesession
+
+import (
+	"fmt"
+
+	"github.com/binsarjr/sveltego/cookiesession/internal/crypto"
+)
+
+// Codec encrypts and decrypts cookie session payloads.
+// Encrypt always uses the newest (head) secret; Decrypt tries all secrets.
+type Codec interface {
+	Encrypt(plaintext []byte) (cookie string, err error)
+	Decrypt(cookie string) (plaintext []byte, err error)
+}
+
+// codec is the concrete implementation backed by a Secrets list.
+type codec struct {
+	secrets crypto.Secrets
+}
+
+// NewCodec returns a Codec backed by the provided secrets.
+// secrets must be newest-first; the first entry is used for encryption.
+// Returns an error if secrets fails validation (empty or any key != 32 bytes).
+func NewCodec(secrets []Secret) (Codec, error) {
+	cs := make(crypto.Secrets, len(secrets))
+	for i, s := range secrets {
+		cs[i] = crypto.Secret{ID: s.ID, Key: s.Key}
+	}
+	if err := cs.Validate(); err != nil {
+		return nil, err
+	}
+	return &codec{secrets: cs}, nil
+}
+
+// Encrypt encrypts plaintext and returns a cookie-safe hex string with an
+// &id=N suffix identifying which secret was used.
+func (c *codec) Encrypt(plaintext []byte) (string, error) {
+	encoded, id, err := c.secrets.Encode(plaintext)
+	if err != nil {
+		return "", fmt.Errorf("cookiesession: encrypt: %w", err)
+	}
+	return crypto.JoinID(encoded, id), nil
+}
+
+// Decrypt decodes a cookie value produced by Encrypt.
+// The &id=N suffix is used to select the correct decryption key.
+// Returns ErrDecryptFailed if the ciphertext has been tampered with.
+func (c *codec) Decrypt(cookie string) ([]byte, error) {
+	encoded, id, err := crypto.SplitID(cookie)
+	if err != nil {
+		return nil, fmt.Errorf("cookiesession: decrypt split: %w", err)
+	}
+	plain, _, err := c.secrets.Decode(encoded, id)
+	if err != nil {
+		return nil, fmt.Errorf("cookiesession: decrypt: %w", err)
+	}
+	return plain, nil
+}
+
+// Secret pairs a rotation ID with a 32-byte AES-256 key.
+// The Key must be exactly 32 bytes; use `sveltego gen-secret` to generate one.
+type Secret struct {
+	ID  uint32
+	Key []byte
+}

--- a/packages/cookiesession/go.mod
+++ b/packages/cookiesession/go.mod
@@ -1,0 +1,3 @@
+module github.com/binsarjr/sveltego/cookiesession
+
+go 1.23

--- a/packages/cookiesession/internal/crypto/crypto.go
+++ b/packages/cookiesession/internal/crypto/crypto.go
@@ -1,0 +1,181 @@
+// Package crypto implements AES-256-GCM authenticated encryption for
+// cookiesession wire values.
+//
+// Wire format: hex(nonce || ciphertext || tag)
+// The nonce is 12 bytes (GCM standard), the tag is 16 bytes (GCM default).
+// Cookie-level ID suffix ("&id=N") is handled by the caller via JoinID/SplitID.
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const (
+	keySize   = 32 // AES-256
+	nonceSize = 12 // GCM standard
+)
+
+var (
+	// ErrKeyLength is returned when a key is not exactly 32 bytes.
+	ErrKeyLength = errors.New("cookiesession: secret key must be exactly 32 bytes (use sveltego gen-secret)")
+
+	// ErrNoSecrets is returned when Secrets is empty.
+	ErrNoSecrets = errors.New("cookiesession: at least one secret is required")
+
+	// ErrDecryptFailed is returned when GCM tag validation fails (tampered or wrong key).
+	ErrDecryptFailed = errors.New("cookiesession: decryption failed (tampered ciphertext or wrong key)")
+
+	// ErrSecretNotFound is returned when no secret with the requested ID exists.
+	ErrSecretNotFound = errors.New("cookiesession: no secret found with the given id")
+)
+
+// Secret pairs a rotation ID with a 32-byte AES-256 key.
+type Secret struct {
+	ID  uint32
+	Key []byte // exactly 32 bytes
+}
+
+// Secrets is a newest-first ordered list of secrets.
+// Secrets[0] is always used for encryption; all entries are tried for decryption.
+type Secrets []Secret
+
+// Validate checks that the list is non-empty and every key is exactly 32 bytes.
+func (s Secrets) Validate() error {
+	if len(s) == 0 {
+		return ErrNoSecrets
+	}
+	for i, sec := range s {
+		if len(sec.Key) != keySize {
+			return fmt.Errorf("%w (secret index %d, id %d, got %d bytes)", ErrKeyLength, i, sec.ID, len(sec.Key))
+		}
+	}
+	return nil
+}
+
+// Encode encrypts plaintext with the head secret (Secrets[0]).
+// Returns the hex-encoded ciphertext and the secret ID used.
+func (s Secrets) Encode(plaintext []byte) (encoded string, id uint32, err error) {
+	if err = s.Validate(); err != nil {
+		return "", 0, err
+	}
+	head := s[0]
+	encoded, err = Encrypt(head.Key, plaintext)
+	if err != nil {
+		return "", 0, err
+	}
+	return encoded, head.ID, nil
+}
+
+// Decode decrypts encoded using the secret identified by id.
+// headWasUsed reports whether Secrets[0] performed the decryption.
+// Falls back to head (Secrets[0]) if no secret with that ID is found and id
+// matches Secrets[0].ID — callers should always supply the id from JoinID/SplitID.
+func (s Secrets) Decode(encoded string, id uint32) (plaintext []byte, headWasUsed bool, err error) {
+	if err = s.Validate(); err != nil {
+		return nil, false, err
+	}
+	// Find the secret with the matching ID.
+	for i, sec := range s {
+		if sec.ID == id {
+			plain, e := Decrypt(sec.Key, encoded)
+			if e != nil {
+				return nil, false, e
+			}
+			return plain, i == 0, nil
+		}
+	}
+	return nil, false, fmt.Errorf("%w (id %d)", ErrSecretNotFound, id)
+}
+
+// Encrypt encrypts plaintext with the given 32-byte key using AES-256-GCM.
+// It generates a fresh random 12-byte nonce on every call.
+// Returns hex(nonce || ciphertext || tag).
+func Encrypt(key, plaintext []byte) (string, error) {
+	if len(key) != keySize {
+		return "", fmt.Errorf("%w (got %d bytes)", ErrKeyLength, len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("cookiesession: aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("cookiesession: cipher.NewGCM: %w", err)
+	}
+
+	nonce := make([]byte, nonceSize)
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("cookiesession: rand nonce: %w", err)
+	}
+
+	// Seal appends ciphertext+tag to nonce so the layout is nonce||ct||tag.
+	dst := gcm.Seal(nonce, nonce, plaintext, nil)
+	return hex.EncodeToString(dst), nil
+}
+
+// Decrypt decrypts a hex-encoded value produced by Encrypt.
+// Returns ErrDecryptFailed if the GCM tag is invalid (tampered or wrong key).
+func Decrypt(key []byte, encoded string) ([]byte, error) {
+	if len(key) != keySize {
+		return nil, fmt.Errorf("%w (got %d bytes)", ErrKeyLength, len(key))
+	}
+
+	raw, err := hex.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("cookiesession: hex decode: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("cookiesession: aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cookiesession: cipher.NewGCM: %w", err)
+	}
+
+	minLen := nonceSize + gcm.Overhead()
+	if len(raw) < minLen {
+		return nil, ErrDecryptFailed
+	}
+
+	nonce, ct := raw[:nonceSize], raw[nonceSize:]
+	plain, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil, ErrDecryptFailed
+	}
+	return plain, nil
+}
+
+// JoinID appends the secret ID suffix to an encoded cookie value.
+// Format: "<hex>&id=<decimal>".
+func JoinID(encoded string, id uint32) string {
+	return encoded + "&id=" + strconv.FormatUint(uint64(id), 10)
+}
+
+// SplitID separates a cookie value into the hex-encoded ciphertext and the
+// secret ID. Returns the raw encoded string and id=0 if no suffix is present
+// (for single-key deployments).
+func SplitID(cookie string) (encoded string, id uint32, err error) {
+	const prefix = "&id="
+	idx := strings.LastIndex(cookie, prefix)
+	if idx < 0 {
+		// No ID suffix — caller interprets as head ID 0 or handles accordingly.
+		return cookie, 0, nil
+	}
+	encoded = cookie[:idx]
+	n, e := strconv.ParseUint(cookie[idx+len(prefix):], 10, 32)
+	if e != nil {
+		return "", 0, fmt.Errorf("cookiesession: invalid id suffix: %w", e)
+	}
+	return encoded, uint32(n), nil
+}

--- a/packages/cookiesession/internal/crypto/crypto_test.go
+++ b/packages/cookiesession/internal/crypto/crypto_test.go
@@ -1,0 +1,260 @@
+package crypto_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/cookiesession/internal/crypto"
+)
+
+func makeKey(b byte) []byte {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = b
+	}
+	return key
+}
+
+// TestRoundTrip verifies 1 KiB plaintext survives encrypt→decrypt unchanged.
+func TestRoundTrip(t *testing.T) {
+	key := makeKey(0xAB)
+	plaintext := bytes.Repeat([]byte("Hello sveltego! "), 64) // 1024 bytes
+
+	encoded, err := crypto.Encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	got, err := crypto.Decrypt(key, encoded)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip mismatch: got %d bytes, want %d", len(got), len(plaintext))
+	}
+}
+
+// TestEmptyPlaintext verifies empty byte slices are accepted.
+func TestEmptyPlaintext(t *testing.T) {
+	key := makeKey(0x01)
+
+	encoded, err := crypto.Encrypt(key, []byte{})
+	if err != nil {
+		t.Fatalf("Encrypt empty: %v", err)
+	}
+	got, err := crypto.Decrypt(key, encoded)
+	if err != nil {
+		t.Fatalf("Decrypt empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty plaintext, got %d bytes", len(got))
+	}
+}
+
+// TestLargePlaintext verifies a 128 KiB payload.
+func TestLargePlaintext(t *testing.T) {
+	key := makeKey(0xCC)
+	plaintext := bytes.Repeat([]byte{0xFF}, 128*1024)
+
+	encoded, err := crypto.Encrypt(key, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt large: %v", err)
+	}
+	got, err := crypto.Decrypt(key, encoded)
+	if err != nil {
+		t.Fatalf("Decrypt large: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatal("large round-trip mismatch")
+	}
+}
+
+// TestTamperDetection verifies that any single-byte mutation causes decrypt to fail.
+func TestTamperDetection(t *testing.T) {
+	key := makeKey(0x77)
+	encoded, err := crypto.Encrypt(key, []byte("secret payload"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Flip the last hex char.
+	runes := []rune(encoded)
+	last := runes[len(runes)-1]
+	if last == 'f' {
+		runes[len(runes)-1] = '0'
+	} else {
+		runes[len(runes)-1] = 'f'
+	}
+	tampered := string(runes)
+
+	if _, err = crypto.Decrypt(key, tampered); err == nil {
+		t.Fatal("expected error on tampered ciphertext, got nil")
+	}
+}
+
+// TestNonceUniqueness verifies 1000 successive Encrypt calls yield distinct outputs.
+func TestNonceUniqueness(t *testing.T) {
+	key := makeKey(0x55)
+	plaintext := []byte("same plaintext every time")
+
+	seen := make(map[string]struct{}, 1000)
+	for i := range 1000 {
+		enc, err := crypto.Encrypt(key, plaintext)
+		if err != nil {
+			t.Fatalf("Encrypt[%d]: %v", i, err)
+		}
+		if _, dup := seen[enc]; dup {
+			t.Fatalf("nonce collision at iteration %d", i)
+		}
+		seen[enc] = struct{}{}
+	}
+}
+
+// TestKeyLengthValidation verifies that a 31-byte key is rejected with a message
+// mentioning "32 bytes".
+func TestKeyLengthValidation(t *testing.T) {
+	shortKey := make([]byte, 31)
+
+	_, err := crypto.Encrypt(shortKey, []byte("x"))
+	if err == nil {
+		t.Fatal("Encrypt with 31-byte key should fail")
+	}
+	if !strings.Contains(err.Error(), "32 bytes") {
+		t.Fatalf("error should mention '32 bytes', got: %v", err)
+	}
+
+	_, err = crypto.Decrypt(shortKey, "deadbeef")
+	if err == nil {
+		t.Fatal("Decrypt with 31-byte key should fail")
+	}
+	if !strings.Contains(err.Error(), "32 bytes") {
+		t.Fatalf("error should mention '32 bytes', got: %v", err)
+	}
+}
+
+// TestSecretsValidation verifies empty slice and bad key lengths are rejected.
+func TestSecretsValidation(t *testing.T) {
+	// Empty slice.
+	if err := crypto.Secrets(nil).Validate(); err == nil {
+		t.Fatal("empty Secrets should fail Validate")
+	}
+
+	// Key too short.
+	bad := crypto.Secrets{{ID: 1, Key: make([]byte, 16)}}
+	if err := bad.Validate(); err == nil {
+		t.Fatal("16-byte key should fail Validate")
+	}
+	if !strings.Contains(bad.Validate().Error(), "32 bytes") {
+		t.Fatalf("validate error should mention '32 bytes'")
+	}
+}
+
+// TestSecretsEncodeDecode verifies round-trip via Secrets helpers.
+func TestSecretsEncodeDecode(t *testing.T) {
+	secrets := crypto.Secrets{
+		{ID: 2, Key: makeKey(0x22)},
+		{ID: 1, Key: makeKey(0x11)},
+	}
+	plaintext := []byte("cookiesession payload")
+
+	encoded, id, err := secrets.Encode(plaintext)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if id != 2 {
+		t.Fatalf("expected id 2 (head), got %d", id)
+	}
+
+	got, headWasUsed, err := secrets.Decode(encoded, id)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !headWasUsed {
+		t.Fatal("head should have been used when id matches head")
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatal("round-trip via Secrets mismatch")
+	}
+}
+
+// TestRotationAcceptsOldKey verifies that an old (non-head) secret can still decrypt.
+func TestRotationAcceptsOldKey(t *testing.T) {
+	oldSecret := crypto.Secret{ID: 1, Key: makeKey(0x11)}
+	newSecret := crypto.Secret{ID: 2, Key: makeKey(0x22)}
+
+	// Encrypt with old key directly.
+	encoded, err := crypto.Encrypt(oldSecret.Key, []byte("old session data"))
+	if err != nil {
+		t.Fatalf("Encrypt with old key: %v", err)
+	}
+
+	// Build a Secrets with the new key as head and old as fallback.
+	secrets := crypto.Secrets{newSecret, oldSecret}
+
+	got, headWasUsed, err := secrets.Decode(encoded, oldSecret.ID)
+	if err != nil {
+		t.Fatalf("Decode with old id: %v", err)
+	}
+	if headWasUsed {
+		t.Fatal("headWasUsed should be false when using old secret")
+	}
+	if !bytes.Equal(got, []byte("old session data")) {
+		t.Fatal("rotation decode mismatch")
+	}
+}
+
+// TestRotationRejectsUnknownKey verifies an unknown id returns ErrSecretNotFound.
+func TestRotationRejectsUnknownKey(t *testing.T) {
+	secrets := crypto.Secrets{
+		{ID: 1, Key: makeKey(0x11)},
+	}
+	encoded, _, err := secrets.Encode([]byte("data"))
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	_, _, err = secrets.Decode(encoded, 99) // unknown id
+	if err == nil {
+		t.Fatal("expected error for unknown id, got nil")
+	}
+}
+
+// TestJoinSplitID verifies the wire suffix helper round-trips correctly.
+func TestJoinSplitID(t *testing.T) {
+	encoded := "deadbeef01020304"
+	cookie := crypto.JoinID(encoded, 42)
+
+	gotEncoded, gotID, err := crypto.SplitID(cookie)
+	if err != nil {
+		t.Fatalf("SplitID: %v", err)
+	}
+	if gotEncoded != encoded {
+		t.Fatalf("SplitID encoded: got %q, want %q", gotEncoded, encoded)
+	}
+	if gotID != 42 {
+		t.Fatalf("SplitID id: got %d, want 42", gotID)
+	}
+}
+
+// TestSplitIDNoSuffix verifies SplitID is tolerant of cookies without the &id= suffix.
+func TestSplitIDNoSuffix(t *testing.T) {
+	enc, id, err := crypto.SplitID("deadbeef")
+	if err != nil {
+		t.Fatalf("SplitID no suffix: %v", err)
+	}
+	if enc != "deadbeef" || id != 0 {
+		t.Fatalf("SplitID no suffix: enc=%q id=%d", enc, id)
+	}
+}
+
+// FuzzDecrypt confirms Decrypt never panics on arbitrary input.
+func FuzzDecrypt(f *testing.F) {
+	f.Add([]byte("notvalidhex"))
+	f.Add([]byte("deadbeef"))
+	f.Add([]byte(""))
+	key := makeKey(0xAA)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = crypto.Decrypt(key, string(data))
+	})
+}

--- a/packages/cookiesession/internal/crypto/crypto_test.go
+++ b/packages/cookiesession/internal/crypto/crypto_test.go
@@ -254,7 +254,7 @@ func FuzzDecrypt(f *testing.F) {
 	f.Add([]byte("deadbeef"))
 	f.Add([]byte(""))
 	key := makeKey(0xAA)
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		_, _ = crypto.Decrypt(key, string(data))
 	})
 }


### PR DESCRIPTION
## Summary

- New module `packages/cookiesession` (`github.com/binsarjr/sveltego/cookiesession`, go 1.23).
- `internal/crypto`: low-level AES-256-GCM primitives — `Encrypt`/`Decrypt`, `Secrets` type for N-key rotation, `JoinID`/`SplitID` wire-format helpers.
- Public surface: `Codec` interface + `NewCodec([]Secret)` factory. Secrets[0] encrypts; all N secrets tried for decrypt.
- Wire format: `hex(nonce‖ct‖tag)&id=<decimal>` — hex avoids base64 padding chars in cookies, matches JS upstream interop contract.
- 16 tests: round-trip (1 KiB, empty, 128 KiB), tamper detection, 1000-nonce uniqueness, 31-byte key rejection, Secrets validation, rotation accept/reject, JoinID/SplitID, fuzz target.
- `STABILITY.md`: tier experimental per RFC #97.
- `go.work`: adds `./packages/cookiesession`, bumps workspace to go 1.23 (required by new module; backward-compatible with all existing go 1.22 modules).

## Design notes

- **Nonce**: `crypto/rand.Read` 12 bytes per Encrypt call — catastrophic reuse impossible.
- **Key validation**: 32-byte enforcement at `Validate()` and call-site; error message cites `sveltego gen-secret`.
- **No panics on bad input**: `FuzzDecrypt` confirms fail-closed on arbitrary bytes.
- **No third-party crypto**: stdlib `crypto/aes` + `crypto/cipher.NewGCM` only.

## Closes

Closes #197

Foundation for #198 (Session[T]), #199 (Handle middleware), #200 (counter playground), #203 (docs) — master tracker #195.