### PR TITLE
feat(kit): Cron scheduled tasks convention

### DIFF
--- a/packages/sveltego/exports/kit/cron.go
+++ b/packages/sveltego/exports/kit/cron.go
@@ -1,0 +1,70 @@
+package kit
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CronTask declares a scheduled task the server runs in the background.
+// Spec must be one of the supported shorthand forms: @every <duration>,
+// @hourly, @daily, or @weekly. Fn receives a context that is cancelled
+// when the server shuts down; errors are logged but do not stop the loop.
+// Name is optional and used only in log output.
+type CronTask struct {
+	Name string
+	Spec string
+	Fn   func(ctx context.Context) error
+}
+
+// ParseSchedule converts a spec string into the interval between runs.
+// Supported forms:
+//
+//	@every <duration>  — any duration parseable by time.ParseDuration
+//	@hourly            — 1 hour
+//	@daily             — 24 hours
+//	@weekly            — 7 days
+//
+// Full crontab syntax is not supported; use @every for arbitrary intervals.
+func ParseSchedule(spec string) (time.Duration, error) {
+	spec = strings.TrimSpace(spec)
+	switch spec {
+	case "@hourly":
+		return time.Hour, nil
+	case "@daily":
+		return 24 * time.Hour, nil
+	case "@weekly":
+		return 7 * 24 * time.Hour, nil
+	}
+	after, ok := strings.CutPrefix(spec, "@every ")
+	if !ok {
+		return 0, fmt.Errorf("kit: unsupported cron spec %q; use @every <duration>, @hourly, @daily, or @weekly", spec)
+	}
+	// Allow both pure duration strings ("5s") and unit-only shorthand ("5m").
+	// time.ParseDuration handles those already; attempt an integer-only value
+	// for the rare case where users omit units, which we reject with a clear message.
+	d, err := parseDurationOrBare(strings.TrimSpace(after))
+	if err != nil {
+		return 0, fmt.Errorf("kit: invalid @every duration %q: %w", after, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("kit: @every duration must be positive, got %q", after)
+	}
+	return d, nil
+}
+
+// parseDurationOrBare wraps time.ParseDuration and tries to surface a clean
+// error for a bare integer (missing unit) rather than a cryptic parse failure.
+func parseDurationOrBare(s string) (time.Duration, error) {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		// If the string looks like a plain integer, hint the user.
+		if _, intErr := strconv.ParseInt(s, 10, 64); intErr == nil {
+			return 0, fmt.Errorf("%w (did you mean %ss?)", err, s)
+		}
+		return 0, err
+	}
+	return d, nil
+}

--- a/packages/sveltego/exports/kit/cron.go
+++ b/packages/sveltego/exports/kit/cron.go
@@ -2,7 +2,7 @@ package kit
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -40,17 +40,17 @@ func ParseSchedule(spec string) (time.Duration, error) {
 	}
 	after, ok := strings.CutPrefix(spec, "@every ")
 	if !ok {
-		return 0, fmt.Errorf("kit: unsupported cron spec %q; use @every <duration>, @hourly, @daily, or @weekly", spec)
+		return 0, errors.New("kit: unsupported cron spec " + strconv.Quote(spec) + "; use @every <duration>, @hourly, @daily, or @weekly")
 	}
 	// Allow both pure duration strings ("5s") and unit-only shorthand ("5m").
 	// time.ParseDuration handles those already; attempt an integer-only value
 	// for the rare case where users omit units, which we reject with a clear message.
 	d, err := parseDurationOrBare(strings.TrimSpace(after))
 	if err != nil {
-		return 0, fmt.Errorf("kit: invalid @every duration %q: %w", after, err)
+		return 0, errors.New("kit: invalid @every duration " + strconv.Quote(after) + ": " + err.Error())
 	}
 	if d <= 0 {
-		return 0, fmt.Errorf("kit: @every duration must be positive, got %q", after)
+		return 0, errors.New("kit: @every duration must be positive, got " + strconv.Quote(after))
 	}
 	return d, nil
 }
