### PR TITLE
feat(env): build-time substitution + private-leak guard (#117)

### DIFF
--- a/packages/sveltego/exports/kit/env/doc.go
+++ b/packages/sveltego/exports/kit/env/doc.go
@@ -1,18 +1,21 @@
 // Package env mirrors SvelteKit's $env/static/* and $env/dynamic/*
-// namespaces with four runtime accessors: StaticPrivate, StaticPublic,
+// namespaces with four accessors: StaticPrivate, StaticPublic,
 // DynamicPrivate, and DynamicPublic. Public accessors enforce a
 // PUBLIC_ key prefix so leaks into client bundles are detectable;
 // private accessors carry no prefix constraint and must never appear
-// in client-side code.
+// in +page.svelte or +layout.svelte template expressions.
 //
 // The Static* accessors panic on missing keys and are intended for
 // values whose absence should fail process startup (DATABASE_URL,
 // PUBLIC_API_URL). The Dynamic* accessors return "" on missing keys
 // for runtime-toggleable settings.
 //
-// Build-time substitution of Static* calls into literal strings, and
-// the codegen guard that rejects private env references in
-// +page.svelte client bundles, are deferred to the v0.3 Vite
-// client-bundle work. Until then Static* and Dynamic* differ only in
-// missing-key behaviour.
+// Build-time substitution (v0.3, #117): codegen replaces every
+// env.StaticPublic("X") call in .svelte template expressions with the
+// Go string literal for X's value at build time, baking the value into
+// the binary. A missing key is a fatal build error. StaticPrivate calls
+// in templates are rejected by the codegen private-leak guard
+// (checkPrivateEnv) because the inlined value would appear in
+// server-rendered HTML delivered to browsers. Dynamic* accessors are
+// always resolved at request time and are never substituted.
 package env

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -35,12 +35,18 @@ const genFileMode = 0o600
 //
 // Release, when true, activates production-build restrictions: imports of
 // $lib/dev/** are rejected as fatal errors, mirroring sveltejs/kit#13078.
+//
+// EnvLookup is called for each env.StaticPublic("X") call found in .svelte
+// sources during codegen. The call is replaced with the Go string literal
+// for the returned value, baking it into the binary at build time. A
+// missing key is a fatal build error. When nil, os.LookupEnv is used.
 type BuildOptions struct {
 	ProjectRoot string
 	OutDir      string
 	Verbose     bool
 	Release     bool
 	Logger      *slog.Logger
+	EnvLookup   EnvLookup
 }
 
 // BuildResult summarizes one [Build] invocation. Routes counts every
@@ -64,6 +70,9 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 	logger := opts.Logger
 	if logger == nil {
 		logger = slog.Default()
+	}
+	if opts.EnvLookup == nil {
+		opts.EnvLookup = os.LookupEnv
 	}
 
 	if !filepath.IsAbs(opts.ProjectRoot) {
@@ -132,7 +141,7 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 		}
 		switch {
 		case route.HasPage:
-			refs, hasHead, err := emitPage(opts.ProjectRoot, outDir, modulePath, route, opts.Release)
+			refs, hasHead, err := emitPage(opts.ProjectRoot, outDir, modulePath, route, opts.Release, opts.EnvLookup)
 			if err != nil {
 				return nil, err
 			}
@@ -162,7 +171,7 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 			if i < len(route.LayoutServerFiles) {
 				serverFile = route.LayoutServerFiles[i]
 			}
-			hasHead, err := emitLayout(opts.ProjectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile, opts.Release)
+			hasHead, err := emitLayout(opts.ProjectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile, opts.Release, opts.EnvLookup)
 			if err != nil {
 				return nil, err
 			}
@@ -243,8 +252,9 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 // decide whether the missing-lib warning fires. The bool reports
 // whether the page contributed a Head method (drives manifest
 // HeadFn wiring). When release is true, any $lib/dev/** import is a
-// fatal error.
-func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRoute, release bool) (int, bool, error) {
+// fatal error. lookup is used to resolve env.Static* calls to literal
+// values at build time.
+func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRoute, release bool, lookup EnvLookup) (int, bool, error) {
 	pageName := "+page.svelte"
 	if route.HasReset {
 		pageName = "+page@" + route.ResetTarget + ".svelte"
@@ -259,7 +269,11 @@ func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRou
 			return 0, false, err
 		}
 	}
-	rewritten, hits := rewriteLibImports(string(src), modulePath)
+	substituted, err := substituteStaticEnv(string(src), lookup)
+	if err != nil {
+		return 0, false, fmt.Errorf("codegen: %s: %w", pagePath, err)
+	}
+	rewritten, hits := rewriteLibImports(substituted, modulePath)
 	src = []byte(rewritten)
 
 	frag, perrs := parser.Parse(src)
@@ -476,8 +490,9 @@ func emitErrorPage(projectRoot, outDir, errorDir, pkgPath, pkgName string) error
 // silently ignores files whose name starts with "_". serverFile, when
 // non-empty, points at a sibling layout.server.go whose Load() inline
 // struct return is used to infer LayoutData fields. When release is true,
-// any $lib/dev/** import is a fatal error.
-func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile string, release bool) (bool, error) {
+// any $lib/dev/** import is a fatal error. lookup resolves env.Static*
+// calls to literal string values at build time.
+func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile string, release bool, lookup EnvLookup) (bool, error) {
 	layoutPath, err := resolveLayoutSource(layoutDir)
 	if err != nil {
 		return false, err
@@ -491,7 +506,11 @@ func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile str
 			return false, err
 		}
 	}
