### PR TITLE
fix(streaming): silence error spam on client disconnect

### DIFF
--- a/packages/sveltego/exports/kit/streamed.go
+++ b/packages/sveltego/exports/kit/streamed.go
@@ -15,6 +15,13 @@ const DefaultStreamTimeout = 30 * time.Second
 // timeout elapsed before the producer goroutine completed.
 var ErrStreamTimeout = errors.New("kit: stream timeout")
 
+// ErrClientGone is returned by the chunk writer when a client disconnects
+// mid-stream (broken pipe, closed connection, cancelled request). The
+// pipeline logs it once at debug level and suppresses further writes;
+// it never routes through HandleError because a disconnect is not a
+// server-side fault.
+var ErrClientGone = errors.New("kit: client disconnected")
+
 // streamIDCounter assigns unique IDs to Streamed values within a process.
 // Render path uses the ID as the data-stream attribute and as the first
 // argument to __sveltego__resolve so the client patches the right slot.

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -15,15 +15,15 @@ import (
 // Log keys are named constants so sloglint's no-raw-keys rule passes
 // and grep over log output finds every callsite for a given attribute.
 const (
-	logKeyMethod    = "method"
-	logKeyPath      = "path"
-	logKeyError     = "error"
-	logKeyStatus    = "status"
-	logKeyLocation  = "location"
-	logKeyFailCode  = "fail_code"
-	logKeyName      = "name"
-	logKeySpec      = "spec"
-	logKeyStreamID  = "stream_id"
+	logKeyMethod   = "method"
+	logKeyPath     = "path"
+	logKeyError    = "error"
+	logKeyStatus   = "status"
+	logKeyLocation = "location"
+	logKeyFailCode = "fail_code"
+	logKeyName     = "name"
+	logKeySpec     = "spec"
+	logKeyStreamID = "stream_id"
 )
 
 // httpStatuser lets user errors carry a non-500 status into the

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -15,14 +15,15 @@ import (
 // Log keys are named constants so sloglint's no-raw-keys rule passes
 // and grep over log output finds every callsite for a given attribute.
 const (
-	logKeyMethod   = "method"
-	logKeyPath     = "path"
-	logKeyError    = "error"
-	logKeyStatus   = "status"
-	logKeyLocation = "location"
-	logKeyFailCode = "fail_code"
-	logKeyName     = "name"
-	logKeySpec     = "spec"
+	logKeyMethod    = "method"
+	logKeyPath      = "path"
+	logKeyError     = "error"
+	logKeyStatus    = "status"
+	logKeyLocation  = "location"
+	logKeyFailCode  = "fail_code"
+	logKeyName      = "name"
+	logKeySpec      = "spec"
+	logKeyStreamID  = "stream_id"
 )
 
 // httpStatuser lets user errors carry a non-500 status into the

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -7,11 +7,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -412,6 +416,9 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 			}
 		}
 		if err := s.renderStreaming(w, r, ev, inner, streams, status, headBytes); err != nil {
+			if errors.Is(err, kit.ErrClientGone) {
+				return nil, errStreamingWrote
+			}
 			return nil, err
 		}
 		return nil, errStreamingWrote
@@ -524,11 +531,40 @@ func appendStreams(dst []streamedField, v any) []streamedField {
 	return dst
 }
 
+// isClientGone reports whether err signals that the client closed the
+// connection. Covers broken pipe, use of closed network connection, and
+// context cancellation caused by the request going away — all of which
+// are normal events that should not pollute error logs.
+func isClientGone(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if ctx.Err() != nil {
+		return true
+	}
+	if errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, io.ErrClosedPipe) ||
+		errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return true
+	}
+	return false
+}
+
 // renderStreaming writes the chunked HTML response to w. It flushes the
 // shell + page body first, then waits on each stream in registration
 // order, emitting a __sveltego__resolve script per resolution. The
 // shellTail closes the document only after every stream resolves or
 // fails, so the response body is well-formed HTML even on timeout.
