### PR TITLE
docs(review): v0.1 master code-quality review

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -6,6 +6,7 @@ To add a new entry, create a new `YYYY-MM-DD-<topic>.md` file there — **do not
 
 Entries newest-first:
 
+- [2026-04-30: defer #158 (collectStreams reflection) to v1.0 perf hardening — closes #215](lessons/2026-04-30-v0.1-master-review-defer-158.md)
 - [2026-04-30: CI playground skip lists are pre-existing footguns](lessons/2026-04-30-ci-playground-skip-lists-are-pre-existing-footguns.md)
 - [2026-04-30: Phase 0kk: blog playground (#62) + Form/PageData gap (#143)](lessons/2026-04-30-phase-0kk-blog-playground-62-formpagedata-gap-143-3.md)
 - [2026-04-30: Phase 0ii — deploy adapters (#93)](lessons/2026-04-30-phase-0ii-deploy-adapters-93.md)

--- a/tasks/lessons/2026-04-30-v0.1-master-review-defer-158.md
+++ b/tasks/lessons/2026-04-30-v0.1-master-review-defer-158.md
@@ -1,0 +1,41 @@
+# 2026-04-30 — defer #158 (`collectStreams` reflection) to v1.0 perf hardening
+
+## Insight
+
+The v0.1 master code-quality umbrella (#215) was authored with the
+acceptance criterion "closes when every linked sub-issue is resolved or
+explicitly deferred with a note in `tasks/lessons.md`". Of 21 children,
+20 shipped during v0.1 cleanup. Only #158 (replace
+`pipeline.collectStreams` reflection with codegen-emitted typed walkers)
+remains open.
+
+Closing #215 unblocks downstream tracking — there is no value in keeping
+an umbrella open on a single perf optimization once the rest of the
+review surface has shipped. That said, #158 is a real defect for apps
+that don't use streaming: every page render pays a reflection walk over
+its `PageData` and every layout's `LayoutData` even when no field
+implements `kit.StreamedAny`.
+
+## Self-rules
+
+1. Master review umbrellas (#215-style) close when ≥80% of children
+   ship AND every still-open child has a clear deferral target. Do
+   not let one perf item hold an umbrella open indefinitely.
+2. Deferral != closure of the underlying issue. #158 stays open with
+   a clear milestone (v1.0 perf hardening) and a comment cross-linking
+   the lessons file. Future reviewers must be able to find it.
+3. The reflection-on-hot-path pattern is acceptable in the codebase
+   ONLY when (a) the input domain is bounded (form binding, action
+   inject), or (b) the call site is opt-in (BindForm). Unconditional
+   reflection on every page request is the anti-pattern; #158 is the
+   sole remaining instance.
+4. Codegen-emitted typed walkers are the framework's preferred answer
+   to "we need to inspect a user struct on the hot path". When a
+   future reviewer spots a similar pattern, point them at #158's
+   eventual fix as the template.
+
+## References
+
+- Umbrella: #215
+- Open child: #158
+- Master review: `tasks/reviews/2026-04-30-v0.1-master-review.md`

--- a/tasks/reviews/2026-04-30-v0.1-master-review.md
+++ b/tasks/reviews/2026-04-30-v0.1-master-review.md
@@ -1,0 +1,553 @@
+# v0.1 master code-quality review
+
+Date: 2026-04-30
+Reviewer: agent-aedbe8c995c01f5e9 (Opus 4.7, 1M context)
+Commit reviewed: `e8a4172` (origin/main at review start)
+Tracking issue: closes #215
+
+## 1. Executive summary
+
+The v0.1 public surface is in good shape. The kit / server / router /
+render packages all hang together as a coherent SvelteKit-shaped runtime
+with a single source of truth for ctx, hooks, and pipeline state. Hot
+paths are pooled and zero-alloc on the no-stream path. Existing perf
+findings (reflection in `collectStreams`, head copy, etc.) are already
+tracked under #215 and most are closed.
+
+Top remaining concerns:
+
+- No `STABILITY.md` per package yet (RFC #97 calls for this — every
+  reviewed package is implicitly "experimental" with no machine-readable
+  marker).
+- One real correctness issue: `RenderCtx` allocated for the error path
+  drops `RawParams` and `OriginalURL`, so `+error.svelte` cannot reach
+  the same data the success path has.
+- One small architectural smell: `kit.RenderCtx` and `kit.LoadCtx`
+  duplicate the `Locals/URL/Params/RawParams/Cookies/Request` block.
+  Tolerable for v0.1 but worth a follow-up.
+- Sub-issue #158 (`collectStreams` reflection) is the single open child
+  on the umbrella; everything else has shipped.
+
+No P0 (blocker) findings. Two P1 (should-fix) findings. The rest are P2
+polish bundled in per-package umbrellas.
+
+## 2. Methodology
+
+Walked every public file in:
+
+- `packages/sveltego/exports/kit/` (action, bind, cookies, cron, csp,
+  ctx, event, hooks, link, page_options, response, robots, sentinels,
+  sitemap, static_config, streamed)
+- `packages/sveltego/exports/kit/params/` (params, int, slug, uuid)
+- `packages/sveltego/render/` (writer, escape, render, FlushTo)
+- `packages/sveltego/runtime/router/` (route, segment, matcher, tree,
+  match)
+- `packages/sveltego/server/` (server, pipeline, errors, head, actions,
+  cron, shell, static)
+- `packages/sveltego/internal/codegen/` public entry points only —
+  `Build`, `Generate`, `GenerateLayout`, `GenerateErrorPage`,
+  `GenerateManifest`, `GenerateLinks`, `EmitLinksFile`,
+  `CollectLinkRoutes`, `SortLinkRoutes`, plus their `*Options` /
+  `*Result` shapes.
+
+Tools: `cat -n` for line-numbered reads (Read tool was unstable for
+non-cwd-rooted paths from a worktree), `grep` for cross-references.
+Serena MCP tools were not available in this session (`ToolSearch`
+returned no matches); fell back to native search per CLAUDE.md rule 8.
+
+No `go vet`, `go build`, lint, or test was run — this is a read-only
+review and the umbrella body already records those gates as clean at
+review time.
+
+Time: ~75 minutes of focused walk.
+
+## 3. Findings by package
+
+### 3.1 `exports/kit/` — public kit API
+
+#### P1 — `kit.LoadCtx.Speculative` accepts forgeable hint
+
+`packages/sveltego/exports/kit/ctx.go:137-149` reads
+`X-Sveltego-Preload` and `Sec-Purpose: prefetch` and returns true. The
+godoc explicitly says these are hints, not security boundaries. That's
+correct. But there is no other public API that distinguishes
+prefetch-vs-real-navigation, so any user code that gates side effects
+("don't increment the analytics counter on prefetch") relies entirely
+on this method. That's fine as long as the godoc is loud, which it is —
+keep it that way and resist any future pressure to "tighten" it. Not a
+defect; flagged here so future PRs that touch `Speculative` don't
+accidentally promote it to a security boundary.
+
+Resolution: no change needed; this is a "do not regress" note, not a
+fix.
+
+#### P2 — `RenderCtx` and `LoadCtx` duplicate state
+
+Both structs carry `Locals`, `URL`, `Params`, `RawParams`, `Cookies`,
+`Request`. `RenderCtx` adds `Writer`; `LoadCtx` adds `parents` (the
+load-chain stack) and `headers`. Today the pipeline copies field-by-
+field from `RequestEvent` → `LoadCtx` (`pipeline.go:333-340`) and
+`RequestEvent` → `RenderCtx` (`pipeline.go:376-383`). One source of
+truth would be a shared embedded struct or a `RequestState` interface.
+
+Cost of fix: medium; touches generated code (every page Render
+signature takes `*RenderCtx`). Keep deferred until v0.5 ctx work
+catches up.
+
+#### P2 — `Hooks.WithDefaults` mutates a copy, easy footgun
+
+`hooks.go:199` returns the bundle by value — fine. Nothing forbids the
+caller from passing a pointer-receiver method on a future hook type
+that captures state, however. A package-level note saying "Hooks is
+intentionally a value type; do not share state through it" would
+prevent the mistake. Polish.
+
+#### P2 — `kit.Link` re-parses pattern per call
+
+`link.go:33` does a `strings.Split` over the pattern and a per-segment
+`HasPrefix` walk. For runtime fallback usage this is fine (handful of
+calls per request), but the typed `kit.Link` codegen path already
+dominates real usage. Documented as a fallback in the godoc. No fix
+needed.
+
+#### P2 — `kit.CSPTemplate.Build` returns `""` on nil receiver
+
+`csp.go:109-114`. Accepting nil receiver is unusual but documented.
+Idiomatic Go would be either to require non-nil and panic, or to return
+a sensible default. Keep as-is for callers that conditionally build the
+template. Polish.
+
+#### P2 — godoc gap: `BindError` field is exported but no Set helper
+
+`bind.go:23-26`. `BindError.FieldErrors` is a public map; users reading
+it can mutate it. Either freeze via getter or add a comment that
+mutation is undefined. Minor.
+
+#### P2 — `SafeError` zero-value `Error()` returns `"Internal Server Error"` even when caller meant "no error"
+
+`hooks.go:98-106`. Probably intentional (zero-value `SafeError` should
+not be passed around as a successful result), but worth a one-line
+godoc clarifying that callers must always inspect `Code != 0` before
+calling `.Error()`. Minor.
+
+#### P2 — naming: `Streamed` vs `Stream`
+
+`streamed.go:31` declares `type Streamed[T any]`; `streamed.go:58`
+declares `func Stream[T any]`. The verb-vs-noun split is correct, but
+the file is named `streamed.go` while the constructor is `Stream` — a
+reader expects `kit.Stream(...)` to return `*kit.Stream`. The typed
+struct does need to be a noun (`Streamed`) and `kit.StreamCtx` is the
+preferred constructor. No rename, but a one-line file-level comment
+would defuse confusion. Polish.
+
+#### P2 — `kit.SitemapBuilder.Add` Priority-out-of-range silently drops
+
+`sitemap.go:97`. Valid priority is `[0,1]`. Out-of-range omits the
+`<priority>` element. Silent — should at minimum log a Warn via the
+caller's logger, but the builder has no logger; logging would force a
+context dependency. Document the silent drop in the Add godoc instead.
+Already partially documented at line 27 ("Priority outside [0,1] omits
+<priority>"); reiterate at the method.
+
+### 3.2 `exports/kit/params/` — built-in matchers
+
+#### P2 — `Slug` empty-string rejection should also reject leading whitespace
+
+`slug.go:11`. Currently `""` is rejected. Inputs like `" foo"` aren't
+slugs in the URL sense and the byte loop already rejects them (space
+fails the switch). Confirmed safe. No fix.
+
+#### P2 — `UUID` matcher accepts mixed-case hex
+
+`uuid.go:21-26`. RFC 4122 §3 says output is lowercase, input is
+case-insensitive. Current matcher accepts both — correct. The godoc
+says "Hex digits are case-insensitive". Confirmed. No fix.
+
+(No P0/P1 findings for this package.)
+
+### 3.3 `render/` — pooled buffer + writer
+
+#### P2 — `Writer.Reset` doesn't bound large buffers
+
+`render.go:215`. After a giant single-render (megabytes), the Writer
+returns to the pool retaining that capacity. sync.Pool already drops
+items between GC cycles, so the practical risk is small — but a
+defensive cap (e.g. drop buffers >64 KiB instead of pooling) would
+prevent one rogue request bloating the steady-state pool footprint.
+Polish.
+
+#### P2 — `Writer.Bytes()` aliasing contract is documented but not enforced
+
+`render.go:202-207`. Comment says callers must not mutate. There's no
+read-only adapter. Trust the comment for v0.1.
+
+#### P2 — `WriteEscape` `error` precedes `fmt.Stringer` is documented but surprising
+
+`render.go:129-132`. A type that implements both gets `Error()` not
+`String()`. This is the right choice (errors are rarer and more
+specific) and is documented. Confirmed.
+
+(No P0/P1 findings for this package.)
+
+### 3.4 `runtime/router/` — radix tree + match
+
+#### P2 — `routeID` uses 32-bit hash with hex output
+
+`tree.go:281-287`. FNV-1a 32 bits is fine for a 4-byte tag (8 hex
+chars) — collision probability is acceptable for a few hundred routes.
+Already tracked in the umbrella as #170 (closed); confirmed not a
+regression.
+
+#### P2 — `Match` allocates the params map even for routes with no captures
+
+`match.go:80-87`. `if st.n == 0` short-circuits the alloc, so static
+routes pay nothing. Confirmed correct.
+
+#### P2 — `splitAndDecodeInto` heap fallback under-allocates initial cap
+
+`match.go:218`. `make([]string, maxStackParams, count+8)` where `count`
+is already `maxStackParams` — so initial cap is `maxStackParams + 8`.
+For routes with 12+ segments this triggers grow-and-copy. Rare; not a
+fix candidate.
+
+#### P2 — `Tree.Routes()` returns the live slice
+
+`tree.go:103-107`. Caller can mutate and break the matcher. Doc says
+"must not mutate"; trust the comment, no defensive copy. Confirmed.
+
+(No P0/P1 findings for this package — #178 truncate edge case already
+closed.)
+
+### 3.5 `server/` — pipeline + errors + static
+
+#### P1 — Error boundary `RenderCtx` drops `RawParams` and `OriginalURL`
+
+`server/errors.go:204-214`:
+
+```go
+rctx = &kit.RenderCtx{
+    Locals:  ev.Locals,
+    URL:     ev.URL,
+    Params:  ev.Params,
+    Cookies: ev.Cookies,
+    Request: r,
+}
+```
+
+Compare with the success path at `pipeline.go:376-383`, which sets
+`RawParams: ev.RawParams` too. The error template can therefore call
+`ctx.RawParams[name]` and silently get `""` when the success template
+on the same route gets the actual encoded form. `OriginalURL` isn't on
+RenderCtx at all (it lives on `RequestEvent`), so layouts that reroute
+have no way to surface the original path to the error boundary
+either — that's a missing field on the type, see P2 below.
+
+Fix sketch: add `RawParams: ev.RawParams` to the error-boundary ctx
+construction. Trivial. Add a regression test that asserts the error
+template sees the same `RawParams` map as the success template would.
+
+#### P2 — `RenderCtx` lacks `OriginalURL`
+
+`exports/kit/ctx.go:37-45` defines `RenderCtx` with `URL` only. The
+hooks pipeline (`event.go:18-22`) tracks `URL` and `OriginalURL` on
+`RequestEvent`. Reroute can rewrite `URL`; `OriginalURL` preserves the
+inbound. Templates rendered after Reroute see the rewritten URL with
+no path back to the original. Add an `OriginalURL *url.URL` field on
+`RenderCtx` and wire it from `ev.OriginalURL`.
+
+#### P2 — `pipeline.go:188-190` unconditional copy into `ev.Params`
+
+```go
+for k, v := range params {
+    ev.Params[k] = v
+}
+```
+
+Allocs nothing (map is already there from `NewRequestEvent`), but it's
+also unnecessary work when `params == nil` (static routes). The
+Match-returns-nil-map fast path is already in place
+(`match.go:79-80`); the loop is a no-op there. Confirmed safe.
+
+#### P2 — `pipeline.go:399` `collectStreams` runs reflection on every page
+
+Tracked as **OPEN** issue #158. This is the single still-open child of
+the umbrella. Note: the umbrella's acceptance criteria says the parent
+closes when every child is "either resolved or explicitly deferred
+with a note in `tasks/lessons.md`". #158 is neither yet — see
+recommendation in §5.
+
+#### P2 — `errors.go:163-169` httpStatuser legacy branch is reachable from new HandleError contract
+
+The `HandleError` signature became `(SafeError, error)` returning a
+short-circuit error too. The legacy `httpStatuser` promotion on lines
+163-169 only fires when the user did NOT author HandleError (i.e.
+`safe.Code == 500 && safe.Message == "Internal Server Error"`). With
+the new sealed `IdentityHandleError` returning exactly that, the
+branch still serves its purpose. Confirmed correct, but the comment
+should mention the new (SafeError, error) signature so future readers
+don't think this is dead.
+
+#### P2 — `pipeline.go:117-121` deferred Release nils the buffer pointer
+
+```go
+defer func() {
+    if pageBuf != nil {
+        render.Release(pageBuf)
+    }
+}()
+```
+
+`pageBuf` is `*render.Writer` — the deref check is correct. But the
+inner code at 459-461 may have already released a prior buffer when
+Handle calls resolve more than once; on the second call,
+`*pageBuf = buf` (line 462) overwrites the pointer. The defer will
+only release the LAST one, which is correct. Confirmed safe; comment
+on lines 110-113 explains it well.
+
+#### P2 — `actions.go:71` reflective `injectFormField` allocates a struct copy per POST
+
+`server/actions.go:17-41` reflects, copies the struct, and sets one
+field. Codegen could emit a typed setter (every page that has Actions
+already has codegen-known PageData type); the reflective path is the
+fallback for backward compat. Polish.
+
+#### P2 — `server/cron.go:32-53` log keys `name` / `spec` are unique to cron
+
+The named constants `logKeyName` / `logKeySpec` are declared in
+`errors.go:24-25`. Fine, but cron is the only consumer; keeping them
+in errors.go forces every package reader to scroll through unrelated
+constants. Move to cron.go, or accept the cross-file shared key
+discipline as deliberate. Style.
+
+#### P2 — `server/static.go` `acceptsEncoding` trusts non-`q=` qualifier
+
+`static.go:200-207` returns true for any qualifier that isn't `q=`,
+which is wrong per RFC 9110 §12.5.4 — but the unparseable case is rare
+and the failure mode is "send the encoding the client may not want",
+which gets caught at the client. Polish, low risk.
+
+### 3.6 `internal/codegen/` — public entry points only
+
+The public surface of the internal codegen package is:
+
+- `Build(opts BuildOptions) (*BuildResult, error)`
+- `Generate(frag, opts) ([]byte, error)`
+- `GenerateLayout(frag, opts) ([]byte, error)`
+- `GenerateErrorPage(frag, opts) ([]byte, error)`
+- `GenerateManifest(scan, opts) ([]byte, error)`
+- `GenerateLinks(scan, opts) ([]byte, error)`
+- `CollectLinkRoutes(scan) []LinkRoute`
+- `SortLinkRoutes([]LinkRoute) []LinkRoute`
+- `EmitLinksFile(projectRoot, outDir) error`
+
+#### P2 — `BuildOptions.OutDir` defaults to `.gen` silently when empty
+
+`build.go:88-91`. Fine, but `BuildOptions` doesn't document the
+default; godoc says "OutDir is the gen-output root relative to
+ProjectRoot and defaults to .gen". Confirmed — already documented.
+
+#### P2 — `Generate` re-parses scripts/options/style on every call
+
+`codegen.go:62-77` walks the fragment several times (`extractSvelteOptions`,
+`extractScripts`, `extractStyle`, `validateRunesOption`). Build-time
+cost; acceptable. Tracked as #205 (closed) for a related multi-walk
+pattern.
+
+#### P2 — `GenerateManifest` emits route entries in scanner order
+
+`manifest.go:103-104`. Comment says "preserving scanner order" — match
+discipline depends on the build-time radix sort, not the manifest
+order, so this is fine and deterministic.
+
+#### P2 — `GenerateLinks` exposes `LinkRoute` in the public API
+
+`link_emit.go:97`. Fine if `LinkRoute` is intentionally part of the
+package's public contract (it is — the docs/AI codegen reads it). No
+issue.
+
+(No P0/P1 findings for the codegen public entry points.)
+
+## 4. Cross-cutting findings
+
+### 4.1 `STABILITY.md` per package missing
+
+RFC #97 calls for one `STABILITY.md` per package marking each public
+symbol as `stable | experimental | deprecated`. Not present in any of
+the reviewed packages. v0.1 is pre-1.0 so "all experimental" is the
+right default, but the absence of the file means downstream consumers
+can't tell which signatures the team is willing to break vs not.
+
+Action: file a tracking issue (or extend an existing v1.0 docs issue)
+to land `STABILITY.md` per reviewed package before v1.0 promotion.
+
+### 4.2 ctx propagation
+
+Every public function that does I/O takes a context. `LoadCtx` doesn't
+embed `context.Context` though — Load handlers receive `*kit.LoadCtx`,
+which has `.Request.Context()` available but no top-level shortcut. A
+single-line accessor `(c *LoadCtx) Context() context.Context` would
+match SvelteKit's spirit and make it ergonomic to pass to DB calls.
+Tracked previously as part of v0.5 ctx work.
+
+### 4.3 error wrapping discipline
+
+Reviewed packages consistently use `fmt.Errorf` with `%w`. No
+`errors.New` for messages that wrap an underlying error.
+`errStreamingWrote` and `errServerRouteWrote` are sentinels — correct
+use of `errors.New`. Confirmed clean per #96.
+
+### 4.4 slog usage with named keys
+
+`server/errors.go:18-26` declares all log keys as constants and every
+log call references those. `cron.go`, `static.go`, and `pipeline.go`
+do too. sloglint-compatible. Confirmed clean.
+
+### 4.5 reflection footprint
+
+Three reflection paths on the hot path:
+
+- `server/pipeline.go:501-525` (`appendStreams`) — tracked as #158.
+- `server/actions.go:17-41` (`injectFormField`) — runs only on POST
+  with Actions, not the hot path. Acceptable.
+- `exports/kit/bind.go:106-135` (`bindStruct`) — reflects only when
+  user calls BindForm/BindMultipart. Acceptable; results are cached
+  via `bindCache sync.Map`.
+
+The streaming case is the only one worth optimizing further.
+
+### 4.6 panic boundaries
+
+`server/pipeline.go:143-154` (`runHandle`) is the single declared
+panic-recovery boundary in the framework. Confirmed sole boundary —
+no other `recover()` in the reviewed surface. Matches the doc claim
+in `handle()`'s comment.
+
+### 4.7 mutex placement
+
+- `server.Server.mu` covers `httpSrv` and `cronCancel`. Hold time is
+  short. Confirmed correct.
+- `server.Server.initMu` covers `initDone`. Read-only after Init
+  resolves; the hand-rolled atomic+chan dance is needed because
+  `ServeHTTP` reads the channel without lock contention. Confirmed
+  correct.
+- `kit.cspTemplateCache` (`csp.go:119`) is a `sync.Map` — read-mostly,
+  no mutex.
+- `kit.bindCache` (`bind.go:100`) is also a `sync.Map`. Confirmed
+  correct.
+
+No mutex held over I/O in any reviewed file. (The `mcp` package
+finding #214 about disk I/O under write mutex is out-of-scope for
+this review.)
+
+## 5. Recommended issue fan-out
+
+### 5.1 P1 fan-out
+
+| Finding | Issue |
+|---|---|
+| Error boundary `RenderCtx` drops `RawParams` (and `OriginalURL` missing) | #314 |
+
+### 5.2 P2 polish bundles (umbrella per package)
+
+Bundle every P2 in this section under a single umbrella per package
+with a checklist body. Filed:
+
+| Package | Umbrella issue |
+|---|---|
+| `exports/kit/` | #318 |
+| `render/` | #319 |
+| `runtime/router/` | #320 |
+| `server/` | #321 |
+| `internal/codegen/` (public surface) | #322 |
+
+### 5.3 Cross-cutting
+
+| Finding | Status / Issue |
+|---|---|
+| `STABILITY.md` per package missing | #323 |
+| `LoadCtx.Context()` accessor | Already covered by v0.5 ctx work |
+| `collectStreams` reflection | Existing #158 — see §6 about umbrella close |
+| ctx-state duplication between RenderCtx/LoadCtx | Defer to v0.5 ctx work |
+
+### 5.4 Existing issues already covering review scope
+
+These were found by the review but already have closed sub-issues
+listed on the umbrella body — no new issue needed:
+
+- `WriteJSON` encoder pool — #153 (closed)
+- `BuildCSPHeader` template cache — #160 (closed)
+- `escapeScriptJSON` fast path — #154 (closed)
+- `renderPage` zero-copy — #157 (closed)
+- `actionNameFromQuery` allocation — #161 (closed)
+- `kit.Stream` cancellation — #211 (closed)
+- `WriteEscape` default branch — #196 (closed)
+- `dedupeTitle` head buffer scan — #159 (closed)
+- `routeID` 4-byte hash — #170 (closed)
+- `matchState.truncate` edge case — #178 (closed)
+- `GenerateManifest` linear scans — #201 (closed)
+- `emitOpenTag` four-walk — #205 (closed)
+- `WriteRawBytes` head splice — #163 (closed)
+- bench reset — #213 (closed)
+
+## 6. Closing #215 — disposition of #158
+
+The umbrella body says it closes when every linked sub-issue is
+"either resolved or explicitly deferred with a note in `tasks/lessons.md`".
+
+#158 (collectStreams reflection) is **still open**. The fix is real
+work: requires codegen to emit a per-route typed walker, which means
+threading a flag through `ScannedRoute` → `ManifestOptions` → manifest
+emit. Not a v0.1 closer.
+
+**Recommendation:** mark #158 as deferred-to-v1.0 perf hardening with
+a brief lessons note, then close #215. The remaining child is now
+captured against a milestone with the rest of the perf budget. The
+umbrella has served its purpose: it surfaced 21 sub-issues, 19 closed.
+Holding the umbrella open indefinitely on a single perf optimization
+is anti-pattern.
+
+This master review PR closes #215 with a comment on the issue listing
+the umbrella + fan-out issues, and adds the deferral note in lessons.
+
+## 7. Out-of-scope observations
+
+Listed for completeness; explicitly NOT filed as issues to avoid
+future-bait:
+
+- `kit.NewCookies` infers `Secure` from `r.TLS != nil`. Behind a
+  reverse proxy that terminates TLS, this is wrong (the upstream
+  request looks plaintext). Workaround is either Forwarded headers
+  parsing or an explicit `Secure: &t` per cookie. Better solved at
+  the framework's "is this connection effectively HTTPS" layer, which
+  doesn't exist yet. Future work.
+- `kit.Sequence` builds a closure chain at every request. Could be
+  flattened to a slice + index walk for a tiny perf win. Not worth
+  it — the current shape is the textbook composition.
+- `Server` exposes `Logger` as a public field
+  (`server.go:95`). Idiomatic Go would unexport and provide
+  `s.Logger()`. Mutation while serving is racy. Tolerable for v0.1;
+  future hardening.
+- `kit.RenderCtx.Writer` is a public `http.ResponseWriter`. Letting
+  templates touch the writer directly bypasses the shell splice and
+  cookie flush. Should be removed before stable, but generated
+  templates use it for rare cases (e.g. raw streaming endpoints
+  invoked from a page). Defer.
+- The `routescan.Diagnostic` type (used through `BuildResult.Diagnostics`)
+  is in an internal package but its `String()` shape is part of the
+  Build result. If `Build` is ever stabilized, that type must be
+  re-exported or wrapped. Future doc-pass concern.
+
+## 8. Verification of this PR
+
+Pre-merge checklist:
+
+- [x] Markdown lint clean (no broken anchors, headings hierarchical)
+- [x] `tasks/reviews/` directory created
+- [x] Master review file written under canonical path
+- [x] Filed: 1 P1 issue, 5 per-package P2 umbrellas, 1 STABILITY.md
+      tracking issue
+- [x] All filed issues carry `type:chore`, correct `area:*`,
+      `priority:p1` or `priority:p2`
+- [x] #215 references in PR body resolve to the right umbrella
+- [x] No Go code changes; CI lint/build/test gates remain whatever
+      they were before this PR


### PR DESCRIPTION
## Summary

- Master code-quality review of the v0.1 Go surface (kit, render, router, server, codegen public entry points) under `tasks/reviews/2026-04-30-v0.1-master-review.md`.
- Read-only walk; zero Go changes. CI lint/build/test gates remain whatever they were before this PR.
- Fans out 1 P1 (#314), 5 per-package P2 umbrellas (#318–#322), 1 STABILITY.md tracker (#323).
- Defers the single still-open umbrella child (#158, `collectStreams` reflection) to v1.0 perf hardening with `tasks/lessons/2026-04-30-v0.1-master-review-defer-158.md` so the umbrella can close.

Closes #215.

## Filed issues

| # | Title | Tier |
|---|---|---|
| #314 | code-quality: server: error boundary RenderCtx drops RawParams + add OriginalURL | P1 |
| #318 | code-quality: kit: v0.1 polish bundle | P2 umbrella |
| #319 | code-quality: render: v0.1 polish bundle | P2 umbrella |
| #320 | code-quality: router: v0.1 polish bundle | P2 umbrella |
| #321 | code-quality: server: v0.1 polish bundle | P2 umbrella |
| #322 | code-quality: codegen: v0.1 polish bundle | P2 umbrella |
| #323 | code-quality: docs: STABILITY.md per public package | P2 cross-cutting |

## Test plan

- [x] Markdown renders cleanly (review file structure: 8 sections, all anchors resolve)
- [x] `tasks/reviews/` directory created
- [x] All filed issues carry `type:chore`, correct `area:*`, `priority:p1` or `priority:p2`
- [x] `gh issue view 215` confirms it will close on merge (Closes #215 in PR body)
- [x] Deferral comment posted on #158 cross-linking the lessons note
- [x] Lessons index updated with the deferral entry