### PR TITLE
feat(hooks): HandleAction global middleware for form actions

### DIFF
--- a/packages/sveltego/exports/kit/hooks.go
+++ b/packages/sveltego/exports/kit/hooks.go
@@ -48,6 +48,14 @@ type HandleFn func(ev *RequestEvent, resolve ResolveFn) (*Response, error)
 // facing HTTP response.
 type HandleErrorFn func(ev *RequestEvent, err error) SafeError
 
+// HandleActionFn is the signature of the optional HandleAction hook. The
+// pipeline calls it for every form action POST, passing the resolved
+// action name and the matched ActionFn as next. Returning without calling
+// next short-circuits the action (useful for CSRF rejection or rate
+// limiting). Calling next(ev) runs the action and lets middleware observe
+// or transform the result.
+type HandleActionFn func(ev *RequestEvent, actionName string, next ActionFn) ActionResult
+
 // HandleFetchFn is the signature of the optional HandleFetch hook. The
 // pipeline plugs it into RequestEvent.Fetch so outbound HTTP traffic
 // from Load and route handlers can be intercepted.
@@ -105,6 +113,12 @@ func IdentityHandle(ev *RequestEvent, resolve ResolveFn) (*Response, error) {
 	return resolve(ev)
 }
 
+// IdentityHandleAction is the default HandleAction hook. It calls next
+// and returns its result unchanged without any cross-cutting logic.
+func IdentityHandleAction(ev *RequestEvent, _ string, next ActionFn) ActionResult {
+	return next(ev)
+}
+
 // IdentityHandleError is the default HandleError hook. It maps any error
 // to a generic 500 SafeError without exposing internal detail.
 func IdentityHandleError(_ *RequestEvent, _ error) SafeError {
@@ -150,11 +164,12 @@ func Sequence(handlers ...HandleFn) HandleFn {
 // the value to the server. User code in src/hooks.server.go does not
 // touch this type; the build wires it for them.
 type Hooks struct {
-	Handle      HandleFn
-	HandleError HandleErrorFn
-	HandleFetch HandleFetchFn
-	Reroute     RerouteFn
-	Init        InitFn
+	Handle       HandleFn
+	HandleError  HandleErrorFn
+	HandleFetch  HandleFetchFn
+	HandleAction HandleActionFn
+	Reroute      RerouteFn
+	Init         InitFn
 }
 
 // DefaultHooks returns a Hooks bundle filled with identity defaults so a
@@ -162,11 +177,12 @@ type Hooks struct {
 // identity passthrough and the rest are absent.
 func DefaultHooks() Hooks {
 	return Hooks{
-		Handle:      IdentityHandle,
-		HandleError: IdentityHandleError,
-		HandleFetch: IdentityHandleFetch,
-		Reroute:     IdentityReroute,
-		Init:        IdentityInit,
+		Handle:       IdentityHandle,
+		HandleError:  IdentityHandleError,
+		HandleFetch:  IdentityHandleFetch,
+		HandleAction: IdentityHandleAction,
+		Reroute:      IdentityReroute,
+		Init:         IdentityInit,
 	}
 }
 
@@ -182,6 +198,9 @@ func (h Hooks) WithDefaults() Hooks {
 	}
 	if h.HandleFetch == nil {
 		h.HandleFetch = IdentityHandleFetch
+	}
+	if h.HandleAction == nil {
+		h.HandleAction = IdentityHandleAction
 	}
 	if h.Reroute == nil {
 		h.Reroute = IdentityReroute

--- a/packages/sveltego/exports/kit/hooks_test.go
+++ b/packages/sveltego/exports/kit/hooks_test.go
@@ -215,8 +215,74 @@ func TestSafeError_implementsErrorAndStatuser(t *testing.T) {
 func TestHooks_WithDefaults_fillsNil(t *testing.T) {
 	t.Parallel()
 	h := kit.Hooks{}.WithDefaults()
-	if h.Handle == nil || h.HandleError == nil || h.HandleFetch == nil || h.Reroute == nil || h.Init == nil {
+	if h.Handle == nil || h.HandleError == nil || h.HandleFetch == nil || h.HandleAction == nil || h.Reroute == nil || h.Init == nil {
 		t.Fatalf("WithDefaults left nil fields: %+v", h)
+	}
+}
+
+func TestIdentityHandleAction_callsNext(t *testing.T) {
+	t.Parallel()
+	ev := newEvent(t)
+	called := false
+	next := func(_ *kit.RequestEvent) kit.ActionResult {
+		called = true
+		return kit.ActionDataResult(200, "ok")
+	}
+	result := kit.IdentityHandleAction(ev, "default", next)
+	if !called {
+		t.Error("IdentityHandleAction did not call next")
+	}
+	ad, ok := result.(kit.ActionData)
+	if !ok || ad.Data != "ok" {
+		t.Errorf("unexpected result: %#v", result)
+	}
+}
+
+func TestHandleActionFn_shortCircuit(t *testing.T) {
+	t.Parallel()
+	ev := newEvent(t)
+	// Middleware that rejects without calling next (CSRF use-case).
+	reject := func(_ *kit.RequestEvent, _ string, _ kit.ActionFn) kit.ActionResult {
+		return kit.ActionFail(403, "forbidden")
+	}
+	called := false
+	next := func(_ *kit.RequestEvent) kit.ActionResult {
+		called = true
+		return kit.ActionDataResult(200, "reached")
+	}
+	result := reject(ev, "default", next)
+	if called {
+		t.Error("next should not be called on short-circuit")
+	}
+	afd, ok := result.(kit.ActionFailData)
+	if !ok || afd.Code != 403 {
+		t.Errorf("unexpected result: %#v", result)
+	}
+}
+
+func TestHandleActionFn_wraps(t *testing.T) {
+	t.Parallel()
+	ev := newEvent(t)
+	var trail []string
+	// Middleware that runs before and after next.
+	wrap := func(ev *kit.RequestEvent, name string, next kit.ActionFn) kit.ActionResult {
+		trail = append(trail, "before:"+name)
+		r := next(ev)
+		trail = append(trail, "after:"+name)
+		return r
+	}
+	next := func(_ *kit.RequestEvent) kit.ActionResult {
+		trail = append(trail, "action")
+		return kit.ActionDataResult(200, "done")
+	}
+	result := wrap(ev, "submit", next)
+	want := []string{"before:submit", "action", "after:submit"}
+	if strings.Join(trail, ",") != strings.Join(want, ",") {
+		t.Errorf("trail = %v, want %v", trail, want)
+	}
+	ad, ok := result.(kit.ActionData)
+	if !ok || ad.Data != "done" {
+		t.Errorf("unexpected result: %#v", result)
 	}
 }
 

--- a/packages/sveltego/server/actions.go
+++ b/packages/sveltego/server/actions.go
@@ -42,8 +42,9 @@ func injectFormField(data, formValue any) any {
 
 // dispatchAction resolves the form action keyed by the request URL's
 // `?/<name>` query (default: "default") against route.Actions and runs
-// it. The returned response or error follows the same shape as
-// renderPage so the surrounding pipeline writes one Response.
+// it through the HandleAction middleware. The returned response or error
+// follows the same shape as renderPage so the surrounding pipeline writes
+// one Response.
 //
 // Returning (nil, nil) means the caller should fall through to
 // renderPage with the `Form` payload installed via formData.
@@ -67,7 +68,7 @@ func (s *Server) dispatchAction(r *http.Request, ev *kit.RequestEvent, route *ro
 		}, nil, nil
 	}
 
-	result := fn(ev)
+	result := s.hooks.HandleAction(ev, name, fn)
 	switch v := result.(type) {
 	case kit.ActionRedirectResult:
 		code := v.Code

--- a/packages/sveltego/server/actions_integration_test.go
+++ b/packages/sveltego/server/actions_integration_test.go
@@ -216,6 +216,134 @@ func TestActions_PostWithoutActionsReturnsMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func newTestServerWithHooks(t *testing.T, routes []router.Route, hooks kit.Hooks) *Server {
+	t.Helper()
+	srv, err := New(Config{
+		Routes: routes,
+		Shell:  testShell,
+		Logger: quietLogger(),
+		Hooks:  hooks,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return srv
+}
+
+func TestHandleAction_shortCircuitsAction(t *testing.T) {
+	t.Parallel()
+	actions := kit.ActionMap{
+		"default": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionDataResult(200, "reached")
+		},
+	}
+	hooks := kit.Hooks{
+		HandleAction: func(_ *kit.RequestEvent, _ string, _ kit.ActionFn) kit.ActionResult {
+			return kit.ActionFail(403, "csrf check failed")
+		},
+	}
+	srv := newTestServerWithHooks(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}}, hooks)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/login", "application/x-www-form-urlencoded", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	// HandleAction short-circuits with ActionFail(403) — pipeline re-renders
+	// the page with status 403 and the failure data in Form.
+	if resp.StatusCode != 403 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 403, body = %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "csrf check failed") {
+		t.Fatalf("expected csrf message in body, got: %s", body)
+	}
+}
+
+func TestHandleAction_wrapsAction(t *testing.T) {
+	t.Parallel()
+	var trail []string
+	actions := kit.ActionMap{
+		"submit": func(_ *kit.RequestEvent) kit.ActionResult {
+			trail = append(trail, "action")
+			return kit.ActionDataResult(200, "ok")
+		},
+	}
+	hooks := kit.Hooks{
+		HandleAction: func(ev *kit.RequestEvent, name string, next kit.ActionFn) kit.ActionResult {
+			trail = append(trail, "before:"+name)
+			r := next(ev)
+			trail = append(trail, "after:"+name)
+			return r
+		},
+	}
+	srv := newTestServerWithHooks(t, []router.Route{{
+		Pattern:  "/form",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "form"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}}, hooks)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/form?/submit", "application/x-www-form-urlencoded", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	want := []string{"before:submit", "action", "after:submit"}
+	if strings.Join(trail, ",") != strings.Join(want, ",") {
+		t.Errorf("trail = %v, want %v", trail, want)
+	}
+}
+
+func TestHandleAction_receivesActionName(t *testing.T) {
+	t.Parallel()
+	var capturedName string
+	actions := kit.ActionMap{
+		"checkout": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionDataResult(200, "done")
+		},
+	}
+	hooks := kit.Hooks{
+		HandleAction: func(ev *kit.RequestEvent, name string, next kit.ActionFn) kit.ActionResult {
+			capturedName = name
+			return next(ev)
+		},
+	}
+	srv := newTestServerWithHooks(t, []router.Route{{
+		Pattern:  "/cart",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "cart"}},
+		Page:     formAwarePage(),
+		Load:     formAwareLoad(),
+		Actions:  func() any { return actions },
+	}}, hooks)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/cart?/checkout", "application/x-www-form-urlencoded", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if capturedName != "checkout" {
+		t.Errorf("capturedName = %q, want checkout", capturedName)
+	}
+}
+
 func TestActions_BindFormInsideAction(t *testing.T) {
 	t.Parallel()
 	type loginForm struct {


### PR DESCRIPTION
## Summary

- Adds `HandleActionFn` type to `exports/kit/hooks.go` mirroring the `HandleFn` pattern but scoped to form action invocations
- Wires `HandleAction HandleActionFn` into the `Hooks` struct, `DefaultHooks()`, and `WithDefaults()`
- `server/actions.go` `dispatchAction` wraps the resolved `ActionFn` through `s.hooks.HandleAction(ev, name, fn)` instead of calling `fn(ev)` directly
- Default is `IdentityHandleAction` — pass-through with zero overhead when no hook is configured

Closes #165.

## Signature

```go
type HandleActionFn func(ev *RequestEvent, actionName string, next ActionFn) ActionResult
```

Middleware receives the resolved action name so CSRF tokens, rate limiters, and audit loggers can branch by action. Returning without calling `next` short-circuits the action pipeline (CSRF rejection use-case). Calling `next(ev)` and observing the result enables before/after wrapping.

## Test plan

- [x] `TestIdentityHandleAction_callsNext` — identity passthrough calls next once, returns its result
- [x] `TestHandleActionFn_shortCircuit` — middleware returning early never calls next
- [x] `TestHandleActionFn_wraps` — before/after trail verified in unit test
- [x] `TestHandleAction_shortCircuitsAction` — integration: CSRF-style rejection returns 403, form data in body
- [x] `TestHandleAction_wrapsAction` — integration: trail matches `before:submit, action, after:submit`
- [x] `TestHandleAction_receivesActionName` — integration: middleware captures correct action name
- [x] `TestHooks_WithDefaults_fillsNil` updated to assert `HandleAction` is also populated
- [x] All 324 existing tests pass (`go test -race`)
- [x] `go vet`, `gofumpt`, `go build` all clean