### PR TITLE
test(bench): reset timer in render/router bench files

### DIFF
--- a/packages/sveltego/render/render_bench_test.go
+++ b/packages/sveltego/render/render_bench_test.go
@@ -69,6 +69,7 @@ func BenchmarkWriteEscapeAttr_Dirty(b *testing.B) {
 func BenchmarkWriteJSON(b *testing.B) {
 	payload := map[string]any{"name": "Tom", "tags": []string{"a", "b", "c"}, "n": 42}
 	b.ReportAllocs()
+	b.ResetTimer()
 	for range b.N {
 		w := render.Acquire()
 		_ = w.WriteJSON(payload)
@@ -79,6 +80,7 @@ func BenchmarkWriteJSON(b *testing.B) {
 func BenchmarkWriteRawBytes(b *testing.B) {
 	payload := []byte("<title>page</title><meta name=\"x\" content=\"y\">")
 	b.ReportAllocs()
+	b.ResetTimer()
 	for range b.N {
 		w := render.Acquire()
 		w.WriteRawBytes(payload)
@@ -94,6 +96,7 @@ type benchStruct struct {
 func BenchmarkWriteEscape_Default(b *testing.B) {
 	v := benchStruct{A: 7, B: "hello"}
 	b.ReportAllocs()
+	b.ResetTimer()
 	for range b.N {
 		w := render.Acquire()
 		w.WriteEscape(v)
@@ -104,6 +107,7 @@ func BenchmarkWriteEscape_Default(b *testing.B) {
 func BenchmarkWriteEscapeAttr_Default(b *testing.B) {
 	v := benchStruct{A: 7, B: "hello"}
 	b.ReportAllocs()
+	b.ResetTimer()
 	for range b.N {
 		w := render.Acquire()
 		w.WriteEscapeAttr(v)


### PR DESCRIPTION
## Summary

- Add `b.ResetTimer()` after non-trivial pre-loop setup in four `render` bench functions (`BenchmarkWriteJSON`, `BenchmarkWriteRawBytes`, `BenchmarkWriteEscape_Default`, `BenchmarkWriteEscapeAttr_Default`) so payload construction cost is excluded from measurements
- `runtime/router` bench (`bench_test.go`) already had `b.ResetTimer()` and `b.ReportAllocs()` in all five `BenchmarkMatch_*` functions — no changes needed there
- All benchmarks have `b.ReportAllocs()` (already present in both files before this PR)

Closes #272. Follow-up to #213.

## Test plan

- [ ] `go test -bench=. -benchmem -count=3 ./packages/sveltego/render/...` — alloc counts stable across 3 runs (verified locally)
- [ ] `go test -bench=. -benchmem -count=3 ./packages/sveltego/runtime/router/...` — alloc counts stable across 3 runs (verified locally)
- [ ] `go vet ./packages/sveltego/render/... ./packages/sveltego/runtime/router/...` — clean