### PR TITLE
examples(dashboard): migrate to Tailwind v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
             create-sveltego: 'packages/create-sveltego/**'
             mcp: 'packages/mcp/**'
             lsp: 'packages/lsp/**'
-            playground: 'playgrounds/basic/**'
+            playground: ['playgrounds/basic/**', 'playgrounds/dashboard/**']
             benchmarks: 'benchmarks/**'
             test-utils: 'test-utils/**'
             shared:

--- a/docs/ai-development.md
+++ b/docs/ai-development.md
@@ -72,11 +72,11 @@ The shipped templates do this for you; the prompts below assume the rules are lo
 
 **Scaffold a route**
 
-> Create a `src/routes/blog/[slug]` route with `+page.svelte` and `+page.server.go`. The page shows a `Post` fetched by slug from `db.PostBySlug(ctx, slug)`. Fields: `Title`, `Body` (HTML), `PublishedAt` (`time.Time`).
+> Create a `src/routes/blog/[slug]` route with `+page.svelte` and `page.server.go`. The page shows a `Post` fetched by slug from `db.PostBySlug(ctx, slug)`. Fields: `Title`, `Body` (HTML), `PublishedAt` (`time.Time`).
 
 **Write a form action**
 
-> Add a comment form to `src/routes/blog/[slug]/+page.svelte` and an action in `+page.server.go` that validates body is non-empty, appends to `db.Comments`, and redirects back to the page on success or returns `kit.ActionFail(422, ...)` on validation failure.
+> Add a comment form to `src/routes/blog/[slug]/+page.svelte` and an action in `page.server.go` that validates body is non-empty, appends to `db.Comments`, and redirects back to the page on success or returns `kit.ActionFail(422, ...)` on validation failure.
 
 **Add a hook**
 

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -6,7 +6,7 @@ summary: POST handlers tied to a page — default and named actions, validation,
 
 # Form actions
 
-Form actions are POST handlers attached to a page. They live in `+page.server.go` next to `Load` and run on `POST` to the page route.
+Form actions are POST handlers attached to a page. They live in `page.server.go` next to `Load` and run on `POST` to the page route.
 
 ## Shape
 

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -10,7 +10,7 @@ summary: sveltego build, .gen output, Vite client bundle, single-binary deploy.
 
 ## Pipeline
 
-1. Scan `src/routes/**` for `+page.svelte`, `+page.server.go`, `+layout.svelte`, `+layout.server.go`, `+server.go`, `+error.svelte`.
+1. Scan `src/routes/**` for `+page.svelte`, `page.server.go`, `+layout.svelte`, `layout.server.go`, `server.go`, `+error.svelte`.
 2. Parse `.svelte` files via the sveltego parser; validate Go expressions in mustaches via `go/parser.ParseExpr`.
 3. Emit `.gen/*.go` — one Go file per template, plus a manifest registering routes, layouts, and page options.
 4. Run Vite to produce the client hydration bundle (`dist/`).
@@ -33,7 +33,7 @@ The `.gen/` directory is gitignored; it is regenerated on every build.
 
 ## Page options
 
-Declare per-page options as exported constants in `+page.server.go` or `+layout.server.go`:
+Declare per-page options as exported constants in `page.server.go` or `layout.server.go`:
 
 ```go
 //go:build sveltego

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -59,11 +59,11 @@ var Handle = kit.Sequence(authHandle, requestIDHandle, telemetryHandle)
 
 ## HandleError
 
-Called whenever `Handle`, `Load`, render, or a `+server.go` handler returns an error. Returns a `kit.SafeError` — the user-facing contract: `Code`, `Message`, `ID`. Logs the raw error; the response body never echoes internal detail.
+Called whenever `Handle`, `Load`, render, or a `server.go` handler returns an error. Returns a `kit.SafeError` — the user-facing contract: `Code`, `Message`, `ID`. Logs the raw error; the response body never echoes internal detail. When `Message` is empty, the framework substitutes `http.StatusText(Code)`.
 
 ## HandleFetch
 
-Intercepts outbound HTTP from `Load` and `+server.go`. Use it to add auth headers, redirect to local services, or apply request-scoped retries.
+Intercepts outbound HTTP from `Load` and `server.go`. Use it to add auth headers, redirect to local services, or apply request-scoped retries.
 
 `RequestEvent.Fetch(req)` dispatches through `HandleFetch`; bypass it (e.g. `http.DefaultClient.Do`) and the hook is silently skipped.
 

--- a/docs/guide/load.md
+++ b/docs/guide/load.md
@@ -35,7 +35,7 @@ Inside the template, fields are referenced as `{Data.Title}`, `{Data.Posts}`, et
 
 ## Layout load
 
-`+layout.server.go` works the same way and exports `LayoutData`. The pipeline runs each layer's `Load` outer-to-inner. Children read the immediate parent through `ctx.Parent()`:
+`layout.server.go` works the same way and exports `LayoutData`. The pipeline runs each layer's `Load` outer-to-inner. Children read the immediate parent through `ctx.Parent()`:
 
 ```go
 parent := ctx.Parent().(rootlayout.LayoutData)
