### PR TITLE
feat(kit): Locals reachable in nested Loads without parent wait

### DIFF
--- a/packages/sveltego/exports/kit/ctx.go
+++ b/packages/sveltego/exports/kit/ctx.go
@@ -56,10 +56,19 @@ func (c *RenderCtx) RawParam(name string) (string, bool) {
 // LoadCtx is the request-scoped context handed to user-written Load
 // functions in +page.server.go and +layout.server.go.
 //
+// Locals is the same map the Handle hook populated before any Load runs;
+// reading it never requires calling [LoadCtx.Parent]. Values set by a
+// parent layout's Load are only available after [LoadCtx.Parent] returns
+// that layout's data — but values written by Handle (session, user,
+// nonce, …) are always present immediately.
+//
 // parents stores layout Load() returns in outer→inner order; the pipeline
 // pushes each layout result before invoking the next layer's Load. User
 // code reads only the immediate parent through [LoadCtx.Parent].
 type LoadCtx struct {
+	// Locals is the shared per-request bag populated by Handle before any
+	// Load runs. All layout and page Loads in the chain read the same map
+	// without waiting for a parent Load to complete.
 	Locals    map[string]any
 	URL       *url.URL
 	Params    map[string]string
@@ -165,7 +174,9 @@ func NewRenderCtx(r *http.Request, w http.ResponseWriter, params map[string]stri
 }
 
 // NewLoadCtx builds a LoadCtx for the given request and route params.
-// Locals and Cookies are initialized non-nil.
+// Locals and Cookies are initialized non-nil. The server pipeline replaces
+// Locals with the shared [RequestEvent.Locals] map so Handle-populated
+// values are visible to every Load without requiring a [LoadCtx.Parent] call.
 func NewLoadCtx(r *http.Request, params map[string]string) *LoadCtx {
 	ctx := &LoadCtx{
 		Locals:  map[string]any{},

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -332,6 +332,9 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 	)
 	if route.Load != nil || hasAnyLayoutLoader(route.LayoutLoaders) {
 		lctx = kit.NewLoadCtx(r, ev.Params)
+		// Share the event's Locals map so every layout and page Load in the
+		// chain reads Handle-populated values (session, user, nonce, …)
+		// without requiring a Parent() call first.
 		lctx.Locals = ev.Locals
 		lctx.Cookies = ev.Cookies
 		lctx.RawParams = ev.RawParams

--- a/packages/sveltego/server/server_test.go
+++ b/packages/sveltego/server/server_test.go
@@ -96,6 +96,8 @@ func segmentsFor(pattern string) []router.Segment {
 		return []router.Segment{{Kind: router.SegmentStatic, Value: "protected"}}
 	case "/public":
 		return []router.Segment{{Kind: router.SegmentStatic, Value: "public"}}
+	case "/dashboard":
+		return []router.Segment{{Kind: router.SegmentStatic, Value: "dashboard"}}
 	}
 	panic("unknown pattern: " + pattern)
 }
@@ -958,6 +960,96 @@ func TestServeHTTP_ssrOnlyRendersHTML(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "<h1>protected</h1>") {
 		t.Fatalf("body missing page content: %q", body)
+	}
+}
+
+// TestServeHTTP_localsReachableWithoutParent asserts that Locals written by
+// the Handle hook are visible to every layout and page Load in the chain
+// without any of them calling ctx.Parent(). This is the server-side
+// guarantee from sveltejs/kit#11587: Handle populates Locals once before any
+// Load runs; all Loads share the same map.
+func TestServeHTTP_localsReachableWithoutParent(t *testing.T) {
+	t.Parallel()
+
+	const wantUser = "alice"
+
+	// rootLoad reads Locals["user"] set by Handle. It deliberately never
+	// calls ctx.Parent() to prove that Locals are pre-populated.
+	rootLoad := func(ctx *kit.LoadCtx) (any, error) {
+		u, _ := ctx.Locals["user"].(string)
+		if u != wantUser {
+			return nil, fmt.Errorf("rootLoad: Locals[user] = %q, want %q", u, wantUser)
+		}
+		return u, nil
+	}
+
+	// leafLoad also reads Locals["user"] without calling ctx.Parent(),
+	// proving that even a nested layout loader receives the same map.
+	leafLoad := func(ctx *kit.LoadCtx) (any, error) {
+		u, _ := ctx.Locals["user"].(string)
+		if u != wantUser {
+			return nil, fmt.Errorf("leafLoad: Locals[user] = %q, want %q", u, wantUser)
+		}
+		return u, nil
+	}
+
+	pageLoad := func(ctx *kit.LoadCtx) (any, error) {
+		u, _ := ctx.Locals["user"].(string)
+		if u != wantUser {
+			return nil, fmt.Errorf("pageLoad: Locals[user] = %q, want %q", u, wantUser)
+		}
+		return u, nil
+	}
+
+	identityLayout := func(w *render.Writer, _ *kit.RenderCtx, _ any, children func(*render.Writer) error) error {
+		return children(w)
+	}
+
+	page := func(w *render.Writer, _ *kit.RenderCtx, data any) error {
+		s, _ := data.(string)
+		w.WriteString("<user>" + s + "</user>")
+		return nil
+	}
+
+	srv, err := New(Config{
+		Routes: []router.Route{{
+			Pattern:     "/dashboard",
+			Segments:    segmentsFor("/dashboard"),
+			Page:        page,
+			Load:        pageLoad,
+			LayoutChain: []router.LayoutHandler{identityLayout, identityLayout},
+			LayoutLoaders: []router.LayoutLoadHandler{
+				rootLoad,
+				leafLoad,
+			},
+		}},
+		Shell:  testShell,
+		Logger: quietLogger(),
+		Hooks: kit.Hooks{
+			Handle: func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) {
+				ev.Locals["user"] = wantUser
+				return resolve(ev)
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/dashboard")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "<user>"+wantUser+"</user>") {
+		t.Fatalf("body = %q, want <user>alice</user>", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `LoadCtx.Locals` points to the same `map[string]any` that the `Handle` hook populated — the pipeline assigns `ev.Locals` to `lctx.Locals` before the first layout Load runs.
- Every layout and page Load in the chain therefore reads Handle-set values (session, user, nonce, …) without calling `ctx.Parent()`.
- A parent layout's Load output is still only available after `ctx.Parent()` — that ordering is intentional and unchanged.

## Changes

**`packages/sveltego/exports/kit/ctx.go`**
- Updated `LoadCtx` struct godoc to state the Locals invariant: Handle populates the map before any Load; reading it never requires `Parent()`.
- Added field-level comment on `Locals` reinforcing the same guarantee.
- Updated `NewLoadCtx` godoc to note the pipeline replaces the initial map with the shared event Locals.

**`packages/sveltego/server/pipeline.go`**
- Added inline comment on `lctx.Locals = ev.Locals` explaining why the assignment must precede all layout Load invocations.

**`packages/sveltego/server/server_test.go`**
- `TestServeHTTP_localsReachableWithoutParent`: 2-layer layout + page Load, each reads `Locals["user"]` set by `Handle`; `ctx.Parent()` is never called. Fails before the pipeline assignment existed; passes now.

## Note on parent-wait ordering

Parent layout Load output (returned data structs) still serialises outer→inner via `PushParent`/`Parent()`. That is correct behaviour and is not changed. Only Locals — which are owned by Handle, not by any Load — bypass the wait.

Closes #169