@@ -62,7 +62,7 @@ func parseDurationOrBare(s string) (time.Duration, error) {
 	if err != nil {
 		// If the string looks like a plain integer, hint the user.
 		if _, intErr := strconv.ParseInt(s, 10, 64); intErr == nil {
-			return 0, fmt.Errorf("%w (did you mean %ss?)", err, s)
+			return 0, errors.New(err.Error() + " (did you mean " + s + "s?)")
 		}
 		return 0, err
 	}

--- a/packages/sveltego/exports/kit/cron_test.go
+++ b/packages/sveltego/exports/kit/cron_test.go
@@ -1,0 +1,55 @@
+package kit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+func TestParseSchedule(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		spec    string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"@hourly", time.Hour, false},
+		{"@daily", 24 * time.Hour, false},
+		{"@weekly", 7 * 24 * time.Hour, false},
+		{"@every 5s", 5 * time.Second, false},
+		{"@every 30m", 30 * time.Minute, false},
+		{"@every 2h", 2 * time.Hour, false},
+		{"@every 1h30m", 90 * time.Minute, false},
+		// whitespace tolerance
+		{"  @daily  ", 24 * time.Hour, false},
+		{"@every  10s", 10 * time.Second, false},
+		// errors
+		{"@every 0s", 0, true},
+		{"@every -5s", 0, true},
+		{"@every 42", 0, true},   // bare integer, no unit
+		{"@monthly", 0, true},    // unsupported shorthand
+		{"*/5 * * * *", 0, true}, // full crontab not supported
+		{"", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.spec, func(t *testing.T) {
+			t.Parallel()
+			got, err := kit.ParseSchedule(tc.spec)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSchedule(%q) = %v, want error", tc.spec, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSchedule(%q) error: %v", tc.spec, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseSchedule(%q) = %v, want %v", tc.spec, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/sveltego/server/cron.go
+++ b/packages/sveltego/server/cron.go
@@ -19,8 +19,8 @@ func runCronTasks(ctx context.Context, tasks []kit.CronTask, logger *slog.Logger
 		if err != nil {
 			logger.Error("server: cron task skipped — bad spec",
 				logKeyError, err.Error(),
-				"name", task.Name,
-				"spec", task.Spec,
+				logKeyName, task.Name,
+				logKeySpec, task.Spec,
 			)
 			continue
 		}
@@ -46,7 +46,7 @@ func runCronLoop(ctx context.Context, task kit.CronTask, interval time.Duration,
 			if err := task.Fn(ctx); err != nil {
 				logger.Error("server: cron task error",
 					logKeyError, err.Error(),
-					"name", name,
+					logKeyName, name,
 				)
 			}
 		}

--- a/packages/sveltego/server/cron.go
+++ b/packages/sveltego/server/cron.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+// runCronTasks starts one goroutine per task. Each goroutine fires the task
+// on its parsed interval and exits when ctx is cancelled. Errors from the
+// task function are logged via logger but do not stop the loop — a failing
+// task keeps retrying on its normal schedule. Tasks whose Spec fails to
+// parse are logged and skipped rather than aborting server startup.
+func runCronTasks(ctx context.Context, tasks []kit.CronTask, logger *slog.Logger) {
+	for _, task := range tasks {
+		interval, err := kit.ParseSchedule(task.Spec)
+		if err != nil {
+			logger.Error("server: cron task skipped — bad spec",
+				logKeyError, err.Error(),
+				"name", task.Name,
+				"spec", task.Spec,
+			)
+			continue
+		}
+		go runCronLoop(ctx, task, interval, logger)
+	}
+}
+
+// runCronLoop ticks at interval and calls task.Fn until ctx is done.
+func runCronLoop(ctx context.Context, task kit.CronTask, interval time.Duration, logger *slog.Logger) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	name := task.Name
+	if name == "" {
+		name = task.Spec
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := task.Fn(ctx); err != nil {
+				logger.Error("server: cron task error",
+					logKeyError, err.Error(),
+					"name", name,
+				)
+			}
+		}
+	}
+}

--- a/packages/sveltego/server/cron_test.go
+++ b/packages/sveltego/server/cron_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/runtime/router"
+)
+
+func TestCronTask_fires(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int64
+	srv, err := New(Config{
+		Routes: []router.Route{{Pattern: "/", Segments: segmentsFor("/"), Page: staticPage("x")}},
+		Shell:  testShell,
+		Logger: quietLogger(),
+		CronTasks: []kit.CronTask{
+			{
+				Name: "counter",
+				Spec: "@every 50ms",
+				Fn: func(_ context.Context) error {
+					count.Add(1)
+					return nil
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := srv.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Give the task enough time to fire at least 3 times.
+	time.Sleep(250 * time.Millisecond)
+
+	got := count.Load()
+	if got < 3 {
+		t.Fatalf("cron task fired %d times in 250ms, want ≥3", got)
+	}
+}
+
+func TestCronTask_stopsOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int64
+	srv, err := New(Config{
+		Routes: []router.Route{{Pattern: "/", Segments: segmentsFor("/"), Page: staticPage("x")}},
+		Shell:  testShell,
+		Logger: quietLogger(),
+		CronTasks: []kit.CronTask{
+			{
+				Spec: "@every 20ms",
+				Fn: func(_ context.Context) error {
+					count.Add(1)
+					return nil
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := srv.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Let it fire a few times.
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel via Shutdown (no http.Server bound, so Shutdown just cancels cron).
+	shutCtx, shutCancel := context.WithTimeout(context.Background(), time.Second)
+	defer shutCancel()
+	if err := srv.Shutdown(shutCtx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	after := count.Load()
+	// Give goroutines a short window to exit.
+	time.Sleep(80 * time.Millisecond)
+	final := count.Load()
+
+	// Counter must not keep climbing after shutdown.
+	if final > after+1 {
+		t.Fatalf("cron kept running after shutdown: count went from %d to %d", after, final)
+	}
+}
+
+func TestCronTask_badSpecSkipped(t *testing.T) {
+	t.Parallel()
+
+	// A task with a bad spec must not prevent the server from starting.
+	srv, err := New(Config{
+		Routes: []router.Route{{Pattern: "/", Segments: segmentsFor("/"), Page: staticPage("x")}},
+		Shell:  testShell,
+		Logger: quietLogger(),
+		CronTasks: []kit.CronTask{
+			{Spec: "*/5 * * * *", Fn: func(_ context.Context) error { return nil }},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Init must succeed even though the task spec is invalid.
+	if err := srv.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+}

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -21,6 +21,8 @@ const (
 	logKeyStatus   = "status"
 	logKeyLocation = "location"
 	logKeyFailCode = "fail_code"
+	logKeyName     = "name"
+	logKeySpec     = "spec"
 )
 
 // httpStatuser lets user errors carry a non-500 status into the

--- a/packages/sveltego/server/server.go
+++ b/packages/sveltego/server/server.go
@@ -82,6 +82,11 @@ type Config struct {
 	// after Init returns a non-nil error. An empty value falls back to a
 	// built-in error page.
 	InitErrorHTML string
+	// CronTasks is the optional list of scheduled background tasks. Each
+	// task starts a goroutine on server init that ticks at the parsed
+	// interval until the server shuts down. Tasks are skipped when their
+	// Spec fails to parse; the error is logged and startup continues.
+	CronTasks []kit.CronTask
 }
 
 // Server is the http.Handler implementation that drives a sveltego app.
@@ -91,6 +96,7 @@ type Server struct {
 	hooks         kit.Hooks
 	csp           kit.CSPConfig
 	streamTimeout time.Duration
+	cronTasks     []kit.CronTask
 
 	shellHead string
 	shellMid  string
@@ -109,8 +115,9 @@ type Server struct {
 	// initErrorHTML is served with 500 when Init returned an error.
 	initErrorHTML string
 
-	mu      sync.Mutex
-	httpSrv *http.Server
+	mu         sync.Mutex
+	httpSrv    *http.Server
+	cronCancel context.CancelFunc
 }
 
 // New validates cfg and returns a Server ready for use as an http.Handler.
@@ -165,6 +172,7 @@ func New(cfg Config) (*Server, error) {
 		hooks:           cfg.Hooks.WithDefaults(),
 		csp:             cfg.CSP,
 		streamTimeout:   streamTimeout,
+		cronTasks:       cfg.CronTasks,
 		shellHead:       head,
 		shellMid:        mid,
 		shellTail:       tail,
@@ -270,11 +278,11 @@ func (s *Server) RunInitAsync(ctx context.Context) {
 func (s *Server) runInitAsync(ctx context.Context, done chan struct{}) {
 	err := s.hooks.Init(ctx)
 	if err != nil {
-		logFn := s.Logger.Error
-		logFn("server: init hook failed", logKeyError, err.Error())
+		s.Logger.Error("server: init hook failed", logKeyError, err.Error())
 		s.initState.Store(initFailed)
 	} else {
 		s.initState.Store(initReady)
+		s.startCron(ctx)
 	}
 	close(done)
 }
@@ -293,6 +301,7 @@ func (s *Server) Init(ctx context.Context) error {
 	}
 	s.initState.Store(initReady)
 	close(done)
+	s.startCron(ctx)
 	return nil
 }
 
@@ -305,12 +314,31 @@ func writeInitFallback(w http.ResponseWriter, status int, body string) {
 	_, _ = w.Write([]byte(body))
 }
 
+// startCron derives a child context from parent and launches background
+// cron goroutines. It records the cancel func so Shutdown can stop them.
+// No-op when CronTasks is empty.
+func (s *Server) startCron(parent context.Context) {
+	if len(s.cronTasks) == 0 {
+		return
+	}
+	cronCtx, cancel := context.WithCancel(parent)
+	s.mu.Lock()
+	s.cronCancel = cancel
+	s.mu.Unlock()
+	runCronTasks(cronCtx, s.cronTasks, s.Logger)
+}
+
 // Shutdown gracefully stops a server started via ListenAndServe.
-// In-flight requests complete; new connections are refused.
+// In-flight requests complete; new connections are refused. Any running
+// cron goroutines are stopped via context cancellation before returning.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.mu.Lock()
 	srv := s.httpSrv
+	cancel := s.cronCancel
 	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	if srv == nil {
 		return nil
 	}


### PR DESCRIPTION
Closes #193

## Why

Ports the spirit of sveltejs/kit#10477 into Go. Users need a first-class
way to declare scheduled background tasks that colocate with the rest of
the app and start/stop cleanly with the server lifecycle.

## What

- **`kit.CronTask`** — struct holding `Name`, `Spec`, and `Fn func(context.Context) error`.
- **`kit.ParseSchedule(spec)`** — parser supporting `@every <duration>`, `@hourly`, `@daily`, `@weekly`. Full crontab syntax is intentionally excluded (follow-up).
- **`server.Config.CronTasks`** — wire tasks into the server; they start after `Init` succeeds and are cancelled on `Shutdown`.
- **`server/cron.go`** — `runCronTasks` / `runCronLoop` driven by `time.Ticker`; errors logged, loop continues.

## Tests

- `ParseSchedule`: 14 table-driven cases covering all shorthands, whitespace tolerance, zero/negative duration, bare integer, unsupported specs.
- `TestCronTask_fires`: task at `@every 50ms` fires ≥3 times in 250ms.
- `TestCronTask_stopsOnShutdown`: counter stops incrementing after `Shutdown`.
- `TestCronTask_badSpecSkipped`: invalid spec does not abort `Init`.

All 337 tests pass with `-race`.