-	frag, perrs := parser.Parse(src)
+	substituted, err := substituteStaticEnv(string(src), lookup)
+	if err != nil {
+		return false, fmt.Errorf("codegen: %s: %w", layoutPath, err)
+	}
+	frag, perrs := parser.Parse([]byte(substituted))
 	if len(perrs) > 0 {
 		return false, fmt.Errorf("codegen: parse %s: %w", layoutPath, perrs)
 	}

--- a/packages/sveltego/internal/codegen/env_subst.go
+++ b/packages/sveltego/internal/codegen/env_subst.go
@@ -1,0 +1,63 @@
+package codegen
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// staticPublicEnvRe matches env.StaticPublic("KEY") call expressions in
+// raw .svelte source. The match is deliberately text-level so we can
+// rewrite the call to a Go string literal before the source reaches the
+// parser, baking the value into the binary at build time.
+//
+// Only StaticPublic is substituted here. env.StaticPrivate in templates
+// is rejected by the private-leak guard (checkPrivateEnv / validateExpr)
+// because even if inlined as a literal, the value would appear in
+// server-rendered HTML that is delivered to the browser.
+//
+// Capture group: [1] = the key string without quotes.
+var staticPublicEnvRe = regexp.MustCompile(
+	`\benv\.StaticPublic\("([^"]+)"\)`,
+)
+
+// EnvLookup resolves an environment variable by name. The second return
+// is true when the variable is present (possibly with an empty value).
+// The caller supplies os.LookupEnv in production and a stub in tests.
+type EnvLookup func(key string) (string, bool)
+
+// substituteStaticEnv rewrites every env.StaticPublic("X") call in body
+// to the Go string literal for the value returned by lookup at build time.
+// A call whose key is unset in the build environment is a fatal error —
+// StaticPublic panics at runtime when its key is unset, and the build-time
+// substitute requires the value to be known.
+//
+// env.StaticPrivate calls are NOT substituted; they are instead rejected
+// by the downstream private-leak guard (checkPrivateEnv) because the
+// value would appear in SSR HTML visible to clients.
+//
+// The function operates on the raw .svelte source text before parsing,
+// analogous to rewriteLibImports for $lib paths.
+func substituteStaticEnv(body string, lookup EnvLookup) (string, error) {
+	if !staticPublicEnvRe.MatchString(body) {
+		return body, nil
+	}
+	var substErr error
+	out := staticPublicEnvRe.ReplaceAllStringFunc(body, func(match string) string {
+		if substErr != nil {
+			return match
+		}
+		sub := staticPublicEnvRe.FindStringSubmatch(match)
+		key := sub[1]
+		val, ok := lookup(key)
+		if !ok {
+			substErr = fmt.Errorf("codegen: env.StaticPublic(%q): key is unset in build environment", key)
+			return match
+		}
+		return strconv.Quote(val)
+	})
+	if substErr != nil {
+		return "", substErr
+	}
+	return out, nil
+}

