### PR TITLE
feat(codegen): detect+resolve PageData Form collision

### DIFF
--- a/packages/sveltego/internal/codegen/actions_pagedata_test.go
+++ b/packages/sveltego/internal/codegen/actions_pagedata_test.go
@@ -1,6 +1,8 @@
 package codegen
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -42,5 +44,61 @@ func TestGenerate_NoActions_NoFormField(t *testing.T) {
 	}
 	if strings.Contains(string(out), "Form any") {
 		t.Errorf("unexpected Form field when HasActions=false:\n%s", out)
+	}
+}
+
+// TestGenerate_HasActions_UserDeclaredFormDeduped verifies that when a
+// page.server.go Load() return already contains `Form any` AND HasActions is
+// true, codegen emits exactly one Form field (no compile-error duplicate).
+// This is the fix for #143.
+func TestGenerate_HasActions_UserDeclaredFormDeduped(t *testing.T) {
+	t.Parallel()
+
+	// Write a transient server file that declares Form any in its Load return.
+	serverSrc := `package fixture
+
+func Load() (struct {
+	Title string
+	Form  any
+}, error) {
+	return struct {
+		Title string
+		Form  any
+	}{Title: "hello"}, nil
+}
+`
+	dir := t.TempDir()
+	serverPath := filepath.Join(dir, "page.server.go")
+	if err := os.WriteFile(serverPath, []byte(serverSrc), 0o644); err != nil {
+		t.Fatalf("write server file: %v", err)
+	}
+
+	src := []byte("<h1>{data.Title}</h1>")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{
+		PackageName:    "page",
+		HasActions:     true,
+		ServerFilePath: serverPath,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	got := string(out)
+
+	// Must contain exactly one Form field. go/format may align struct columns
+	// with extra spaces (e.g. `Form  any` when next to `Title string`), so
+	// search for the field name followed by at least one space, not the exact
+	// "Form any" two-token string.
+	formCount := strings.Count(got, "\tForm ")
+	if formCount != 1 {
+		t.Errorf("expected exactly 1 Form field in struct body, got %d:\n%s", formCount, got)
+	}
+
+	// Title field from Load must still be present.
+	if !strings.Contains(got, "Title string") {
+		t.Errorf("expected `Title string` in PageData:\n%s", got)
 	}
 }

--- a/packages/sveltego/internal/codegen/codegen.go
+++ b/packages/sveltego/internal/codegen/codegen.go
@@ -80,6 +80,10 @@ func Generate(frag *ast.Fragment, opts Options) ([]byte, error) {
 		return nil, err
 	}
 	if opts.HasActions {
+		// Remove any user-declared Form field before injecting the contract field.
+		// This allows page.server.go to declare `Form any` in its Load return
+		// without causing a duplicate-field compile error. See #143.
+		pageData.Fields = dropField(pageData.Fields, "Form")
 		pageData.Fields = append(pageData.Fields, pageDataField{Name: "Form", Type: "any"})
 	}
 

--- a/packages/sveltego/internal/codegen/pagedata.go
+++ b/packages/sveltego/internal/codegen/pagedata.go
@@ -171,6 +171,17 @@ func collectSelectorPackages(expr goast.Expr, set map[string]struct{}) {
 	})
 }
 
+// dropField returns a new slice with any field whose Name matches name removed.
+func dropField(fields []pageDataField, name string) []pageDataField {
+	var out []pageDataField
+	for _, f := range fields {
+		if f.Name != name {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // emitPageDataStruct writes `type PageData = struct{...}` as a type alias
 // (note the `=`). The alias preserves type identity between the user's
 // inline anonymous struct literal returned by Load() and PageData, so the


### PR DESCRIPTION
## Summary

- When `HasActions=true`, codegen unconditionally appended `Form any` to `pageData.Fields` without checking if the field already existed.
- Add `dropField` helper in `pagedata.go` that strips any existing field by name before injection.
- Apply `dropField("Form")` before the `HasActions` append in `Generate()`, so user-declared `Form any` in `Load()` is silently deduplicated.

## Test plan

- [x] `TestGenerate_HasActions_AddsFormField` — pre-existing, still passes (no server file, Form injected from scratch)
- [x] `TestGenerate_NoActions_NoFormField` — pre-existing, still passes
- [x] `TestGenerate_HasActions_UserDeclaredFormDeduped` — **new**: writes a temp `page.server.go` with `Form any` in Load return + `HasActions=true`; asserts exactly one `Form` field in emitted PageData and `Title` is preserved
- [x] Full suite: 376 tests, race detector clean

Closes #143