### PR TITLE
docs: post-wave-5..8 sync (file naming, new kit APIs)

### DIFF
--- a/docs/ai-development.md
+++ b/docs/ai-development.md
@@ -72,11 +72,11 @@ The shipped templates do this for you; the prompts below assume the rules are lo
 
 **Scaffold a route**
 
-> Create a `src/routes/blog/[slug]` route with `+page.svelte` and `+page.server.go`. The page shows a `Post` fetched by slug from `db.PostBySlug(ctx, slug)`. Fields: `Title`, `Body` (HTML), `PublishedAt` (`time.Time`).
+> Create a `src/routes/blog/[slug]` route with `+page.svelte` and `page.server.go`. The page shows a `Post` fetched by slug from `db.PostBySlug(ctx, slug)`. Fields: `Title`, `Body` (HTML), `PublishedAt` (`time.Time`).
 
 **Write a form action**
 
-> Add a comment form to `src/routes/blog/[slug]/+page.svelte` and an action in `+page.server.go` that validates body is non-empty, appends to `db.Comments`, and redirects back to the page on success or returns `kit.ActionFail(422, ...)` on validation failure.
+> Add a comment form to `src/routes/blog/[slug]/+page.svelte` and an action in `page.server.go` that validates body is non-empty, appends to `db.Comments`, and redirects back to the page on success or returns `kit.ActionFail(422, ...)` on validation failure.
 
 **Add a hook**
 

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -6,7 +6,7 @@ summary: POST handlers tied to a page — default and named actions, validation,
 
 # Form actions
 
-Form actions are POST handlers attached to a page. They live in `+page.server.go` next to `Load` and run on `POST` to the page route.
+Form actions are POST handlers attached to a page. They live in `page.server.go` next to `Load` and run on `POST` to the page route.
 
 ## Shape
 

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -10,7 +10,7 @@ summary: sveltego build, .gen output, Vite client bundle, single-binary deploy.
 
 ## Pipeline
 
-1. Scan `src/routes/**` for `+page.svelte`, `+page.server.go`, `+layout.svelte`, `+layout.server.go`, `+server.go`, `+error.svelte`.
+1. Scan `src/routes/**` for `+page.svelte`, `page.server.go`, `+layout.svelte`, `layout.server.go`, `server.go`, `+error.svelte`.
 2. Parse `.svelte` files via the sveltego parser; validate Go expressions in mustaches via `go/parser.ParseExpr`.
 3. Emit `.gen/*.go` — one Go file per template, plus a manifest registering routes, layouts, and page options.
 4. Run Vite to produce the client hydration bundle (`dist/`).
@@ -33,7 +33,7 @@ The `.gen/` directory is gitignored; it is regenerated on every build.
 
 ## Page options
 
-Declare per-page options as exported constants in `+page.server.go` or `+layout.server.go`:
+Declare per-page options as exported constants in `page.server.go` or `layout.server.go`:
 
 ```go
 //go:build sveltego

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -59,11 +59,11 @@ var Handle = kit.Sequence(authHandle, requestIDHandle, telemetryHandle)
 
 ## HandleError
 
-Called whenever `Handle`, `Load`, render, or a `+server.go` handler returns an error. Returns a `kit.SafeError` — the user-facing contract: `Code`, `Message`, `ID`. Logs the raw error; the response body never echoes internal detail.
+Called whenever `Handle`, `Load`, render, or a `server.go` handler returns an error. Returns a `kit.SafeError` — the user-facing contract: `Code`, `Message`, `ID`. Logs the raw error; the response body never echoes internal detail. When `Message` is empty, the framework substitutes `http.StatusText(Code)`.
 
 ## HandleFetch
 
-Intercepts outbound HTTP from `Load` and `+server.go`. Use it to add auth headers, redirect to local services, or apply request-scoped retries.
+Intercepts outbound HTTP from `Load` and `server.go`. Use it to add auth headers, redirect to local services, or apply request-scoped retries.
 
 `RequestEvent.Fetch(req)` dispatches through `HandleFetch`; bypass it (e.g. `http.DefaultClient.Do`) and the hook is silently skipped.
 

--- a/docs/guide/load.md
+++ b/docs/guide/load.md
@@ -35,7 +35,7 @@ Inside the template, fields are referenced as `{Data.Title}`, `{Data.Posts}`, et
 
 ## Layout load
 
-`+layout.server.go` works the same way and exports `LayoutData`. The pipeline runs each layer's `Load` outer-to-inner. Children read the immediate parent through `ctx.Parent()`:
+`layout.server.go` works the same way and exports `LayoutData`. The pipeline runs each layer's `Load` outer-to-inner. Children read the immediate parent through `ctx.Parent()`:
 
 ```go
 parent := ctx.Parent().(rootlayout.LayoutData)
