### PR TITLE
feat(auth): package scaffold + module layout

### DIFF
--- a/go.work
+++ b/go.work
@@ -10,6 +10,7 @@ use (
 	./packages/adapter-lambda
 	./packages/adapter-server
 	./packages/adapter-static
+	./packages/auth
 	./packages/cookiesession
 	./packages/create-sveltego
 	./packages/enhanced-img

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md — packages/auth
+
+## Where things go
+
+This package follows the ADR 0006 layout exactly. Each top-level file covers
+one concern: `auth.go` (aggregate + Config + New), `identity.go` (core types),
+`errors.go` (sentinels), `session.go` (token format — #220), `password.go`
+(Hasher — #222), `csrf.go` (#233), `hook.go` (kit integration — #228).
+Sub-packages live under named directories:
+
+```
+storage/{memory,sql,pgx,mongo,redis}/
+email/{smtp,resend,sendgrid,noop}/
+sms/{twilio,noop}/
+provider/{google,github,...,generic}/
+totp/  webauthn/  rbac/  org/  admin/  plugin/  kitform/
+```
+
+Do not create new top-level files or sub-packages without a corresponding
+issue and an ADR 0006 amendment. If a feature doesn't map to an existing
+file slot, open an issue first.
+
+## Before changing public surface
+
+Read ADR 0006 (`tasks/decisions/0006-auth-master-plan.md`) and
+`STABILITY.md` before adding, renaming, or removing any exported symbol.
+All symbols are **experimental** at v0.0.x, but breaking changes still
+require a changelog entry. Run `go vet ./...` + `gofumpt -l .` +
+`goimports -l -local github.com/binsarjr/sveltego .` after every edit.
+No JS in tests — this is a pure-Go module.

--- a/packages/auth/STABILITY.md
+++ b/packages/auth/STABILITY.md
@@ -1,0 +1,34 @@
+# Stability — auth
+
+Last updated: 2026-04-30 · Version: pre-alpha (v0.0.x)
+
+Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97) and
+[ADR 0006](../../tasks/decisions/0006-auth-master-plan.md). Every public
+symbol below is **experimental** until the package reaches v0.6 stable.
+Breaking changes require only a changelog entry and a minor-version bump
+while the major version is 0.
+
+## Stable
+
+(none yet)
+
+## Experimental
+
+- `Auth` — central aggregate; construct via `New`.
+- `Config` — all fields; populated incrementally by sub-issues #217–#234.
+- `New(Config) (*Auth, error)` — constructor; defaults enforced.
+- `User` — identity record.
+- `Account` — provider link record.
+- `Session` — active session record.
+- `Verification` — short-lived verification record.
+- `ErrNotFound`, `ErrConflict`, `ErrInvalidCredentials`, `ErrSessionExpired`,
+  `ErrRateLimited`, `ErrCSRFInvalid`, `ErrEmailNotVerified`, `Err2FARequired`
+  — sentinel errors.
+
+## Deprecated
+
+(none yet)
+
+## Internal-only (do not import even though exported)
+
+(none yet)

--- a/packages/auth/auth.go
+++ b/packages/auth/auth.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"log/slog"
+	"time"
+)
+
+// Config holds all options for the Auth aggregate. Fields marked "populated by
+// sub-issues" are reserved placeholders — they will be typed interfaces once
+// the relevant issues land (#217–#221, #223, etc.). Do not remove them.
+type Config struct {
+	// BaseURL is the canonical origin of the application (e.g. "https://example.com").
+	BaseURL string
+
+	// BasePath is the URL prefix for all auth endpoints. Defaults to "/auth".
+	BasePath string
+
+	// Logger is the structured logger. Defaults to slog.Default().
+	Logger *slog.Logger
+
+	// Now returns the current time. Defaults to time.Now. Override in tests.
+	Now func() time.Time
+
+	// Storage is the persistence adapter (populated by #217–#219).
+	// Type will become a typed interface once the storage package lands.
+	Storage any
+
+	// Mailer is the email delivery adapter (populated by the email-provider issues).
+	Mailer any
+
+	// SMS is the SMS delivery adapter (populated by the sms-provider issues).
+	SMS any
+
+	// Plugins holds optional capability extensions (populated by #224+).
+	Plugins []any
+
+	// EnableCSRF enables double-submit CSRF protection on mutating auth endpoints.
+	// Defaults to true once csrf.go lands (#233).
+	EnableCSRF bool
+
+	// EnableRateLimit enables per-endpoint rate limiting (populated by a follow-up issue).
+	EnableRateLimit bool
+}
+
+// Auth is the central aggregate for all authentication and authorization
+// operations. Construct one per application via New and pass it into
+// sveltego kit hooks. See ADR 0006 for the full method surface.
+type Auth struct {
+	cfg Config
+}
+
+// New constructs an Auth with the given Config, applying defaults for
+// any zero-value fields. It returns a non-nil *Auth and nil error on
+// success; future validation (e.g. missing BaseURL) may return an error.
+func New(cfg Config) (*Auth, error) {
+	if cfg.BasePath == "" {
+		cfg.BasePath = "/auth"
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &Auth{cfg: cfg}, nil
+}

--- a/packages/auth/auth_test.go
+++ b/packages/auth/auth_test.go
@@ -1,0 +1,19 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/binsarjr/sveltego/auth"
+)
+
+// TestNew_DefaultsHonored verifies that New fills in zero-value Config fields
+// and returns a non-nil *Auth.
+func TestNew_DefaultsHonored(t *testing.T) {
+	a, err := auth.New(auth.Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+	if a == nil {
+		t.Fatal("New returned nil *Auth")
+	}
+}

--- a/packages/auth/doc.go
+++ b/packages/auth/doc.go
@@ -1,0 +1,8 @@
+// Package auth implements sveltego-auth, a Go-native authentication and
+// authorization library for the sveltego framework. It provides email+password,
+// magic link, OAuth, TOTP/OTP, passkeys, RBAC, organisations, and anonymous
+// auth — all as a single import with pluggable storage, mailer, and SMS adapters.
+//
+// The canonical design is in ADR 0006 (tasks/decisions/0006-auth-master-plan.md)
+// and the master tracking issue #155 on github.com/binsarjr/sveltego.
+package auth

--- a/packages/auth/errors.go
+++ b/packages/auth/errors.go
@@ -1,0 +1,38 @@
+package auth
+
+import "errors"
+
+// Sentinel errors returned by Auth methods. Callers should use errors.Is
+// to test for these values rather than comparing strings.
+var (
+	// ErrNotFound is returned when a requested record does not exist.
+	ErrNotFound = errors.New("auth: not found")
+
+	// ErrConflict is returned when a uniqueness constraint would be violated
+	// (e.g. email already registered).
+	ErrConflict = errors.New("auth: conflict")
+
+	// ErrInvalidCredentials is returned when the supplied password or token
+	// does not match the stored credential.
+	ErrInvalidCredentials = errors.New("auth: invalid credentials")
+
+	// ErrSessionExpired is returned when the session token exists but has
+	// passed its ExpiresAt time.
+	ErrSessionExpired = errors.New("auth: session expired")
+
+	// ErrRateLimited is returned when a caller has exceeded the per-endpoint
+	// rate limit.
+	ErrRateLimited = errors.New("auth: rate limited")
+
+	// ErrCSRFInvalid is returned when the CSRF double-submit token does not
+	// match the cookie value.
+	ErrCSRFInvalid = errors.New("auth: CSRF token invalid")
+
+	// ErrEmailNotVerified is returned when an operation requires a verified
+	// email but the user's EmailVerified flag is false.
+	ErrEmailNotVerified = errors.New("auth: email not verified")
+
+	// Err2FARequired is returned when the account has two-factor authentication
+	// enabled and the caller has not yet completed the second factor.
+	Err2FARequired = errors.New("auth: two-factor authentication required")
+)

--- a/packages/auth/go.mod
+++ b/packages/auth/go.mod
@@ -1,0 +1,3 @@
+module github.com/binsarjr/sveltego/auth
+
+go 1.22

--- a/packages/auth/identity.go
+++ b/packages/auth/identity.go
@@ -1,0 +1,116 @@
+package auth
+
+import "time"
+
+// User represents an authenticated principal. Fields mirror the better-auth
+// shape (ADR 0006) so storage adapters can target a common schema. Storage
+// logic lives in the storage sub-packages (#217–#219).
+type User struct {
+	// ID is the unique identifier for the user (UUIDv7 by default).
+	ID string
+
+	// Email is the user's primary email address.
+	Email string
+
+	// EmailVerified indicates whether the email has been confirmed.
+	EmailVerified bool
+
+	// Name is the user's display name.
+	Name string
+
+	// Image is the URL of the user's avatar.
+	Image string
+
+	// CreatedAt is when the user record was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when the user record was last modified.
+	UpdatedAt time.Time
+}
+
+// Account links a User to an external OAuth provider or a credential method
+// (e.g. "email" for password-based logins). One User may have many Accounts.
+type Account struct {
+	// ID is the unique identifier for the account record.
+	ID string
+
+	// UserID is the foreign key back to User.ID.
+	UserID string
+
+	// Provider is the provider identifier (e.g. "email", "google", "github").
+	Provider string
+
+	// ProviderAccountID is the provider-side user identifier.
+	ProviderAccountID string
+
+	// AccessToken is the OAuth access token (populated for OAuth accounts).
+	AccessToken string
+
+	// RefreshToken is the OAuth refresh token.
+	RefreshToken string
+
+	// ExpiresAt is when the OAuth access token expires.
+	ExpiresAt *time.Time
+
+	// CreatedAt is when the account record was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when the account record was last modified.
+	UpdatedAt time.Time
+}
+
+// Session represents an active authentication session. DB-backed sessions
+// store a hashed token; stateless sessions encode this struct into a signed
+// encrypted cookie (see ADR 0006 §Session Strategies, #220–#221).
+type Session struct {
+	// ID is the unique session identifier.
+	ID string
+
+	// UserID is the foreign key to User.ID.
+	UserID string
+
+	// Token is the raw session token (only present immediately after creation;
+	// stored as a hash in the DB).
+	Token string
+
+	// ExpiresAt is when this session becomes invalid.
+	ExpiresAt time.Time
+
+	// FreshUntil is when the session is considered "fresh" for sensitive ops.
+	// After this time, re-authentication may be required.
+	FreshUntil time.Time
+
+	// IPAddress is the IP that created the session (for display in session list).
+	IPAddress string
+
+	// UserAgent is the User-Agent header at session creation time.
+	UserAgent string
+
+	// CreatedAt is when the session was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when the session was last refreshed.
+	UpdatedAt time.Time
+}
+
+// Verification is a short-lived record used for email verification,
+// magic links, OTP codes, and password-reset flows.
+type Verification struct {
+	// ID is the unique identifier for the verification record.
+	ID string
+
+	// UserID is the foreign key to User.ID.
+	UserID string
+
+	// Kind identifies the verification type (e.g. "email", "magic-link", "otp", "password-reset").
+	Kind string
+
+	// Token is the raw verification token (stored hashed in the DB).
+	Token string
+
+	// ExpiresAt is when the verification record becomes invalid.
+	ExpiresAt time.Time
+
+	// CreatedAt is when the verification record was created.
+	CreatedAt time.Time
+}


### PR DESCRIPTION
Closes #216

## Summary

- Adds `packages/auth/` as `github.com/binsarjr/sveltego/auth` (Go 1.22), registered in `go.work` alphabetically between `adapter-static` and `create-sveltego`.
- Delivers all deliverables from #216: `go.mod`, `doc.go`, `auth.go` (`Auth` + `Config` + `New` with defaults), `identity.go` (`User`, `Account`, `Session`, `Verification`), `errors.go` (8 sentinel errors), `auth_test.go` (`TestNew_DefaultsHonored`, race-clean), `STABILITY.md`, and `CLAUDE.md`.

## Test plan

- [x] `go build github.com/binsarjr/sveltego/auth/...` clean
- [x] `go test -race github.com/binsarjr/sveltego/auth/...` passes (1 test)
- [x] `go vet ./packages/auth/...` clean
- [x] `gofumpt -l packages/auth/` — no output
- [x] `goimports -l -local github.com/binsarjr/sveltego packages/auth/` — no output
- [x] `go work sync` clean
- [x] Workspace-wide `go test -race github.com/binsarjr/sveltego/...` unchanged (only pre-existing `playgrounds/dashboard/cmd/app` failure, confirmed present on `main` before this branch)