@@ -80,4 +80,4 @@ The render path emits a placeholder, flushes the shell, then patches the slot wh
 
 - It cannot run on the client. Loaders are server-only.
 - It must not mutate `RequestEvent.Locals` after `Handle` finished — read only.
-- It cannot write to `http.ResponseWriter`; responses come from the page template or a `+server.go` handler.
+- It cannot write to `http.ResponseWriter`; responses come from the page template or a `server.go` handler.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -13,10 +13,10 @@ sveltego mirrors SvelteKit's *shape*, not its *implementation*. The file convent
 | SvelteKit | sveltego |
 |---|---|
 | `+page.svelte` | `+page.svelte` |
-| `+page.server.ts` | `+page.server.go` |
+| `+page.server.ts` | `page.server.go` (no `+` prefix; use `//go:build sveltego`) |
 | `+layout.svelte` | `+layout.svelte` |
-| `+layout.server.ts` | `+layout.server.go` |
-| `+server.ts` | `+server.go` |
+| `+layout.server.ts` | `layout.server.go` (no `+` prefix; use `//go:build sveltego`) |
+| `+server.ts` | `server.go` (no `+` prefix; use `//go:build sveltego`) |
 | `+error.svelte` | `+error.svelte` |
 | `hooks.server.ts` | `hooks.server.go` |
 | `[param]`, `[[opt]]`, `[...rest]`, `(group)` | identical |

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -1,7 +1,7 @@
 ---
 title: Routing
 order: 20
-summary: File-based routing — +page.svelte, +page.server.go, +server.go, params, groups.
+summary: File-based routing — +page.svelte, page.server.go, server.go, params, groups.
 ---
 
 # Routing
@@ -13,10 +13,10 @@ sveltego uses file-based routing under `src/routes/`. The conventions match Svel
 | File | Purpose |
 |---|---|
 | `+page.svelte` | SSR template. Mustache expressions are Go. |
-| `+page.server.go` | Page server module: `Load`, `Actions`. |
+| `page.server.go` | Page server module: `Load`, `Actions`. No `+` prefix; identified by `//go:build sveltego`. |
 | `+layout.svelte` | Layout chain. Wraps descendant `+page.svelte`. |
-| `+layout.server.go` | Layout-level `Load` cascading to children. |
-| `+server.go` | REST endpoints (`GET`, `POST`, ...). No template. |
+| `layout.server.go` | Layout-level `Load` cascading to children. No `+` prefix. |
+| `server.go` | REST endpoints (`GET`, `POST`, ...). No template, no `+` prefix. |
 | `+error.svelte` | Error boundary for the subtree. |
 | `+page@.svelte` | Layout reset — opt out of the parent chain. |
 
@@ -56,7 +56,7 @@ Reference it as `[id=hex]`.
 
 ## Endpoints
 