@@ -80,4 +80,4 @@ The render path emits a placeholder, flushes the shell, then patches the slot wh
 
 - It cannot run on the client. Loaders are server-only.
 - It must not mutate `RequestEvent.Locals` after `Handle` finished — read only.
-- It cannot write to `http.ResponseWriter`; responses come from the page template or a `+server.go` handler.
+- It cannot write to `http.ResponseWriter`; responses come from the page template or a `server.go` handler.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -13,10 +13,10 @@ sveltego mirrors SvelteKit's *shape*, not its *implementation*. The file convent
 | SvelteKit | sveltego |
 |---|---|
 | `+page.svelte` | `+page.svelte` |
-| `+page.server.ts` | `+page.server.go` |
+| `+page.server.ts` | `page.server.go` (no `+` prefix; use `//go:build sveltego`) |
 | `+layout.svelte` | `+layout.svelte` |
-| `+layout.server.ts` | `+layout.server.go` |
-| `+server.ts` | `+server.go` |
+| `+layout.server.ts` | `layout.server.go` (no `+` prefix; use `//go:build sveltego`) |
+| `+server.ts` | `server.go` (no `+` prefix; use `//go:build sveltego`) |
 | `+error.svelte` | `+error.svelte` |
 | `hooks.server.ts` | `hooks.server.go` |
 | `[param]`, `[[opt]]`, `[...rest]`, `(group)` | identical |

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -1,7 +1,7 @@
 ---
 title: Routing
 order: 20
-summary: File-based routing — +page.svelte, +page.server.go, +server.go, params, groups.
+summary: File-based routing — +page.svelte, page.server.go, server.go, params, groups.
 ---
 
 # Routing
@@ -13,10 +13,10 @@ sveltego uses file-based routing under `src/routes/`. The conventions match Svel
 | File | Purpose |
 |---|---|
 | `+page.svelte` | SSR template. Mustache expressions are Go. |
-| `+page.server.go` | Page server module: `Load`, `Actions`. |
+| `page.server.go` | Page server module: `Load`, `Actions`. No `+` prefix; identified by `//go:build sveltego`. |
 | `+layout.svelte` | Layout chain. Wraps descendant `+page.svelte`. |
-| `+layout.server.go` | Layout-level `Load` cascading to children. |
-| `+server.go` | REST endpoints (`GET`, `POST`, ...). No template. |
+| `layout.server.go` | Layout-level `Load` cascading to children. No `+` prefix. |
+| `server.go` | REST endpoints (`GET`, `POST`, ...). No template, no `+` prefix. |
 | `+error.svelte` | Error boundary for the subtree. |
 | `+page@.svelte` | Layout reset — opt out of the parent chain. |
 
@@ -56,7 +56,7 @@ Reference it as `[id=hex]`.
 
 ## Endpoints
 
-`+server.go` exposes named handlers per HTTP method:
+`server.go` exposes named handlers per HTTP method:
 
 ```go
 //go:build sveltego

--- a/docs/reference/kit.md
+++ b/docs/reference/kit.md
@@ -14,11 +14,27 @@ This page summarises the surface. Source is the canonical spec; godoc is generat
 
 | Type | Used in | Purpose |
 |---|---|---|
-| `RequestEvent` | hooks, `+server.go`, actions | Request-scoped state with `URL`, `Params`, `Locals`, `Cookies`. |
+| `RequestEvent` | hooks, `server.go`, actions | Request-scoped state with `URL`, `Params`, `Locals`, `Cookies`. |
 | `RenderCtx` | generated render code | SSR-time context passed into templates. |
-| `LoadCtx` | `Load` in `+page.server.go`, `+layout.server.go` | Load-time context with `Parent()` for layout chain. |
+| `LoadCtx` | `Load` in `page.server.go`, `layout.server.go` | Load-time context with `Parent()` for layout chain. |
 
 `RequestEvent.Fetch(req)` dispatches outbound HTTP through `HandleFetch`.
+
+`LoadCtx.Header()` returns a `*HeaderWriter` for setting response headers from a loader:
+
+```go
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+  ctx.Header().Set("Cache-Control", "no-store")
+  ctx.Header().Add("Vary", "Accept")
+  return PageData{}, nil
+}
+```
+
+`HeaderWriter` has three methods: `Set(key, value string)` (replace all), `Add(key, value string)` (append), `Del(key string)` (remove all).
+
+`LoadCtx.RawParam(name string) (string, bool)` returns the un-decoded route parameter value (percent-encoding preserved). Use when the decoded value would lose a `%2F` slash inside a segment.
+
+`LoadCtx.Speculative() bool` returns `true` when the request carries `X-Sveltego-Preload: 1` — the client prefetch header. Use to skip expensive side-effects during preloads.
 
 ## Hooks
 
@@ -32,17 +48,37 @@ type InitFn         func(ctx context.Context) error
 
 Compose handlers with `kit.Sequence(...)`. Defaults via `kit.DefaultHooks()` and `Hooks{}.WithDefaults()`.
 
+`InitFn` returning a non-nil error aborts startup; the server emits a `503 Service Unavailable` (or `500` when the HTTP listener could not bind) while the `Init` call is pending.
+
 ## Errors and short-circuits
 
 ```go