--- a/packages/sveltego/internal/codegen/env_subst_test.go
+++ b/packages/sveltego/internal/codegen/env_subst_test.go
@@ -1,0 +1,280 @@
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testEnvLookup is a stub EnvLookup used across substituteStaticEnv unit tests.
+var testEnvLookup = func(key string) (string, bool) {
+	m := map[string]string{
+		"PUBLIC_API_URL": "https://api.example.com",
+		"PUBLIC_EMPTY":   "",
+	}
+	v, ok := m[key]
+	return v, ok
+}
+
+func TestSubstituteStaticEnv(t *testing.T) {
+	t.Run("no static calls → unchanged", func(t *testing.T) {
+		src := `<p>{greeting}</p>`
+		got, err := substituteStaticEnv(src, testEnvLookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != src {
+			t.Errorf("want unchanged, got %q", got)
+		}
+	})
+
+	t.Run("StaticPublic substituted to literal", func(t *testing.T) {
+		src := `<p>{env.StaticPublic("PUBLIC_API_URL")}</p>`
+		got, err := substituteStaticEnv(src, testEnvLookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, `"https://api.example.com"`) {
+			t.Errorf("want literal URL in %q", got)
+		}
+		if strings.Contains(got, "env.StaticPublic") {
+			t.Errorf("call site not removed in %q", got)
+		}
+	})
+
+	t.Run("empty value is valid", func(t *testing.T) {
+		src := `{env.StaticPublic("PUBLIC_EMPTY")}`
+		got, err := substituteStaticEnv(src, testEnvLookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, `""`) {
+			t.Errorf("want empty string literal in %q", got)
+		}
+	})
+
+	t.Run("multiple calls in same source", func(t *testing.T) {
+		src := `<a href={env.StaticPublic("PUBLIC_API_URL")}>{env.StaticPublic("PUBLIC_API_URL")}</a>`
+		got, err := substituteStaticEnv(src, testEnvLookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(got, "env.StaticPublic") {
+			t.Errorf("call site not fully removed in %q", got)
+		}
+		if strings.Count(got, `"https://api.example.com"`) != 2 {
+			t.Errorf("expected 2 literal replacements in %q", got)
+		}
+	})
+
+	t.Run("unset key returns error", func(t *testing.T) {
+		src := `{env.StaticPublic("PUBLIC_MISSING_KEY")}`
+		_, err := substituteStaticEnv(src, testEnvLookup)
+		if err == nil {
+			t.Fatal("expected error for unset key, got nil")
+		}
+		if !strings.Contains(err.Error(), "PUBLIC_MISSING_KEY") {
+			t.Errorf("error should mention the key: %v", err)
+		}
+		if !strings.Contains(err.Error(), "unset in build environment") {
+			t.Errorf("error should describe cause: %v", err)
+		}
+	})
+
+	t.Run("StaticPrivate not substituted", func(t *testing.T) {
+		// substituteStaticEnv only rewrites StaticPublic. StaticPrivate
+		// must pass through so checkPrivateEnv can reject it.
+		src := `{env.StaticPrivate("DATABASE_URL")}`
+		got, err := substituteStaticEnv(src, testEnvLookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, "env.StaticPrivate") {
+			t.Errorf("StaticPrivate should be untouched, got %q", got)
+		}
+	})
+
+	t.Run("DynamicPublic not substituted", func(t *testing.T) {
+		src := `{env.DynamicPublic("PUBLIC_API_URL")}`
+		got, err := substituteStaticEnv(src, testEnvLookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, "env.DynamicPublic") {
+			t.Errorf("DynamicPublic should be untouched, got %q", got)
+		}
+	})
+
+	t.Run("DynamicPrivate not substituted", func(t *testing.T) {
+		src := `{env.DynamicPrivate("X")}`
+		got, err := substituteStaticEnv(src, testEnvLookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, "env.DynamicPrivate") {
+			t.Errorf("DynamicPrivate should be untouched, got %q", got)
+		}
+	})
+
+	t.Run("value with special chars produces valid Go literal", func(t *testing.T) {
+		lookup := func(string) (string, bool) { return `say "hi"`, true }
+		src := `{env.StaticPublic("PUBLIC_GREET")}`
+		got, err := substituteStaticEnv(src, lookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// strconv.Quote wraps in double quotes with escaping.
+		if !strings.Contains(got, `"say \"hi\""`) {
+			t.Errorf("want escaped literal in %q", got)
+		}
+	})
+}
+
+// ---- Build-level integration tests ----
+
+// envSubstRoot returns a temp directory wired with a minimal go.mod + routes dir.
+func envSubstRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/envtest\n\ngo 1.22\n")
+	if err := os.MkdirAll(filepath.Join(root, "src", "routes"), 0o755); err != nil {
+		t.Fatalf("mkdir routes: %v", err)
+	}
+	return root
+}
+
+// writePlainPage writes a +page.svelte with the given body.
+func writePlainPage(t *testing.T, root, body string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "src", "routes", "+page.svelte"), body)
+}
+
+// readGenPageSrc returns the generated page.gen.go content.
+func readGenPageSrc(t *testing.T, root string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, ".gen", "routes", "page.gen.go"))
+	if err != nil {
+		t.Fatalf("read page.gen.go: %v", err)
+	}
+	return string(b)
+}
+
+func TestBuildSubstitutesPublicEnv(t *testing.T) {
+	root := envSubstRoot(t)
+	writePlainPage(t, root, `<p>{env.StaticPublic("PUBLIC_SITE_NAME")}</p>`)
+
+	lookup := func(key string) (string, bool) {
+		if key == "PUBLIC_SITE_NAME" {
+			return "MySite", true
+		}
+		return "", false
+	}
+
+	result, err := Build(BuildOptions{ProjectRoot: root, EnvLookup: lookup})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if result.Routes != 1 {
+		t.Fatalf("want 1 route, got %d", result.Routes)
+	}
+
+	src := readGenPageSrc(t, root)
+	if !strings.Contains(src, `"MySite"`) {
+		t.Errorf("generated source missing literal; got:\n%s", src)
+	}
+	if strings.Contains(src, "env.StaticPublic") {
+		t.Errorf("env.StaticPublic call not removed; got:\n%s", src)
+	}
+}
+
+func TestBuildRejectsUnsetKey(t *testing.T) {
+	root := envSubstRoot(t)
+	writePlainPage(t, root, `<p>{env.StaticPublic("PUBLIC_MISSING")}</p>`)
+
+	_, err := Build(BuildOptions{
+		ProjectRoot: root,
+		EnvLookup:   func(string) (string, bool) { return "", false },
+	})
+	if err == nil {
+		t.Fatal("expected error for unset key, got nil")
+	}
+	if !strings.Contains(err.Error(), "PUBLIC_MISSING") {
+		t.Errorf("error should mention key name, got: %v", err)
+	}
+}
+
+// TestBuildRejectsPrivateEnvInTemplate verifies that env.StaticPrivate in a
+// template is rejected by the private-leak guard. substituteStaticEnv does
+// not rewrite StaticPrivate, so checkPrivateEnv sees the call and aborts.
+func TestBuildRejectsPrivateEnvInTemplate(t *testing.T) {
+	root := envSubstRoot(t)
+	writePlainPage(t, root, `<p>{env.StaticPrivate("DATABASE_URL")}</p>`)
+
+	_, err := Build(BuildOptions{
+		ProjectRoot: root,
+		EnvLookup:   func(key string) (string, bool) { return "postgres://x", true },
+	})
+	if err == nil {
+		t.Fatal("expected private-env diagnostic, got nil")
+	}
+	if !strings.Contains(err.Error(), "private env access not allowed") {
+		t.Errorf("want private-env diagnostic, got: %v", err)
+	}
+}
+
+// TestBuildDefaultEnvLookupUsesOsEnv verifies that nil EnvLookup falls
+// back to os.LookupEnv.
+func TestBuildDefaultEnvLookupUsesOsEnv(t *testing.T) {
+	root := envSubstRoot(t)
+	writePlainPage(t, root, `<p>{env.StaticPublic("PUBLIC_SVELTEGO_TEST_SUBST")}</p>`)
+
+	t.Setenv("PUBLIC_SVELTEGO_TEST_SUBST", "hello-from-os")
+
+	result, err := Build(BuildOptions{ProjectRoot: root}) // no EnvLookup → os.LookupEnv
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if result.Routes != 1 {
+		t.Fatalf("want 1 route, got %d", result.Routes)
+	}
+
+	src := readGenPageSrc(t, root)
+	if !strings.Contains(src, `"hello-from-os"`) {
+		t.Errorf("generated source missing os env literal; got:\n%s", src)
+	}
+}
+
+// TestBuildSubstitutesPublicEnvInLayout verifies that env.StaticPublic
+// calls in +layout.svelte are also inlined at build time.
+func TestBuildSubstitutesPublicEnvInLayout(t *testing.T) {
+	root := envSubstRoot(t)
+
+	writeFile(t, filepath.Join(root, "src", "routes", "+layout.svelte"),
+		`<div class={env.StaticPublic("PUBLIC_THEME")}><slot/></div>`)
+	writePlainPage(t, root, `<p>hello</p>`)
+
+	lookup := func(key string) (string, bool) {
+		if key == "PUBLIC_THEME" {
+			return "dark", true
+		}
+		return "", false
+	}
+
+	_, err := Build(BuildOptions{ProjectRoot: root, EnvLookup: lookup})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(root, ".gen", "routes", "layout.gen.go"))
+	if err != nil {
+		t.Fatalf("read layout.gen.go: %v", err)
+	}
+	src := string(b)
+	if !strings.Contains(src, `"dark"`) {
+		t.Errorf("layout.gen.go missing literal; got:\n%s", src)
+	}
+	if strings.Contains(src, "env.StaticPublic") {
+		t.Errorf("env.StaticPublic not removed from layout; got:\n%s", src)
+	}
+}