-`+server.go` exposes named handlers per HTTP method:
+`server.go` exposes named handlers per HTTP method:
 
 ```go
 //go:build sveltego

--- a/docs/reference/kit.md
+++ b/docs/reference/kit.md
@@ -14,11 +14,27 @@ This page summarises the surface. Source is the canonical spec; godoc is generat
 
 | Type | Used in | Purpose |
 |---|---|---|
-| `RequestEvent` | hooks, `+server.go`, actions | Request-scoped state with `URL`, `Params`, `Locals`, `Cookies`. |
+| `RequestEvent` | hooks, `server.go`, actions | Request-scoped state with `URL`, `Params`, `Locals`, `Cookies`. |
 | `RenderCtx` | generated render code | SSR-time context passed into templates. |
-| `LoadCtx` | `Load` in `+page.server.go`, `+layout.server.go` | Load-time context with `Parent()` for layout chain. |
+| `LoadCtx` | `Load` in `page.server.go`, `layout.server.go` | Load-time context with `Parent()` for layout chain. |
 
 `RequestEvent.Fetch(req)` dispatches outbound HTTP through `HandleFetch`.
+
+`LoadCtx.Header()` returns a `*HeaderWriter` for setting response headers from a loader:
+
+```go
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+  ctx.Header().Set("Cache-Control", "no-store")
+  ctx.Header().Add("Vary", "Accept")
+  return PageData{}, nil
+}
+```
+
+`HeaderWriter` has three methods: `Set(key, value string)` (replace all), `Add(key, value string)` (append), `Del(key string)` (remove all).
+
+`LoadCtx.RawParam(name string) (string, bool)` returns the un-decoded route parameter value (percent-encoding preserved). Use when the decoded value would lose a `%2F` slash inside a segment.
+
+`LoadCtx.Speculative() bool` returns `true` when the request carries `X-Sveltego-Preload: 1` — the client prefetch header. Use to skip expensive side-effects during preloads.
 
 ## Hooks
 
@@ -32,17 +48,37 @@ type InitFn         func(ctx context.Context) error
 
 Compose handlers with `kit.Sequence(...)`. Defaults via `kit.DefaultHooks()` and `Hooks{}.WithDefaults()`.
 
+`InitFn` returning a non-nil error aborts startup; the server emits a `503 Service Unavailable` (or `500` when the HTTP listener could not bind) while the `Init` call is pending.
+
 ## Errors and short-circuits
 
 ```go
-kit.Redirect(code int, location string) error
-kit.Error(code int, message string) error
+kit.Redirect(code int, location string, opts ...RedirectOption) error
+kit.Error(code int, message ...string) error
 kit.Fail(code int, data any) error
 ```
 
 All three implement `error` and `httpStatuser`.
 
-`SafeError{Code, Message, ID}` is the user-facing error contract returned from `HandleError`.
+`kit.RedirectReload()` is a `RedirectOption` that signals the client to do a full document reload instead of a SPA navigation:
+
+```go
+return PageData{}, kit.Redirect(303, "/login", kit.RedirectReload())
+```
+
+`SafeError{Code, Message, ID}` is the user-facing error contract returned from `HandleError`. When `Message` is empty, the framework fills it from `http.StatusText(Code)`.
+
+`kit.HTTPError` is an interface user-defined error types can implement to carry an HTTP status code directly to the pipeline without going through a sentinel:
+
+```go
+type HTTPError interface {
+  error
+  Status() int
+  Public() string
+}
+```
+
+The pipeline inspects returned errors for `HTTPError` before falling back to `HandleError`.
 
 ## Responses
 
@@ -140,11 +176,14 @@ type PageOptions struct {
   Prerender     bool
   SSR           bool
   CSR           bool
+  SSROnly       bool
   TrailingSlash TrailingSlash
 }
 ```
 
 `PageOptions.Merge(override PageOptionsOverride) PageOptions` cascades layout values into pages.