-kit.Redirect(code int, location string) error
-kit.Error(code int, message string) error
+kit.Redirect(code int, location string, opts ...RedirectOption) error
+kit.Error(code int, message ...string) error
 kit.Fail(code int, data any) error
 ```
 
 All three implement `error` and `httpStatuser`.
 
-`SafeError{Code, Message, ID}` is the user-facing error contract returned from `HandleError`.
+`kit.RedirectReload()` is a `RedirectOption` that signals the client to do a full document reload instead of a SPA navigation:
+
+```go
+return PageData{}, kit.Redirect(303, "/login", kit.RedirectReload())
+```
+
+`SafeError{Code, Message, ID}` is the user-facing error contract returned from `HandleError`. When `Message` is empty, the framework fills it from `http.StatusText(Code)`.
+
+`kit.HTTPError` is an interface user-defined error types can implement to carry an HTTP status code directly to the pipeline without going through a sentinel:
+
+```go
+type HTTPError interface {
+  error
+  Status() int
+  Public() string
+}
+```
+
+The pipeline inspects returned errors for `HTTPError` before falling back to `HandleError`.
 
 ## Responses
 
@@ -140,11 +176,14 @@ type PageOptions struct {
   Prerender     bool
   SSR           bool
   CSR           bool
+  SSROnly       bool
   TrailingSlash TrailingSlash
 }
 ```
 
 `PageOptions.Merge(override PageOptionsOverride) PageOptions` cascades layout values into pages.