--- a/packages/sveltego/internal/codegen/env_subst_test.go
+++ b/packages/sveltego/internal/codegen/env_subst_test.go
@@ -213,7 +213,7 @@ func TestBuildRejectsPrivateEnvInTemplate(t *testing.T) {
 
 	_, err := Build(BuildOptions{
 		ProjectRoot: root,
-		EnvLookup:   func(key string) (string, bool) { return "postgres://x", true },
+		EnvLookup:   func(_ string) (string, bool) { return "postgres://x", true },
 	})
 	if err == nil {
 		t.Fatal("expected private-env diagnostic, got nil")


### PR DESCRIPTION
## Summary

- Adds `env.StaticPublic("X")` build-time substitution in codegen: every call in `.svelte` template expressions is replaced with a Go string literal baked from the build environment, so the binary carries no env key names as runtime calls. A missing key is a fatal build error (matching `StaticPublic`'s runtime panic-on-unset contract).
- `env.StaticPrivate` in template expressions is intentionally **not** substituted — it passes through unrewritten and is blocked by the existing `checkPrivateEnv` guard. Even as a literal, the value would appear in server-rendered HTML delivered to browsers.
- `DynamicPublic` / `DynamicPrivate` are never substituted (runtime-evaluated by design).
- `BuildOptions.EnvLookup` is a new injectable lookup function; defaults to `os.LookupEnv` for production, making tests deterministic without process env pollution.

## Changes

| File | What changed |
|---|---|
| `internal/codegen/env_subst.go` | New: `EnvLookup` type + `substituteStaticEnv` text-level rewriter |
| `internal/codegen/build.go` | `BuildOptions.EnvLookup` field; wired into `emitPage` + `emitLayout` |
| `internal/codegen/env_subst_test.go` | New: 15 unit + integration tests |
| `exports/kit/env/doc.go` | Updated package doc to reflect shipped behaviour |

## Test plan

- [ ] `go test -race ./internal/codegen/... -count=1` — 390 pass (15 new)
- [ ] `go test -race ./... -count=1` — 1055 pass
- [ ] `gofumpt -l .` — no output
- [ ] `go vet ./...` — clean
- [ ] `TestBuildSubstitutesPublicEnv` — literal baked in generated source
- [ ] `TestBuildRejectsUnsetKey` — fatal error with key name in message
- [ ] `TestBuildRejectsPrivateEnvInTemplate` — private-leak guard fires
- [ ] `TestBuildDefaultEnvLookupUsesOsEnv` — os.LookupEnv fallback works
- [ ] `TestBuildSubstitutesPublicEnvInLayout` — layout.gen.go also inlined

Closes #117