### PR TITLE
feat(kit): Streamed accepts iter.Seq2 + chan sources (#164)

### DIFF
--- a/packages/sveltego/exports/kit/streamed.go
+++ b/packages/sveltego/exports/kit/streamed.go
@@ -186,7 +186,7 @@ func (s *Streamed[T]) WaitAny(ctx context.Context, timeout time.Duration) (any, 
 func StreamedSeq[T any](ctx context.Context, seq iter.Seq2[T, error]) *Streamed[T] {
 	return StreamCtx(ctx, func(c context.Context) (T, error) {
 		var (
-			last    T
+			last     T
 			firstErr error
 		)
 		// Call seq directly with a custom yield so we can return false to

--- a/packages/sveltego/exports/kit/streamed.go
+++ b/packages/sveltego/exports/kit/streamed.go
@@ -3,6 +3,7 @@ package kit
 import (
 	"context"
 	"errors"
+	"iter"
 	"sync/atomic"
 	"time"
 )
@@ -165,6 +166,79 @@ func (s *Streamed[T]) Wait(ctx context.Context, timeout time.Duration) (T, error
 func (s *Streamed[T]) WaitAny(ctx context.Context, timeout time.Duration) (any, error) {
 	v, err := s.Wait(ctx, timeout)
 	return v, err
+}
+
+// StreamedSeq drains seq in a goroutine and resolves with the last value
+// yielded (and the first non-nil error encountered, if any). Iteration
+// stops early when ctx is cancelled. The goroutine starts immediately so
+// work overlaps with shell rendering.
+//
+// Each (v, nil) pair from seq overwrites the accumulated value; a non-nil
+// error terminates the drain and becomes the resolved error. When no value
+// was yielded before an error or cancellation, the zero value of T is
+// returned.
+//
+// ctx must not be nil.
+//
+// Note: the current streaming pipeline resolves Streamed[T] as a single
+// value. Full chunk-by-chunk SSE emission requires the hydration format
+// defined in issue #35.
+func StreamedSeq[T any](ctx context.Context, seq iter.Seq2[T, error]) *Streamed[T] {
+	return StreamCtx(ctx, func(c context.Context) (T, error) {
+		var (
+			last    T
+			firstErr error
+		)
+		// Call seq directly with a custom yield so we can return false to
+		// stop iteration early without the "continued after false" panic that
+		// a bare return inside for-range would cause.
+		seq(func(v T, err error) bool {
+			// Check cancellation before accepting the yielded value.
+			select {
+			case <-c.Done():
+				firstErr = c.Err()
+				return false // stop iteration
+			default:
+			}
+			if err != nil {
+				firstErr = err
+				return false // stop iteration
+			}
+			last = v
+			return true
+		})
+		return last, firstErr
+	})
+}
+
+// StreamedChan drains ch in a goroutine and resolves with the last value
+// received. Draining stops when ch is closed or ctx is cancelled.
+// The goroutine starts immediately so work overlaps with shell rendering.
+//
+// Values are accumulated in order; the resolved result is the final
+// received value. When the channel is closed before any value arrives,
+// the zero value of T is returned with a nil error.
+//
+// ctx must not be nil.
+//
+// Note: the current streaming pipeline resolves Streamed[T] as a single
+// value. Full chunk-by-chunk SSE emission requires the hydration format
+// defined in issue #35.
+func StreamedChan[T any](ctx context.Context, ch <-chan T) *Streamed[T] {
+	return StreamCtx(ctx, func(c context.Context) (T, error) {
+		var last T
+		for {
+			select {
+			case <-c.Done():
+				return last, c.Err()
+			case v, ok := <-ch:
+				if !ok {
+					return last, nil
+				}
+				last = v
+			}
+		}
+	})
 }
 
 // ctxDone returns ctx.Done() or a nil channel when ctx is nil. A nil

--- a/packages/sveltego/exports/kit/streamed_test.go
+++ b/packages/sveltego/exports/kit/streamed_test.go
@@ -3,6 +3,7 @@ package kit_test
 import (
 	"context"
 	"errors"
+	"iter"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -242,4 +243,159 @@ func TestStreamCtx_NoLeakAfterRequestCancel(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("goroutine leak: baseline=%d current=%d", baseline, runtime.NumGoroutine())
+}
+
+// --- StreamedChan tests ---
+
+// TestStreamedChan_ThreeValues verifies that all three values pushed into the
+// channel reach the resolved result (last one wins, matching the drain contract).
+func TestStreamedChan_ThreeValues(t *testing.T) {
+	t.Parallel()
+	ch := make(chan int, 3)
+	ch <- 1
+	ch <- 2
+	ch <- 3
+	close(ch)
+
+	s := kit.StreamedChan(context.Background(), ch)
+	got, err := s.Wait(context.Background(), time.Second)
+	if err != nil {
+		t.Fatalf("Wait err = %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("got %d, want 3 (last value)", got)
+	}
+}
+
+// TestStreamedChan_CtxCancelMidStream verifies that cancelling the request
+// context stops draining and surfaces context.Canceled.
+func TestStreamedChan_CtxCancelMidStream(t *testing.T) {
+	t.Parallel()
+
+	// Unbuffered so the drain blocks after reading the first value.
+	ch := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := kit.StreamedChan(ctx, ch)
+
+	// Send first value, then cancel before sending more.
+	ch <- 10
+	cancel()
+
+	_, err := s.Wait(context.Background(), 2*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+
+	// Drain any leftover read attempt by closing the channel so the goroutine
+	// doesn't leak across test boundaries.
+	close(ch)
+}
+
+// TestStreamedChan_EmptyChannel resolves with zero and nil when the channel
+// is closed before any value arrives.
+func TestStreamedChan_EmptyChannel(t *testing.T) {
+	t.Parallel()
+	ch := make(chan string)
+	close(ch)
+
+	s := kit.StreamedChan(context.Background(), ch)
+	got, err := s.Wait(context.Background(), time.Second)
+	if err != nil {
+		t.Fatalf("Wait err = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got %q, want empty string", got)
+	}
+}
+
+// --- StreamedSeq tests ---
+
+// intSeq returns an iter.Seq2[int, error] that yields the given values with
+// nil errors, making it easy to drive StreamedSeq in tests.
+func intSeq(vals ...int) iter.Seq2[int, error] {
+	return func(yield func(int, error) bool) {
+		for _, v := range vals {
+			if !yield(v, nil) {
+				return
+			}
+		}
+	}
+}
+
+// TestStreamedSeq_LastValueWins confirms that StreamedSeq resolves with the
+// final yielded element (last write wins, matching the drain contract).
+func TestStreamedSeq_LastValueWins(t *testing.T) {
+	t.Parallel()
+	s := kit.StreamedSeq(context.Background(), intSeq(10, 20, 30))
+	got, err := s.Wait(context.Background(), time.Second)
+	if err != nil {
+		t.Fatalf("Wait err = %v", err)
+	}
+	if got != 30 {
+		t.Fatalf("got %d, want 30", got)
+	}
+}
+
+// TestStreamedSeq_ErrorTerminates verifies that the first non-nil error from
+// the iterator becomes the resolved error and stops further iteration.
+func TestStreamedSeq_ErrorTerminates(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("seq error")
+	seq := func(yield func(int, error) bool) {
+		yield(1, nil)
+		yield(2, boom) // should stop here
+		yield(3, nil)  // must not be reached
+	}
+	s := kit.StreamedSeq(context.Background(), seq)
+	_, err := s.Wait(context.Background(), time.Second)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want %v", err, boom)
+	}
+}
+
+// TestStreamedSeq_CtxCancelStopsIteration confirms that a pre-cancelled
+// context causes StreamedSeq to stop after the first yield and surface
+// context.Canceled. Using an already-cancelled context makes the test
+// deterministic: the Done channel is closed before the drain goroutine
+// ever calls yield, so the first yield's cancellation check fires
+// immediately.
+func TestStreamedSeq_CtxCancelStopsIteration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so Done is already closed
+
+	reached := 0
+	seq := func(yield func(int, error) bool) {
+		for i := range 10 {
+			reached++
+			if !yield(i, nil) {
+				return
+			}
+		}
+	}
+
+	s := kit.StreamedSeq(ctx, seq)
+	_, err := s.Wait(context.Background(), 2*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	// The drain must have stopped before processing all 10 values.
+	if reached >= 10 {
+		t.Fatalf("seq was not stopped early: reached %d iterations", reached)
+	}
+}
+
+// TestStreamedSeq_EmptySeq resolves with zero and nil for an empty iterator.
+func TestStreamedSeq_EmptySeq(t *testing.T) {
+	t.Parallel()
+	empty := func(yield func(int, error) bool) {}
+	s := kit.StreamedSeq(context.Background(), iter.Seq2[int, error](empty))
+	got, err := s.Wait(context.Background(), time.Second)
+	if err != nil {
+		t.Fatalf("Wait err = %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("got %d, want 0", got)
+	}
 }

--- a/packages/sveltego/exports/kit/streamed_test.go
+++ b/packages/sveltego/exports/kit/streamed_test.go
@@ -389,7 +389,7 @@ func TestStreamedSeq_CtxCancelStopsIteration(t *testing.T) {
 // TestStreamedSeq_EmptySeq resolves with zero and nil for an empty iterator.
 func TestStreamedSeq_EmptySeq(t *testing.T) {
 	t.Parallel()
-	empty := func(yield func(int, error) bool) {}
+	empty := func(_ func(int, error) bool) {}
 	s := kit.StreamedSeq(context.Background(), iter.Seq2[int, error](empty))
 	got, err := s.Wait(context.Background(), time.Second)
 	if err != nil {

--- a/packages/sveltego/go.mod
+++ b/packages/sveltego/go.mod
@@ -1,6 +1,6 @@
 module github.com/binsarjr/sveltego
 
-go 1.22
+go 1.23
 
 require (
 	github.com/binsarjr/sveltego/test-utils v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
## Summary

- Adds `StreamedSeq[T](ctx, iter.Seq2[T, error])` — drains a Go 1.23 pull iterator, accumulating each yielded value, surfacing the first error encountered.
- Adds `StreamedChan[T](ctx, <-chan T)` — drains a channel until it closes or ctx is cancelled; resolved value is the last one received.
- Both constructors wrap the existing `StreamCtx` machinery (goroutine start, ID assignment, `Cancel`, `Wait`, `WaitAny` all unchanged).
- Context cancellation is honoured at every yield/receive boundary: `StreamedChan` via `select`, `StreamedSeq` via a custom yield function (NOT `for range`) to avoid the Go 1.23 `range function continued iteration after false` runtime panic.
- Bumps `go.mod` and `go.work` from `go 1.22` → `go 1.23` (minimum required for `iter.Seq2`).

## Pipeline compatibility note

The existing `Streamed[T]` resolves to a **single** `T` (the last value produced). This PR preserves that contract — `WaitAny` returns the final accumulated value. True chunk-by-chunk SSE emission (one `<script>__sveltego_resolve(…)</script>` flush per yielded item) requires the hydration payload format from **issue #35** and is out of scope here.

## Test plan

- [x] `TestStreamedChan_ThreeValues` — pushes 3 values, confirms last one wins
- [x] `TestStreamedChan_CtxCancelMidStream` — cancels mid-drain, confirms `context.Canceled`
- [x] `TestStreamedChan_EmptyChannel` — closed-before-any-value → zero + nil
- [x] `TestStreamedSeq_LastValueWins` — 3-element seq, confirms last value
- [x] `TestStreamedSeq_ErrorTerminates` — non-nil error stops iteration, surfaces error
- [x] `TestStreamedSeq_CtxCancelStopsIteration` — pre-cancelled ctx, confirms drain stops early
- [x] `TestStreamedSeq_EmptySeq` — empty iterator → zero + nil
- [x] All 157 existing kit tests pass with `-race`

Closes #164