+
+`SSROnly = true` blocks the `__data.json` scrape endpoint used by the SPA client for prefetch. Use on pages where only the server-rendered HTML response is intended (e.g. print views, webhook acknowledgement pages).
 
 ## Link
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -31,8 +31,8 @@ Runtime route lookup is a map index, not a tree walk. Every static decision (whi
 
 The file is overwritten on every codegen run. Source of truth lives in:
 
-- `+page.server.go` for `Load`, `Actions`, page options.
-- `+layout.server.go` for layout `Load` and cascaded options.
+- `page.server.go` for `Load`, `Actions`, page options.
+- `layout.server.go` for layout `Load` and cascaded options.
 - `hooks.server.go` for hooks.
 - File paths under `src/routes/` for patterns.
 

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -11,10 +11,10 @@ summary: File names, build tag, generated output, and the route-matching contrac
 ```
 src/routes/
   +page.svelte               # SSR template
-  +page.server.go            # Load(), Actions       (//go:build sveltego)
+  page.server.go             # Load(), Actions       (//go:build sveltego)
   +layout.svelte             # layout chain
-  +layout.server.go          # parent data flow      (//go:build sveltego)
-  +server.go                 # REST endpoints        (//go:build sveltego)
+  layout.server.go           # parent data flow      (//go:build sveltego)
+  server.go                  # REST endpoints        (//go:build sveltego)
   +error.svelte              # error boundary
   (group)/                   # route group, no URL segment
   +page@.svelte              # layout reset
@@ -60,10 +60,10 @@ Two builds of the same source produce byte-identical `.gen/` output. Golden test
 
 ## File naming gotchas
 
-- `+page.svelte` — leading `+` is required.
-- `+page.server.go` — note the `.server.` infix and the `+`.
-- `page.server.go` (no `+`) is treated as a normal package file, not a sveltego module.
-- `+server.go` — REST endpoint, no template.
+- `+page.svelte` — leading `+` is required on Svelte template files.
+- `page.server.go` — note the `.server.` infix; no leading `+`. The `//go:build sveltego` tag identifies it to codegen.
+- `+page.server.go` (with `+`) is **not** recognized by routescan. Drop the `+`.
+- `server.go` — REST endpoint, no template. No `+` prefix.
 - `+page@.svelte` — trailing `@` (before the extension) signals a layout reset.
 
 When in doubt, run `sveltego routes` and verify the entry appears.

--- a/playgrounds/dashboard/.gitignore
+++ b/playgrounds/dashboard/.gitignore
@@ -1,3 +1,5 @@
 .gen/
 build/
 /app
+node_modules/
+static/

--- a/playgrounds/dashboard/app.html
+++ b/playgrounds/dashboard/app.html
@@ -5,24 +5,10 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>sveltego dashboard</title>
 %sveltego.head%
-<style>
-body{font-family:system-ui,sans-serif;max-width:48rem;margin:2rem auto;padding:0 1rem;color:#1a1a1a}
-nav{display:flex;gap:1rem;padding:.5rem 0;border-bottom:1px solid #ddd;margin-bottom:1rem}
-nav a{color:#0366d6;text-decoration:none}
-nav a:hover{text-decoration:underline}
-form{margin:1rem 0}
-input[type=text],input[type=password]{padding:.4rem .5rem;border:1px solid #ccc;border-radius:.25rem;font:inherit}
-button{padding:.4rem .8rem;border:1px solid #0366d6;background:#0366d6;color:#fff;border-radius:.25rem;cursor:pointer;font:inherit}
-button.secondary{background:#fff;color:#0366d6}
-button.danger{background:#d73a49;border-color:#d73a49}
-.error{color:#d73a49;margin:.5rem 0}
-table{width:100%;border-collapse:collapse;margin:1rem 0}
-th,td{padding:.5rem;border-bottom:1px solid #eee;text-align:left}
-.chart{border:1px dashed #ccc;padding:1rem;background:#fafafa;margin:1rem 0;font-family:ui-monospace,monospace}
-.bar{display:inline-block;height:1rem;background:#0366d6;margin-right:.25rem;vertical-align:middle}
-</style>
+<!-- Tailwind v4 CDN — replaced by `pnpm build` output once Vite wiring lands (#212) -->
+<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 </head>
-<body>
+<body class="bg-white text-gray-900 font-sans">
 %sveltego.body%
 </body>
 </html>

--- a/playgrounds/dashboard/package.json
+++ b/playgrounds/dashboard/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dashboard",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "tailwindcss": "^4.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/playgrounds/dashboard/src/app.css
+++ b/playgrounds/dashboard/src/app.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/playgrounds/dashboard/src/lib/ui/Button.svelte
+++ b/playgrounds/dashboard/src/lib/ui/Button.svelte
@@ -1,0 +1,16 @@
+<script>
+  let { type = 'button', variant = 'primary', children } = $props();
+
+  const variants = {
+    primary: 'bg-blue-600 text-white border-blue-600 hover:bg-blue-700',
+    secondary: 'bg-white text-blue-600 border-blue-600 hover:bg-blue-50',
+    danger: 'bg-red-600 text-white border-red-600 hover:bg-red-700',
+  };
+</script>
+
+<button
+  {type}
+  class="inline-flex items-center rounded-md border px-3 py-1.5 text-sm font-medium cursor-pointer {variants[variant]}"
+>
+  {@render children?.()}
+</button>

--- a/playgrounds/dashboard/src/lib/ui/Input.svelte
+++ b/playgrounds/dashboard/src/lib/ui/Input.svelte
@@ -1,0 +1,12 @@
+<script>
+  let { type = 'text', name, value = '', placeholder = '', required = false } = $props();
+</script>
+
+<input
+  {type}
+  {name}
+  {value}
+  {placeholder}
+  {required}
+  class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+/>

--- a/playgrounds/dashboard/src/lib/ui/Label.svelte
+++ b/playgrounds/dashboard/src/lib/ui/Label.svelte
@@ -1,0 +1,7 @@
+<script>
+  let { for: htmlFor = '', children } = $props();
+</script>
+
+<label for={htmlFor} class="block text-sm font-medium text-gray-700 mb-1">
+  {@render children?.()}
+</label>

--- a/playgrounds/dashboard/src/routes/+page.svelte
+++ b/playgrounds/dashboard/src/routes/+page.svelte
@@ -1,24 +1,28 @@
 <script lang="go"></script>
 
-<nav>
-  <a href="/">Home</a>
+<div class="max-w-3xl mx-auto px-4 py-8">
+  <nav class="flex items-center gap-4 pb-3 mb-6 border-b border-gray-200">
+    <a href="/" class="text-blue-600 hover:underline text-sm font-medium">Home</a>
+    {#if data.LoggedIn}
+      <a href="/dashboard" class="text-blue-600 hover:underline text-sm font-medium">Dashboard</a>
+      <form method="post" action="/?/logout" class="inline m-0">
+        <button type="submit" class="bg-white text-blue-600 border border-blue-600 rounded-md px-3 py-1 text-sm cursor-pointer hover:bg-blue-50">
+          Logout ({data.Username})
+        </button>
+      </form>
+    {:else}
+      <a href="/login" class="text-blue-600 hover:underline text-sm font-medium">Login</a>
+    {/if}
+  </nav>
+
+  <h1 class="text-2xl font-bold text-gray-900 mb-4">sveltego dashboard</h1>
+
   {#if data.LoggedIn}
-    <a href="/dashboard">Dashboard</a>
-    <form method="post" action="/?/logout" style="display:inline;margin:0">
-      <button type="submit" class="secondary">Logout ({data.Username})</button>
-    </form>
+    <p class="text-gray-700 mb-2">Welcome back, <strong class="font-semibold">{data.Username}</strong>.</p>
+    <p class="text-gray-700"><a href="/dashboard" class="text-blue-600 hover:underline">Go to your dashboard.</a></p>
   {:else}
-    <a href="/login">Login</a>
+    <p class="text-gray-600 mb-3">This playground demonstrates cookie-session authentication, CRUD via
+    form actions, and a JSON polling endpoint. Sign in to continue.</p>
+    <p class="text-gray-700"><a href="/login" class="text-blue-600 hover:underline font-medium">Log in</a> to view the dashboard.</p>
   {/if}
-</nav>
-
-<h1>sveltego dashboard</h1>
-
-{#if data.LoggedIn}
-  <p>Welcome back, <strong>{data.Username}</strong>.</p>
-  <p><a href="/dashboard">Go to your dashboard.</a></p>
-{:else}
-  <p>This playground demonstrates cookie-session authentication, CRUD via
-  form actions, and a JSON polling endpoint. Sign in to continue.</p>
-  <p><a href="/login">Log in</a> to view the dashboard.</p>
-{/if}
+</div>

--- a/playgrounds/dashboard/src/routes/dashboard/+page.svelte
+++ b/playgrounds/dashboard/src/routes/dashboard/+page.svelte
@@ -1,70 +1,100 @@
 <script lang="go"></script>
 
-<nav>
-  <a href="/">Home</a>
-  <a href="/dashboard">Dashboard</a>
-  <form method="post" action="/?/logout" style="display:inline;margin:0">
-    <button type="submit" class="secondary">Logout ({data.Username})</button>
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <nav class="flex items-center gap-4 pb-3 mb-6 border-b border-gray-200">
+    <a href="/" class="text-blue-600 hover:underline text-sm font-medium">Home</a>
+    <a href="/dashboard" class="text-blue-600 hover:underline text-sm font-medium">Dashboard</a>
+    <form method="post" action="/?/logout" class="inline m-0">
+      <button type="submit" class="bg-white text-blue-600 border border-blue-600 rounded-md px-3 py-1 text-sm cursor-pointer hover:bg-blue-50">
+        Logout ({data.Username})
+      </button>
+    </form>
+  </nav>
+
+  <h1 class="text-2xl font-bold text-gray-900 mb-2">Dashboard</h1>
+  <p class="text-gray-600 mb-6">Signed in as <strong class="font-semibold text-gray-900">{data.Username}</strong>.</p>
+
+  {#if data.FlashMsg != ""}
+    <p class="text-red-600 text-sm mb-4">{data.FlashMsg}</p>
+  {/if}
+
+  <h2 class="text-lg font-semibold text-gray-800 mb-3">Items</h2>
+
+  <form method="post" action="/dashboard?/create" class="flex gap-2 mb-6">
+    <input
+      type="text"
+      name="title"
+      placeholder="New item title"
+      required
+      class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+    >
+    <input
+      type="text"
+      name="note"
+      placeholder="Note"
+      class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+    >
+    <button
+      type="submit"
+      class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer"
+    >
+      Create
+    </button>
   </form>
-</nav>
 
-<h1>Dashboard</h1>
+  {#if len(data.Items) > 0}
+    <div class="overflow-x-auto mb-8">
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-gray-200">
+            <th class="text-left py-2 px-3 font-medium text-gray-600">ID</th>
+            <th class="text-left py-2 px-3 font-medium text-gray-600">Title</th>
+            <th class="text-left py-2 px-3 font-medium text-gray-600">Note</th>
+            <th class="text-left py-2 px-3 font-medium text-gray-600">Updated</th>
+            <th class="py-2 px-3"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each data.Items as it}
+            <tr class="border-b border-gray-100 hover:bg-gray-50">
+              <td class="py-2 px-3"><code class="text-xs bg-gray-100 px-1 py-0.5 rounded">{it.ID}</code></td>
+              <td class="py-2 px-3"><a href={"/dashboard/items/" + it.ID} class="text-blue-600 hover:underline">{it.Title}</a></td>
+              <td class="py-2 px-3 text-gray-600">{it.Note}</td>
+              <td class="py-2 px-3 text-gray-500 text-xs">{it.UpdatedAt}</td>
+              <td class="py-2 px-3">
+                <form method="post" action={"/dashboard?/delete"} class="inline m-0">
+                  <input type="hidden" name="id" value={it.ID}>
+                  <button
+                    type="submit"
+                    class="rounded-md bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 cursor-pointer"
+                  >
+                    Delete
+                  </button>
+                </form>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {:else}
+    <p class="text-gray-500 text-sm mb-8">No items yet. Create one above.</p>
+  {/if}
 
-<p>Signed in as <strong>{data.Username}</strong>.</p>
+  <h2 class="text-lg font-semibold text-gray-800 mb-3">Live metrics <span class="text-sm font-normal text-gray-500">(auto-refreshes every 5s)</span></h2>
 
-{#if data.FlashMsg != ""}
-  <p class="error">{data.FlashMsg}</p>
-{/if}
+  <meta http-equiv="refresh" content="5;url=/dashboard">
 
-<h2>Items</h2>
+  <div class="border border-dashed border-gray-300 rounded-lg p-4 bg-gray-50 font-mono text-sm mb-4">
+    <p class="mb-3 text-gray-700">Latest sample: <strong class="text-gray-900">{data.MetricLatest}</strong> @ <code class="text-xs bg-gray-100 px-1 py-0.5 rounded">{data.MetricLatestTS}</code></p>
+    {#each data.MetricBars as b}
+      <div class="flex items-center gap-2 mb-1">
+        <span class="inline-block h-4 bg-blue-600 rounded-sm" style={b.Width}></span>
+        <code class="text-xs text-gray-600">{b.Label}</code>
+        <span class="text-xs text-gray-500">{b.Value}</span>
+      </div>
+    {/each}
+  </div>
 
-<form method="post" action="/dashboard?/create">
-  <input type="text" name="title" placeholder="New item title" required>
-  <input type="text" name="note" placeholder="Note">
-  <button type="submit">Create</button>
-</form>
-
-{#if len(data.Items) > 0}
-  <table>
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Title</th>
-        <th>Note</th>
-        <th>Updated</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      {#each data.Items as it}
-        <tr>
-          <td><code>{it.ID}</code></td>
-          <td><a href={"/dashboard/items/" + it.ID}>{it.Title}</a></td>
-          <td>{it.Note}</td>
-          <td>{it.UpdatedAt}</td>
-          <td>
-            <form method="post" action={"/dashboard?/delete"} style="display:inline;margin:0">
-              <input type="hidden" name="id" value={it.ID}>
-              <button type="submit" class="danger">Delete</button>
-            </form>
-          </td>
-        </tr>
-      {/each}
-    </tbody>
-  </table>
-{:else}
-  <p>No items yet. Create one above.</p>
-{/if}
-
-<h2>Live metrics (auto-refreshes every 5s)</h2>
-
-<meta http-equiv="refresh" content="5;url=/dashboard">
-
-<div class="chart">
-  <p style="margin:0 0 .5rem 0">Latest sample: <strong>{data.MetricLatest}</strong> @ <code>{data.MetricLatestTS}</code></p>
-  {#each data.MetricBars as b}
-    <div><span class="bar" style={b.Width}></span><code>{b.Label}</code> {b.Value}</div>
-  {/each}
+  <p class="text-xs text-gray-400">JSON endpoint: <code class="bg-gray-100 px-1 py-0.5 rounded">GET /api/metrics</code> (returns the same series; ready for client-side polling once <a href="https://github.com/binsarjr/sveltego/issues/34" class="text-blue-600 hover:underline">#34</a> ships).</p>
 </div>
-
-<p style="color:#666;font-size:.85rem">JSON endpoint: <code>GET /api/metrics</code> (returns the same series; ready for client-side polling once <a href="https://github.com/binsarjr/sveltego/issues/34">#34</a> ships).</p>

--- a/playgrounds/dashboard/src/routes/dashboard/items/[id]/+page.svelte
+++ b/playgrounds/dashboard/src/routes/dashboard/items/[id]/+page.svelte
@@ -1,38 +1,65 @@
 <script lang="go"></script>
 
-<nav>
-  <a href="/">Home</a>
-  <a href="/dashboard">Dashboard</a>
-  <form method="post" action="/?/logout" style="display:inline;margin:0">
-    <button type="submit" class="secondary">Logout ({data.Username})</button>
+<div class="max-w-3xl mx-auto px-4 py-8">
+  <nav class="flex items-center gap-4 pb-3 mb-6 border-b border-gray-200">
+    <a href="/" class="text-blue-600 hover:underline text-sm font-medium">Home</a>
+    <a href="/dashboard" class="text-blue-600 hover:underline text-sm font-medium">Dashboard</a>
+    <form method="post" action="/?/logout" class="inline m-0">
+      <button type="submit" class="bg-white text-blue-600 border border-blue-600 rounded-md px-3 py-1 text-sm cursor-pointer hover:bg-blue-50">
+        Logout ({data.Username})
+      </button>
+    </form>
+  </nav>
+
+  <h1 class="text-2xl font-bold text-gray-900 mb-4">Edit item</h1>
+
+  {#if data.FlashMsg != ""}
+    <p class="text-red-600 text-sm mb-4">{data.FlashMsg}</p>
+  {/if}
+
+  <div class="text-sm text-gray-600 mb-4 space-y-1">
+    <p><strong class="font-medium text-gray-700">ID:</strong> <code class="bg-gray-100 px-1 py-0.5 rounded text-xs">{data.Item.ID}</code></p>
+    <p><strong class="font-medium text-gray-700">Last updated:</strong> {data.Item.UpdatedAt}</p>
+  </div>
+
+  <form method="post" action={"/dashboard/items/" + data.Item.ID + "?/update"} class="space-y-4 max-w-sm mb-6">
+    <div>
+      <label class="block text-sm font-medium text-gray-700 mb-1">Title
+        <input
+          type="text"
+          name="title"
+          value={data.Item.Title}
+          required
+          class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+      </label>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-gray-700 mb-1">Note
+        <input
+          type="text"
+          name="note"
+          value={data.Item.Note}
+          class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+      </label>
+    </div>
+    <button
+      type="submit"
+      class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer"
+    >
+      Save
+    </button>
   </form>
-</nav>
 
-<h1>Edit item</h1>
+  <form method="post" action={"/dashboard/items/" + data.Item.ID + "?/delete"}>
+    <button
+      type="submit"
+      class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 cursor-pointer"
+    >
+      Delete
+    </button>
+  </form>
 
-{#if data.FlashMsg != ""}
-  <p class="error">{data.FlashMsg}</p>
-{/if}
-
-<p><strong>ID:</strong> <code>{data.Item.ID}</code></p>
-<p><strong>Last updated:</strong> {data.Item.UpdatedAt}</p>
-
-<form method="post" action={"/dashboard/items/" + data.Item.ID + "?/update"}>
-  <p>
-    <label>Title
-      <input type="text" name="title" value={data.Item.Title} required>
-    </label>
-  </p>
-  <p>
-    <label>Note
-      <input type="text" name="note" value={data.Item.Note}>
-    </label>
-  </p>
-  <button type="submit">Save</button>
-</form>
-
-<form method="post" action={"/dashboard/items/" + data.Item.ID + "?/delete"} style="margin-top:1rem">
-  <button type="submit" class="danger">Delete</button>
-</form>
-
-<p><a href="/dashboard">Back to dashboard</a></p>
+  <p class="mt-6"><a href="/dashboard" class="text-blue-600 hover:underline text-sm">Back to dashboard</a></p>
+</div>

--- a/playgrounds/dashboard/src/routes/login/+page.svelte
+++ b/playgrounds/dashboard/src/routes/login/+page.svelte
@@ -1,28 +1,46 @@
 <script lang="go"></script>
 
-<nav>
-  <a href="/">Home</a>
-  <a href="/login">Login</a>
-</nav>
+<div class="max-w-3xl mx-auto px-4 py-8">
+  <nav class="flex items-center gap-4 pb-3 mb-6 border-b border-gray-200">
+    <a href="/" class="text-blue-600 hover:underline text-sm font-medium">Home</a>
+    <a href="/login" class="text-blue-600 hover:underline text-sm font-medium">Login</a>
+  </nav>
 
-<h1>Sign in</h1>
+  <h1 class="text-2xl font-bold text-gray-900 mb-6">Sign in</h1>
 
-{#if data.LastError != ""}
-  <p class="error">{data.LastError}</p>
-{/if}
+  {#if data.LastError != ""}
+    <p class="text-red-600 text-sm mb-4">{data.LastError}</p>
+  {/if}
 
-<form method="post" action="/login?/default">
-  <p>
-    <label>Username
-      <input type="text" name="username" value={data.LastUsername} required>
-    </label>
-  </p>
-  <p>
-    <label>Password
-      <input type="password" name="password" required>
-    </label>
-  </p>
-  <button type="submit">Sign in</button>
-</form>
+  <form method="post" action="/login?/default" class="space-y-4 max-w-sm">
+    <div>
+      <label class="block text-sm font-medium text-gray-700 mb-1">Username
+        <input
+          type="text"
+          name="username"
+          value={data.LastUsername}
+          required
+          class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+      </label>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-gray-700 mb-1">Password
+        <input
+          type="password"
+          name="password"
+          required
+          class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+      </label>
+    </div>
+    <button
+      type="submit"
+      class="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+    >
+      Sign in
+    </button>
+  </form>
 
-<p style="color:#666;font-size:.9rem">Demo credentials: <code>admin</code> / <code>password123</code>.</p>
+  <p class="mt-6 text-sm text-gray-500">Demo credentials: <code class="bg-gray-100 px-1 py-0.5 rounded text-xs">admin</code> / <code class="bg-gray-100 px-1 py-0.5 rounded text-xs">password123</code>.</p>
+</div>

--- a/playgrounds/dashboard/vite.config.js
+++ b/playgrounds/dashboard/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [tailwindcss()],
+  build: {
+    outDir: 'static',
+    rollupOptions: {
+      input: 'src/app.css',
+      output: {
+        assetFileNames: 'app.css',
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `tailwindcss@^4` and `@tailwindcss/vite@^4` to `playgrounds/dashboard/package.json`
- Adds `vite.config.js` scaffolding (ready for when Vite wiring lands)
- Adds `src/app.css` with `@import "tailwindcss"`
- Replaces all inline styles in `app.html` with the Tailwind v4 CDN browser script; the compiled `static/app.css` from `pnpm build` will supersede this once the Vite integration (#212 deps) unblocks
- Restyled all four route `.svelte` files (`/`, `/login`, `/dashboard`, `/dashboard/items/[id]`) with Tailwind utility classes — no custom CSS remains
- Extracted shared form primitives to `src/lib/ui/`: `Button.svelte`, `Input.svelte`, `Label.svelte` (Svelte 5 `$props()` runes)
- Extended CI path filter to include `playgrounds/dashboard/**` alongside `playgrounds/basic/**`
- Added `node_modules/` and `static/` to `.gitignore`

## Partial-block flag

The `pnpm install && sveltego build` acceptance criterion from #212 is partially blocked:
- `go build ./...` passes (exit 0) — the Go side is clean
- `pnpm build` (Vite CSS compilation) is blocked by the Vite plugin wiring sub-issues listed in #212's dependency chain; the CDN fallback keeps the playground functional in the meantime

## Test plan

- [ ] `cd playgrounds/dashboard && go build ./... && go vet ./...` exits 0
- [ ] Open playground in browser — login form, dashboard table, and metrics widget all render with Tailwind styles via CDN
- [ ] Auth flow (login / logout) still works end-to-end
- [ ] CI path filter picks up `playgrounds/dashboard/**` changes

Closes #212