+//
+// When a write fails because the client disconnected, renderStreaming
+// cancels any pending streams, logs once at debug level, and returns
+// kit.ErrClientGone. The caller must treat that as errStreamingWrote so
+// HandleError is not invoked — a disconnect is not a server fault.
 func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, inner func(*render.Writer) error, streams []streamedField, status int, headBytes []byte) error {
 	if ev.Cookies != nil {
 		ev.Cookies.Apply(w)
@@ -549,20 +585,59 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 	if err := inner(buf); err != nil {
 		return err
 	}
+
+	ctx := r.Context()
+
 	if err := buf.FlushTo(w); err != nil {
+		if isClientGone(ctx, err) {
+			s.cancelStreams(streams)
+			s.Logger.DebugContext(ctx, "streaming: client disconnected before shell flush")
+			return kit.ErrClientGone
+		}
 		return err
 	}
 
-	ctx := r.Context()
 	for _, f := range streams {
 		emitResolveScript(ctx, buf, f.id, f.stream, s.streamTimeout)
+		// ctx.Err() is set when the client disconnected and WaitAny
+		// returned early. The resolve script carries an error payload
+		// that we don't need to flush — log once and bail.
+		if ctx.Err() != nil {
+			s.cancelStreams(streams)
+			s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream",
+				slog.Uint64("stream_id", f.id))
+			return kit.ErrClientGone
+		}
 		if err := buf.FlushTo(w); err != nil {
+			if isClientGone(ctx, err) {
+				s.cancelStreams(streams)
+				s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream (write)",
+					slog.Uint64("stream_id", f.id))
+				return kit.ErrClientGone
+			}
 			return err
 		}
 	}
 
 	buf.WriteString(s.shellTail)
-	return buf.FlushTo(w)
+	if err := buf.FlushTo(w); err != nil {
+		if isClientGone(ctx, err) {
+			s.Logger.DebugContext(ctx, "streaming: client disconnected before shell tail")
+			return kit.ErrClientGone
+		}
+		return err
+	}
+	return nil
+}
+
+// cancelStreams cancels any pending stream producers so goroutines don't
+// outlive the request when the client disconnects mid-stream.
+func (s *Server) cancelStreams(streams []streamedField) {
+	for _, f := range streams {
+		if c, ok := f.stream.(interface{ Cancel() }); ok {
+			c.Cancel()
+		}
+	}
 }
 
 // emitResolveScript writes a single <script>__sveltego__resolve(id, ...)</script>

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -604,14 +605,14 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 		if ctx.Err() != nil {
 			s.cancelStreams(streams)
 			s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream",
-				"stream_id", f.id)
+				slog.String("stream_id", f.id))
 			return kit.ErrClientGone
 		}
 		if err := buf.FlushTo(w); err != nil {
 			if isClientGone(ctx, err) {
 				s.cancelStreams(streams)
 				s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream (write)",
-					"stream_id", f.id)
+					slog.String("stream_id", f.id))
 				return kit.ErrClientGone
 			}
 			return err

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -605,14 +605,14 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 		if ctx.Err() != nil {
 			s.cancelStreams(streams)
 			s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream",
-				slog.String("stream_id", f.id))
+				slog.Uint64("stream_id", f.id))
 			return kit.ErrClientGone
 		}
 		if err := buf.FlushTo(w); err != nil {
 			if isClientGone(ctx, err) {
 				s.cancelStreams(streams)
 				s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream (write)",
-					slog.String("stream_id", f.id))
+					slog.Uint64("stream_id", f.id))
 				return kit.ErrClientGone
 			}
 			return err

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -605,14 +604,14 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 		if ctx.Err() != nil {
 			s.cancelStreams(streams)
 			s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream",
-				slog.Uint64("stream_id", f.id))
+				logKeyStreamID, f.id)
 			return kit.ErrClientGone
 		}
 		if err := buf.FlushTo(w); err != nil {
 			if isClientGone(ctx, err) {
 				s.cancelStreams(streams)
 				s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream (write)",
-					slog.Uint64("stream_id", f.id))
+					logKeyStreamID, f.id)
 				return kit.ErrClientGone
 			}
 			return err

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -605,14 +604,14 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 		if ctx.Err() != nil {
 			s.cancelStreams(streams)
 			s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream",
-				slog.Uint64("stream_id", f.id))
+				"stream_id", f.id)
 			return kit.ErrClientGone
 		}
 		if err := buf.FlushTo(w); err != nil {
 			if isClientGone(ctx, err) {
 				s.cancelStreams(streams)
 				s.Logger.DebugContext(ctx, "streaming: client disconnected mid-stream (write)",
-					slog.Uint64("stream_id", f.id))
+					"stream_id", f.id)
 				return kit.ErrClientGone
 			}
 			return err

--- a/packages/sveltego/server/streaming_integration_test.go
+++ b/packages/sveltego/server/streaming_integration_test.go
@@ -27,7 +27,7 @@ type countingHandler struct {
 	errs  atomic.Int64
 }
 