+
+`SSROnly = true` blocks the `__data.json` scrape endpoint used by the SPA client for prefetch. Use on pages where only the server-rendered HTML response is intended (e.g. print views, webhook acknowledgement pages).
 
 ## Link
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -31,8 +31,8 @@ Runtime route lookup is a map index, not a tree walk. Every static decision (whi
 
 The file is overwritten on every codegen run. Source of truth lives in:
 
-- `+page.server.go` for `Load`, `Actions`, page options.
-- `+layout.server.go` for layout `Load` and cascaded options.
+- `page.server.go` for `Load`, `Actions`, page options.
+- `layout.server.go` for layout `Load` and cascaded options.
 - `hooks.server.go` for hooks.
 - File paths under `src/routes/` for patterns.
 

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -11,10 +11,10 @@ summary: File names, build tag, generated output, and the route-matching contrac
 ```
 src/routes/
   +page.svelte               # SSR template
-  +page.server.go            # Load(), Actions       (//go:build sveltego)
+  page.server.go             # Load(), Actions       (//go:build sveltego)
   +layout.svelte             # layout chain
-  +layout.server.go          # parent data flow      (//go:build sveltego)
-  +server.go                 # REST endpoints        (//go:build sveltego)
+  layout.server.go           # parent data flow      (//go:build sveltego)
+  server.go                  # REST endpoints        (//go:build sveltego)
   +error.svelte              # error boundary
   (group)/                   # route group, no URL segment
   +page@.svelte              # layout reset
@@ -60,10 +60,10 @@ Two builds of the same source produce byte-identical `.gen/` output. Golden test
 
 ## File naming gotchas
 
-- `+page.svelte` — leading `+` is required.
-- `+page.server.go` — note the `.server.` infix and the `+`.
-- `page.server.go` (no `+`) is treated as a normal package file, not a sveltego module.
-- `+server.go` — REST endpoint, no template.
+- `+page.svelte` — leading `+` is required on Svelte template files.
+- `page.server.go` — note the `.server.` infix; no leading `+`. The `//go:build sveltego` tag identifies it to codegen.
+- `+page.server.go` (with `+`) is **not** recognized by routescan. Drop the `+`.
+- `server.go` — REST endpoint, no template. No `+` prefix.
 - `+page@.svelte` — trailing `@` (before the extension) signals a layout reset.
 
 When in doubt, run `sveltego routes` and verify the entry appears.


### PR DESCRIPTION
## Summary

Fresh doc-drift audit branched from current `origin/main`. Replaces closed #291 (rebase too conflicted).

## Live milestone counts (verified via `gh issue list --limit 200`)

| Milestone | Count |
|-----------|-------|
| MVP | 42 |
| v0.2 — Form Actions & Hooks | 15 |
| v0.3 — Client SPA & Hydration | 21 |
| v0.4 — Svelte 5 Full Coverage | 19 |
| v0.5 — SvelteKit parity catch-up | 23 |
| v0.6 — Authentication | 40 |
| v1.0 — Production Ready | 25 |
| v1.1 — LLM & AI Tooling | 6 |

README, CLAUDE.md, AGENTS.md, tasks/todo.md — all correct, no changes needed.

## Drift findings and fixes

### `docs/reference/routes.md` — file tree + gotchas
- **DRIFT**: tree listed `+page.server.go`, `+layout.server.go`, `+server.go` with `+` prefix on Go files.
- **FIX**: corrected to `page.server.go`, `layout.server.go`, `server.go`. Updated gotchas section to explicitly call out that `+page.server.go` (with `+`) is not recognized by routescan.

### `docs/guide/routing.md` — files table + Endpoints section
- **DRIFT**: table rows and `## Endpoints` prose used `+page.server.go`, `+layout.server.go`, `+server.go`.
- **FIX**: all corrected; added note that Go files use `//go:build sveltego` tag as the identifier instead of `+` prefix.

### `docs/guide/build.md` — scan list + page options section
- **DRIFT**: scan list and page options prose used `+page.server.go`, `+layout.server.go`.
- **FIX**: corrected to `page.server.go`, `layout.server.go`.

### `docs/guide/migration.md` — "What carries over" table
- **DRIFT**: `+page.server.go`, `+layout.server.go`, `+server.go` in destination column.
- **FIX**: corrected with no-`+`-prefix note.

### `docs/reference/manifest.md` — source list
- **DRIFT**: `+page.server.go`, `+layout.server.go`.
- **FIX**: corrected.

### `docs/guide/load.md` — layout section + "What Load cannot do"
- **DRIFT**: `+layout.server.go`, `+server.go`.
- **FIX**: corrected.

### `docs/guide/actions.md` — intro paragraph
- **DRIFT**: `+page.server.go`.
- **FIX**: corrected.

### `docs/guide/hooks.md` — HandleFetch + HandleError descriptions
- **DRIFT**: `+server.go` in HandleFetch; no mention of `http.StatusText` default.
- **FIX**: corrected file name; added note that empty `Message` falls back to `http.StatusText(Code)` (#275).

### `docs/ai-development.md` — example AI prompts
- **DRIFT**: `+page.server.go` in scaffold and form-action example prompts.
- **FIX**: corrected to `page.server.go`.

### `docs/reference/kit.md` — new APIs missing from waves 5–8
- **DRIFT**: None of the following were documented.
- **FIX**: Added:
  - `LoadCtx.Header() *HeaderWriter` — Set/Add/Del response headers from a loader (#278)
  - `LoadCtx.RawParam(name) (string, bool)` — un-decoded route params (#288)
  - `LoadCtx.Speculative() bool` — preload header detection (#289)
  - `kit.HTTPError` interface — typed status mapping for user error types (#283)
  - `kit.RedirectReload()` — `RedirectOption` for full document reload on redirect (#279)
  - `kit.SSROnly` field in `PageOptions` — blocks `__data.json` scrape endpoint (#284)
  - `Init` error behavior — 503/500 fallback during pending Init (#286)
  - `kit.Error` default message via `http.StatusText` (#275)
  - Corrected `Redirect` and `Error` signatures (variadic opts/message params)
  - Fixed context table: `+server.go` → `server.go`, `+page.server.go` → `page.server.go`