-func (h *countingHandler) Enabled(_ context.Context, lvl slog.Level) bool { return true }
+func (h *countingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
 func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
 	switch {
 	case r.Level >= slog.LevelError:

--- a/packages/sveltego/server/streaming_integration_test.go
+++ b/packages/sveltego/server/streaming_integration_test.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +17,30 @@ import (
 	"github.com/binsarjr/sveltego/render"
 	"github.com/binsarjr/sveltego/runtime/router"
 )
+
+// countingHandler is a slog.Handler that tallies records by level without
+// producing any output. Used to assert exactly one debug log and zero
+// error logs on client disconnect.
+type countingHandler struct {
+	debug atomic.Int64
+	warn  atomic.Int64
+	errs  atomic.Int64
+}
+
+func (h *countingHandler) Enabled(_ context.Context, lvl slog.Level) bool { return true }
+func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
+	switch {
+	case r.Level >= slog.LevelError:
+		h.errs.Add(1)
+	case r.Level >= slog.LevelWarn:
+		h.warn.Add(1)
+	case r.Level == slog.LevelDebug:
+		h.debug.Add(1)
+	}
+	return nil
+}
+func (h *countingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(_ string) slog.Handler      { return h }
 
 type streamingPageData struct {
 	Title string
@@ -307,6 +333,85 @@ func TestStreaming_ScriptInjectionEscaped(t *testing.T) {
 	}
 	if !strings.Contains(s, `</script`) {
 		t.Fatalf("expected escaped \\u003c/script in payload; body=%q", s)
+	}
+}
+
+func TestStreaming_ClientDisconnect_NoErrorSpam(t *testing.T) {
+	t.Parallel()
+
+	// stuck keeps the stream producer blocked so the client disconnects
+	// while the stream is still pending.
+	stuck := make(chan struct{})
+	t.Cleanup(func() { close(stuck) })
+
+	routes := []router.Route{{
+		Pattern:  "/",
+		Segments: segmentsFor("/"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return streamingPageData{
+				Posts: kit.Stream(func() ([]string, error) {
+					<-stuck
+					return nil, nil
+				}),
+			}, nil
+		},
+		Page: staticPage("<p>shell</p>"),
+	}}
+
+	logs := &countingHandler{}
+	srv, err := New(Config{
+		Routes: routes,
+		Shell:  testShell,
+		Logger: slog.New(logs),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// Start the request; read the shell so the server has flushed the
+	// first chunk before we disconnect.
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		resp, doErr := http.DefaultClient.Do(req)
+		if doErr != nil {
+			done <- doErr
+			return
+		}
+		// Read until the shell arrives so the server is past the first
+		// FlushTo and is now waiting on the stream.
+		br := bufio.NewReader(resp.Body)
+		readUntil(t, br, "<p>shell</p>", 500*time.Millisecond)
+		cancel() // disconnect
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		done <- nil
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not complete after client disconnect")
+	}
+
+	// Give the server goroutine a moment to record its log entries.
+	time.Sleep(50 * time.Millisecond)
+
+	if n := logs.errs.Load(); n != 0 {
+		t.Errorf("want 0 error log entries on client disconnect; got %d", n)
+	}
+	if n := logs.warn.Load(); n != 0 {
+		t.Errorf("want 0 warn log entries on client disconnect; got %d", n)
+	}
+	if n := logs.debug.Load(); n < 1 {
+		t.Errorf("want at least 1 debug log entry on client disconnect; got %d", n)
 	}
 }
 


### PR DESCRIPTION
Closes #177

## Why

When a client disconnects mid-stream, each subsequent write attempt logged an error. A disconnect is not a server fault — it's a normal operating condition and should not flood logs.

## What changed

- `kit.ErrClientGone` sentinel added to `streamed.go` — the canonical signal a disconnect was detected.
- `isClientGone` helper in `pipeline.go` covers: `EPIPE`, `ECONNRESET`, `net.ErrClosed`, `io.ErrClosedPipe`, any `*net.OpError`, and request context cancellation.
- `renderStreaming` checks `ctx.Err()` immediately after each `WaitAny` returns (catches cancel before the write) and checks `isClientGone` on every `FlushTo` error (catches OS-level write failures). On either detection: cancel remaining stream producers, log once at `DEBUG`, return `kit.ErrClientGone`.
- Caller maps `kit.ErrClientGone` → `errStreamingWrote` so `HandleError` is never invoked.
- New test `TestStreaming_ClientDisconnect_NoErrorSpam`: real HTTP server, client cancels after shell arrives; asserts 0 error/warn log entries and ≥1 debug entry. Race-detector clean.