### PR TITLE
feat(auth): Storage interface + memory adapter

### DIFF
--- a/packages/auth/auth.go
+++ b/packages/auth/auth.go
@@ -21,9 +21,8 @@ type Config struct {
 	// Now returns the current time. Defaults to time.Now. Override in tests.
 	Now func() time.Time
 
-	// Storage is the persistence adapter (populated by #217–#219).
-	// Type will become a typed interface once the storage package lands.
-	Storage any
+	// Storage is the persistence adapter. auth.New panics if this is nil.
+	Storage Storage
 
 	// Mailer is the email delivery adapter (populated by the email-provider issues).
 	Mailer any
@@ -53,6 +52,9 @@ type Auth struct {
 // any zero-value fields. It returns a non-nil *Auth and nil error on
 // success; future validation (e.g. missing BaseURL) may return an error.
 func New(cfg Config) (*Auth, error) {
+	if cfg.Storage == nil {
+		panic("auth: Config.Storage must not be nil — auth without storage is meaningless")
+	}
 	if cfg.BasePath == "" {
 		cfg.BasePath = "/auth"
 	}

--- a/packages/auth/auth_test.go
+++ b/packages/auth/auth_test.go
@@ -4,16 +4,27 @@ import (
 	"testing"
 
 	"github.com/binsarjr/sveltego/auth"
+	"github.com/binsarjr/sveltego/auth/storage/memory"
 )
 
 // TestNew_DefaultsHonored verifies that New fills in zero-value Config fields
 // and returns a non-nil *Auth.
 func TestNew_DefaultsHonored(t *testing.T) {
-	a, err := auth.New(auth.Config{})
+	a, err := auth.New(auth.Config{Storage: memory.New()})
 	if err != nil {
 		t.Fatalf("New returned unexpected error: %v", err)
 	}
 	if a == nil {
 		t.Fatal("New returned nil *Auth")
 	}
+}
+
+// TestNew_PanicsWithoutStorage verifies that New panics when Storage is nil.
+func TestNew_PanicsWithoutStorage(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for nil Storage, got none")
+		}
+	}()
+	_, _ = auth.New(auth.Config{}) //nolint:errcheck
 }

--- a/packages/auth/storage.go
+++ b/packages/auth/storage.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"context"
+	"time"
+)
+
+// Storage is the persistence contract every auth adapter must satisfy.
+// All methods receive a context for cancellation and tracing. Sentinel
+// errors (ErrNotFound, ErrConflict, ErrSessionExpired) must be wrapped
+// with fmt.Errorf("auth: %w", sentinel) so callers can use errors.Is.
+type Storage interface {
+	// CreateUser persists a new User. Returns ErrConflict if a user with
+	// the same Email already exists.
+	CreateUser(ctx context.Context, u *User) error
+
+	// UserByID returns the User with the given id. Returns ErrNotFound if
+	// no such user exists.
+	UserByID(ctx context.Context, id string) (*User, error)
+
+	// UserByEmail returns the User with the given email address. Returns
+	// ErrNotFound if no such user exists.
+	UserByEmail(ctx context.Context, email string) (*User, error)
+
+	// UpdateUser persists changes to an existing User record. Returns
+	// ErrNotFound if the user does not exist.
+	UpdateUser(ctx context.Context, u *User) error
+
+	// DeleteUser removes the User and cascades the deletion to all
+	// associated Sessions, Accounts, and Verifications. Returns ErrNotFound
+	// if the user does not exist.
+	DeleteUser(ctx context.Context, id string) error
+
+	// CreateSession persists a new Session.
+	CreateSession(ctx context.Context, s *Session) error
+
+	// SessionByToken returns the Session identified by the given token.
+	// Returns ErrNotFound if no session with that token exists, or
+	// ErrSessionExpired if the session exists but its ExpiresAt is in the past.
+	SessionByToken(ctx context.Context, token string) (*Session, error)
+
+	// RefreshSession extends the expiry of the session identified by token
+	// to newExpiry. Returns ErrNotFound if no such session exists.
+	RefreshSession(ctx context.Context, token string, newExpiry time.Time) error
+
+	// RevokeSession deletes the session identified by token. Idempotent:
+	// returns nil if the session does not exist.
+	RevokeSession(ctx context.Context, token string) error
+
+	// RevokeAllSessions deletes every session belonging to userID. Idempotent.
+	RevokeAllSessions(ctx context.Context, userID string) error
+
+	// CreateAccount persists a new Account linking a User to a provider.
+	CreateAccount(ctx context.Context, a *Account) error
+
+	// AccountsByUser returns all Accounts belonging to the given userID.
+	// Returns an empty slice (not ErrNotFound) when the user has no accounts.
+	AccountsByUser(ctx context.Context, userID string) ([]*Account, error)
+
+	// LinkAccount is an alias of CreateAccount that documents the caller's
+	// intent to associate an external provider with an existing User.
+	LinkAccount(ctx context.Context, a *Account) error
+
+	// UnlinkAccount removes the Account with the given accountID. Returns
+	// ErrNotFound if the account does not exist.
+	UnlinkAccount(ctx context.Context, accountID string) error
+
+	// CreateVerification persists a new Verification record.
+	CreateVerification(ctx context.Context, v *Verification) error
+
+	// VerificationByCode returns the Verification identified by code.
+	// Returns ErrNotFound if the code does not exist.
+	VerificationByCode(ctx context.Context, code string) (*Verification, error)
+
+	// ConsumeVerification marks a Verification as used by deleting it.
+	// Returns ErrNotFound if the code does not exist.
+	ConsumeVerification(ctx context.Context, code string) error
+}

--- a/packages/auth/storage/adaptertest/adaptertest.go
+++ b/packages/auth/storage/adaptertest/adaptertest.go
@@ -1,0 +1,543 @@
+// Package adaptertest provides a shared compliance suite for auth.Storage
+// implementations. Any adapter can re-use it by calling Run from its own
+// test file:
+//
+//	func TestMyAdapter_AdapterCompliance(t *testing.T) {
+//	    adaptertest.Run(t, func() auth.Storage { return myadapter.New() })
+//	}
+package adaptertest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/binsarjr/sveltego/auth"
+)
+
+// Run executes the full compliance suite against the Storage returned by factory.
+// factory is called once per sub-test so each test gets a clean instance.
+func Run(t *testing.T, factory func() auth.Storage) {
+	t.Helper()
+	t.Run("User", func(t *testing.T) { runUserTests(t, factory) })
+	t.Run("Session", func(t *testing.T) { runSessionTests(t, factory) })
+	t.Run("Account", func(t *testing.T) { runAccountTests(t, factory) })
+	t.Run("Verification", func(t *testing.T) { runVerificationTests(t, factory) })
+	t.Run("Cascade", func(t *testing.T) { runCascadeTest(t, factory) })
+	t.Run("Concurrency", func(t *testing.T) { runConcurrencyTest(t, factory) })
+}
+
+// --- helpers ---
+
+func newUser(id, email string) *auth.User {
+	now := time.Now()
+	return &auth.User{
+		ID:        id,
+		Email:     email,
+		Name:      "Test User",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func newSession(id, userID, token string, expiry time.Time) *auth.Session {
+	now := time.Now()
+	return &auth.Session{
+		ID:        id,
+		UserID:    userID,
+		Token:     token,
+		ExpiresAt: expiry,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func newAccount(id, userID, provider string) *auth.Account {
+	now := time.Now()
+	return &auth.Account{
+		ID:                id,
+		UserID:            userID,
+		Provider:          provider,
+		ProviderAccountID: provider + "-remote-id",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+}
+
+func newVerification(id, userID, token string) *auth.Verification {
+	return &auth.Verification{
+		ID:        id,
+		UserID:    userID,
+		Kind:      "email",
+		Token:     token,
+		ExpiresAt: time.Now().Add(time.Hour),
+		CreatedAt: time.Now(),
+	}
+}
+
+// --- User tests ---
+
+func runUserTests(t *testing.T, factory func() auth.Storage) {
+	t.Helper()
+
+	t.Run("CreateAndGetByID", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		u := newUser("u1", "alice@example.com")
+		if err := s.CreateUser(ctx, u); err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		got, err := s.UserByID(ctx, "u1")
+		if err != nil {
+			t.Fatalf("UserByID: %v", err)
+		}
+		if got.Email != u.Email {
+			t.Errorf("email mismatch: got %q want %q", got.Email, u.Email)
+		}
+	})
+
+	t.Run("CreateAndGetByEmail", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		u := newUser("u1", "alice@example.com")
+		if err := s.CreateUser(ctx, u); err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		got, err := s.UserByEmail(ctx, "alice@example.com")
+		if err != nil {
+			t.Fatalf("UserByEmail: %v", err)
+		}
+		if got.ID != "u1" {
+			t.Errorf("id mismatch: got %q want %q", got.ID, "u1")
+		}
+	})
+
+	t.Run("CreateConflict", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		u1 := newUser("u1", "alice@example.com")
+		u2 := newUser("u2", "alice@example.com")
+		if err := s.CreateUser(ctx, u1); err != nil {
+			t.Fatalf("first CreateUser: %v", err)
+		}
+		err := s.CreateUser(ctx, u2)
+		if !errors.Is(err, auth.ErrConflict) {
+			t.Errorf("expected ErrConflict, got %v", err)
+		}
+	})
+
+	t.Run("UserByIDNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		_, err := s.UserByID(ctx, "missing")
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("UserByEmailNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		_, err := s.UserByEmail(ctx, "nobody@example.com")
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("UpdateUser", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		u := newUser("u1", "alice@example.com")
+		if err := s.CreateUser(ctx, u); err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		u.Name = "Alice Updated"
+		if err := s.UpdateUser(ctx, u); err != nil {
+			t.Fatalf("UpdateUser: %v", err)
+		}
+		got, _ := s.UserByID(ctx, "u1")
+		if got.Name != "Alice Updated" {
+			t.Errorf("name not updated: got %q", got.Name)
+		}
+	})
+
+	t.Run("UpdateUserNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		err := s.UpdateUser(ctx, newUser("missing", "x@example.com"))
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("UpdateUserEmailChange", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		u := newUser("u1", "old@example.com")
+		if err := s.CreateUser(ctx, u); err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		u.Email = "new@example.com"
+		if err := s.UpdateUser(ctx, u); err != nil {
+			t.Fatalf("UpdateUser: %v", err)
+		}
+		// old email must be gone
+		if _, err := s.UserByEmail(ctx, "old@example.com"); !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("old email still resolves after update")
+		}
+		// new email must work
+		if _, err := s.UserByEmail(ctx, "new@example.com"); err != nil {
+			t.Errorf("new email not found after update: %v", err)
+		}
+	})
+
+	t.Run("DeleteUser", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		u := newUser("u1", "alice@example.com")
+		if err := s.CreateUser(ctx, u); err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		if err := s.DeleteUser(ctx, "u1"); err != nil {
+			t.Fatalf("DeleteUser: %v", err)
+		}
+		if _, err := s.UserByID(ctx, "u1"); !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("user still found after delete")
+		}
+	})
+
+	t.Run("DeleteUserNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		err := s.DeleteUser(ctx, "missing")
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+// --- Session tests ---
+
+func runSessionTests(t *testing.T, factory func() auth.Storage) {
+	t.Helper()
+
+	t.Run("CreateAndGetByToken", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		sess := newSession("s1", "u1", "tok-abc", time.Now().Add(time.Hour))
+		if err := s.CreateSession(ctx, sess); err != nil {
+			t.Fatalf("CreateSession: %v", err)
+		}
+		got, err := s.SessionByToken(ctx, "tok-abc")
+		if err != nil {
+			t.Fatalf("SessionByToken: %v", err)
+		}
+		if got.UserID != "u1" {
+			t.Errorf("userID mismatch: got %q", got.UserID)
+		}
+	})
+
+	t.Run("SessionByTokenNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		_, err := s.SessionByToken(ctx, "no-such-token")
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("SessionByTokenExpired", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		sess := newSession("s1", "u1", "tok-exp", time.Now().Add(-time.Second))
+		if err := s.CreateSession(ctx, sess); err != nil {
+			t.Fatalf("CreateSession: %v", err)
+		}
+		_, err := s.SessionByToken(ctx, "tok-exp")
+		if !errors.Is(err, auth.ErrSessionExpired) {
+			t.Errorf("expected ErrSessionExpired, got %v", err)
+		}
+	})
+
+	t.Run("RefreshSession", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		sess := newSession("s1", "u1", "tok-r", time.Now().Add(time.Hour))
+		if err := s.CreateSession(ctx, sess); err != nil {
+			t.Fatalf("CreateSession: %v", err)
+		}
+		newExpiry := time.Now().Add(24 * time.Hour)
+		if err := s.RefreshSession(ctx, "tok-r", newExpiry); err != nil {
+			t.Fatalf("RefreshSession: %v", err)
+		}
+		got, _ := s.SessionByToken(ctx, "tok-r")
+		if !got.ExpiresAt.Equal(newExpiry) {
+			t.Errorf("expiry not updated")
+		}
+	})
+
+	t.Run("RefreshSessionNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		err := s.RefreshSession(ctx, "missing", time.Now().Add(time.Hour))
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("RevokeSessionIdempotent", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		sess := newSession("s1", "u1", "tok-rev", time.Now().Add(time.Hour))
+		if err := s.CreateSession(ctx, sess); err != nil {
+			t.Fatalf("CreateSession: %v", err)
+		}
+		if err := s.RevokeSession(ctx, "tok-rev"); err != nil {
+			t.Fatalf("first RevokeSession: %v", err)
+		}
+		// idempotent — second call must not error
+		if err := s.RevokeSession(ctx, "tok-rev"); err != nil {
+			t.Fatalf("second RevokeSession: %v", err)
+		}
+	})
+
+	t.Run("RevokeAllSessions", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		for i := range 3 {
+			sess := newSession(
+				fmt.Sprintf("s%d", i),
+				"u1",
+				fmt.Sprintf("tok-%d", i),
+				time.Now().Add(time.Hour),
+			)
+			if err := s.CreateSession(ctx, sess); err != nil {
+				t.Fatalf("CreateSession %d: %v", i, err)
+			}
+		}
+		if err := s.RevokeAllSessions(ctx, "u1"); err != nil {
+			t.Fatalf("RevokeAllSessions: %v", err)
+		}
+		for i := range 3 {
+			_, err := s.SessionByToken(ctx, fmt.Sprintf("tok-%d", i))
+			if !errors.Is(err, auth.ErrNotFound) {
+				t.Errorf("session tok-%d still present after RevokeAllSessions", i)
+			}
+		}
+	})
+
+	t.Run("RevokeAllSessionsIdempotent", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		// no sessions — must not error
+		if err := s.RevokeAllSessions(ctx, "u-empty"); err != nil {
+			t.Fatalf("RevokeAllSessions on empty: %v", err)
+		}
+	})
+}
+
+// --- Account tests ---
+
+func runAccountTests(t *testing.T, factory func() auth.Storage) {
+	t.Helper()
+
+	t.Run("CreateAndList", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		a := newAccount("a1", "u1", "google")
+		if err := s.CreateAccount(ctx, a); err != nil {
+			t.Fatalf("CreateAccount: %v", err)
+		}
+		list, err := s.AccountsByUser(ctx, "u1")
+		if err != nil {
+			t.Fatalf("AccountsByUser: %v", err)
+		}
+		if len(list) != 1 {
+			t.Errorf("expected 1 account, got %d", len(list))
+		}
+	})
+
+	t.Run("AccountsByUserEmpty", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		list, err := s.AccountsByUser(ctx, "nobody")
+		if err != nil {
+			t.Fatalf("AccountsByUser: %v", err)
+		}
+		if len(list) != 0 {
+			t.Errorf("expected empty slice, got %d", len(list))
+		}
+	})
+
+	t.Run("LinkAccount", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		a := newAccount("a1", "u1", "github")
+		if err := s.LinkAccount(ctx, a); err != nil {
+			t.Fatalf("LinkAccount: %v", err)
+		}
+		list, _ := s.AccountsByUser(ctx, "u1")
+		if len(list) != 1 {
+			t.Errorf("expected 1 account after LinkAccount, got %d", len(list))
+		}
+	})
+
+	t.Run("UnlinkAccount", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		a := newAccount("a1", "u1", "google")
+		if err := s.CreateAccount(ctx, a); err != nil {
+			t.Fatalf("CreateAccount: %v", err)
+		}
+		if err := s.UnlinkAccount(ctx, "a1"); err != nil {
+			t.Fatalf("UnlinkAccount: %v", err)
+		}
+		list, _ := s.AccountsByUser(ctx, "u1")
+		if len(list) != 0 {
+			t.Errorf("expected 0 accounts after unlink, got %d", len(list))
+		}
+	})
+
+	t.Run("UnlinkAccountNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		err := s.UnlinkAccount(ctx, "missing")
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+// --- Verification tests ---
+
+func runVerificationTests(t *testing.T, factory func() auth.Storage) {
+	t.Helper()
+
+	t.Run("CreateAndGet", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		v := newVerification("v1", "u1", "code-abc")
+		if err := s.CreateVerification(ctx, v); err != nil {
+			t.Fatalf("CreateVerification: %v", err)
+		}
+		got, err := s.VerificationByCode(ctx, "code-abc")
+		if err != nil {
+			t.Fatalf("VerificationByCode: %v", err)
+		}
+		if got.UserID != "u1" {
+			t.Errorf("userID mismatch: got %q", got.UserID)
+		}
+	})
+
+	t.Run("VerificationByCodeNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		_, err := s.VerificationByCode(ctx, "no-code")
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("ConsumeVerification", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		v := newVerification("v1", "u1", "code-xyz")
+		if err := s.CreateVerification(ctx, v); err != nil {
+			t.Fatalf("CreateVerification: %v", err)
+		}
+		if err := s.ConsumeVerification(ctx, "code-xyz"); err != nil {
+			t.Fatalf("ConsumeVerification: %v", err)
+		}
+		_, err := s.VerificationByCode(ctx, "code-xyz")
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("verification still present after consume")
+		}
+	})
+
+	t.Run("ConsumeVerificationNotFound", func(t *testing.T) {
+		s := factory()
+		ctx := context.Background()
+		err := s.ConsumeVerification(ctx, "no-code")
+		if !errors.Is(err, auth.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+// --- Cascade test ---
+
+func runCascadeTest(t *testing.T, factory func() auth.Storage) {
+	t.Helper()
+
+	s := factory()
+	ctx := context.Background()
+
+	u := newUser("u1", "cascade@example.com")
+	if err := s.CreateUser(ctx, u); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	sess := newSession("s1", "u1", "tok-cascade", time.Now().Add(time.Hour))
+	if err := s.CreateSession(ctx, sess); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	acc := newAccount("a1", "u1", "google")
+	if err := s.CreateAccount(ctx, acc); err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	ver := newVerification("v1", "u1", "code-cascade")
+	if err := s.CreateVerification(ctx, ver); err != nil {
+		t.Fatalf("CreateVerification: %v", err)
+	}
+
+	if err := s.DeleteUser(ctx, "u1"); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+
+	if _, err := s.SessionByToken(ctx, "tok-cascade"); !errors.Is(err, auth.ErrNotFound) {
+		t.Errorf("session survived DeleteUser cascade")
+	}
+	if list, _ := s.AccountsByUser(ctx, "u1"); len(list) != 0 {
+		t.Errorf("accounts survived DeleteUser cascade: %d remaining", len(list))
+	}
+	if _, err := s.VerificationByCode(ctx, "code-cascade"); !errors.Is(err, auth.ErrNotFound) {
+		t.Errorf("verification survived DeleteUser cascade")
+	}
+}
+
+// --- Concurrency test ---
+
+func runConcurrencyTest(t *testing.T, factory func() auth.Storage) {
+	t.Helper()
+
+	s := factory()
+	ctx := context.Background()
+
+	const goroutines = 100
+	const opsPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(g int) {
+			defer wg.Done()
+			for op := range opsPerGoroutine {
+				id := fmt.Sprintf("u-%d-%d", g, op)
+				email := fmt.Sprintf("user-%d-%d@example.com", g, op)
+				u := newUser(id, email)
+				_ = s.CreateUser(ctx, u)
+				_, _ = s.UserByID(ctx, id)
+				_, _ = s.UserByEmail(ctx, email)
+				tok := fmt.Sprintf("tok-%d-%d", g, op)
+				sess := newSession(id+"s", id, tok, time.Now().Add(time.Hour))
+				_ = s.CreateSession(ctx, sess)
+				_, _ = s.SessionByToken(ctx, tok)
+				_ = s.RevokeSession(ctx, tok)
+				_ = s.DeleteUser(ctx, id)
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/packages/auth/storage/memory/memory.go
+++ b/packages/auth/storage/memory/memory.go
@@ -1,0 +1,264 @@
+// Package memory provides an in-memory implementation of auth.Storage.
+// It is suitable for tests and local development; data is lost on process exit.
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/binsarjr/sveltego/auth"
+)
+
+// Store is a thread-safe in-memory auth.Storage implementation.
+type Store struct {
+	mu            sync.RWMutex
+	users         map[string]*auth.User         // keyed by User.ID
+	usersByEmail  map[string]string             // email -> User.ID
+	sessions      map[string]*auth.Session      // keyed by Session.Token
+	accounts      map[string]*auth.Account      // keyed by Account.ID
+	verifications map[string]*auth.Verification // keyed by Verification.Token
+}
+
+// New returns a new empty Store implementing auth.Storage.
+func New() *Store {
+	return &Store{
+		users:         make(map[string]*auth.User),
+		usersByEmail:  make(map[string]string),
+		sessions:      make(map[string]*auth.Session),
+		accounts:      make(map[string]*auth.Account),
+		verifications: make(map[string]*auth.Verification),
+	}
+}
+
+// Ensure Store implements auth.Storage at compile time.
+var _ auth.Storage = (*Store)(nil)
+
+// --- User ---
+
+// CreateUser persists u. Returns ErrConflict if the email is already taken.
+func (s *Store) CreateUser(_ context.Context, u *auth.User) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.usersByEmail[u.Email]; exists {
+		return fmt.Errorf("auth: %w", auth.ErrConflict)
+	}
+	clone := *u
+	s.users[u.ID] = &clone
+	s.usersByEmail[u.Email] = u.ID
+	return nil
+}
+
+// UserByID returns the user with the given id. Returns ErrNotFound if absent.
+func (s *Store) UserByID(_ context.Context, id string) (*auth.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	u, ok := s.users[id]
+	if !ok {
+		return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	clone := *u
+	return &clone, nil
+}
+
+// UserByEmail returns the user with the given email. Returns ErrNotFound if absent.
+func (s *Store) UserByEmail(_ context.Context, email string) (*auth.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	id, ok := s.usersByEmail[email]
+	if !ok {
+		return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	clone := *s.users[id]
+	return &clone, nil
+}
+
+// UpdateUser replaces the stored record for u.ID. Returns ErrNotFound if absent.
+func (s *Store) UpdateUser(_ context.Context, u *auth.User) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.users[u.ID]
+	if !ok {
+		return fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	// Remove old email index if email changed.
+	if existing.Email != u.Email {
+		delete(s.usersByEmail, existing.Email)
+		s.usersByEmail[u.Email] = u.ID
+	}
+	clone := *u
+	s.users[u.ID] = &clone
+	return nil
+}
+
+// DeleteUser removes the user and cascades to sessions, accounts, and verifications.
+// Returns ErrNotFound if the user does not exist.
+func (s *Store) DeleteUser(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.users[id]
+	if !ok {
+		return fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	delete(s.usersByEmail, u.Email)
+	delete(s.users, id)
+	for token, sess := range s.sessions {
+		if sess.UserID == id {
+			delete(s.sessions, token)
+		}
+	}
+	for aid, acc := range s.accounts {
+		if acc.UserID == id {
+			delete(s.accounts, aid)
+		}
+	}
+	for code, v := range s.verifications {
+		if v.UserID == id {
+			delete(s.verifications, code)
+		}
+	}
+	return nil
+}
+
+// --- Session ---
+
+// CreateSession persists s.
+func (s *Store) CreateSession(_ context.Context, sess *auth.Session) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clone := *sess
+	s.sessions[sess.Token] = &clone
+	return nil
+}
+
+// SessionByToken returns the session for the given token. Returns ErrNotFound
+// if absent, or ErrSessionExpired if the session is past its ExpiresAt.
+func (s *Store) SessionByToken(_ context.Context, token string) (*auth.Session, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.sessions[token]
+	if !ok {
+		return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	if time.Now().After(sess.ExpiresAt) {
+		return nil, fmt.Errorf("auth: %w", auth.ErrSessionExpired)
+	}
+	clone := *sess
+	return &clone, nil
+}
+
+// RefreshSession extends the expiry of the session identified by token.
+// Returns ErrNotFound if absent.
+func (s *Store) RefreshSession(_ context.Context, token string, newExpiry time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[token]
+	if !ok {
+		return fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	sess.ExpiresAt = newExpiry
+	sess.UpdatedAt = time.Now()
+	return nil
+}
+
+// RevokeSession deletes the session identified by token. Idempotent.
+func (s *Store) RevokeSession(_ context.Context, token string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, token)
+	return nil
+}
+
+// RevokeAllSessions deletes every session belonging to userID. Idempotent.
+func (s *Store) RevokeAllSessions(_ context.Context, userID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for token, sess := range s.sessions {
+		if sess.UserID == userID {
+			delete(s.sessions, token)
+		}
+	}
+	return nil
+}
+
+// --- Account ---
+
+// CreateAccount persists a.
+func (s *Store) CreateAccount(_ context.Context, a *auth.Account) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clone := *a
+	s.accounts[a.ID] = &clone
+	return nil
+}
+
+// AccountsByUser returns all accounts belonging to userID.
+func (s *Store) AccountsByUser(_ context.Context, userID string) ([]*auth.Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*auth.Account
+	for _, a := range s.accounts {
+		if a.UserID == userID {
+			clone := *a
+			out = append(out, &clone)
+		}
+	}
+	if out == nil {
+		out = []*auth.Account{}
+	}
+	return out, nil
+}
+
+// LinkAccount is an alias of CreateAccount documenting provider-linking intent.
+func (s *Store) LinkAccount(ctx context.Context, a *auth.Account) error {
+	return s.CreateAccount(ctx, a)
+}
+
+// UnlinkAccount removes the account with the given accountID.
+// Returns ErrNotFound if absent.
+func (s *Store) UnlinkAccount(_ context.Context, accountID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.accounts[accountID]; !ok {
+		return fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	delete(s.accounts, accountID)
+	return nil
+}
+
+// --- Verification ---
+
+// CreateVerification persists v.
+func (s *Store) CreateVerification(_ context.Context, v *auth.Verification) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clone := *v
+	s.verifications[v.Token] = &clone
+	return nil
+}
+
+// VerificationByCode returns the Verification identified by code.
+// Returns ErrNotFound if absent.
+func (s *Store) VerificationByCode(_ context.Context, code string) (*auth.Verification, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.verifications[code]
+	if !ok {
+		return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	clone := *v
+	return &clone, nil
+}
+
+// ConsumeVerification deletes the Verification identified by code.
+// Returns ErrNotFound if absent.
+func (s *Store) ConsumeVerification(_ context.Context, code string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.verifications[code]; !ok {
+		return fmt.Errorf("auth: %w", auth.ErrNotFound)
+	}
+	delete(s.verifications, code)
+	return nil
+}

--- a/packages/auth/storage/memory/memory_test.go
+++ b/packages/auth/storage/memory/memory_test.go
@@ -1,0 +1,47 @@
+package memory_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/binsarjr/sveltego/auth"
+	"github.com/binsarjr/sveltego/auth/storage/adaptertest"
+	"github.com/binsarjr/sveltego/auth/storage/memory"
+)
+
+// TestMemory_AdapterCompliance runs the shared adapter compliance suite
+// against the in-memory Store.
+func TestMemory_AdapterCompliance(t *testing.T) {
+	adaptertest.Run(t, func() auth.Storage { return memory.New() })
+}
+
+// TestMemory_DeletedUserGC verifies that the internal maps are cleaned up
+// after DeleteUser — no ghost entries leak memory.
+func TestMemory_DeletedUserGC(t *testing.T) {
+	s := memory.New()
+	ctx := context.Background()
+
+	const n = 50
+	for i := range n {
+		u := &auth.User{
+			ID:    fmt.Sprintf("gc-u%d", i),
+			Email: fmt.Sprintf("gc-%d@example.com", i),
+		}
+		if err := s.CreateUser(ctx, u); err != nil {
+			t.Fatalf("CreateUser %d: %v", i, err)
+		}
+	}
+	for i := range n {
+		if err := s.DeleteUser(ctx, fmt.Sprintf("gc-u%d", i)); err != nil {
+			t.Fatalf("DeleteUser %d: %v", i, err)
+		}
+	}
+	// All deleted users must now return ErrNotFound.
+	for i := range n {
+		_, err := s.UserByID(ctx, fmt.Sprintf("gc-u%d", i))
+		if err == nil {
+			t.Errorf("user gc-u%d still present after delete", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Defines `auth.Storage` interface with 17 methods covering User, Session, Account, and Verification entities — flat method design per job spec, with godoc and explicit error contracts on each method
- Implements `packages/auth/storage/memory` — thread-safe (`sync.RWMutex`) in-memory adapter; cascades `DeleteUser` across sessions/accounts/verifications; `SessionByToken` returns `ErrSessionExpired` without auto-deleting
- Ships `packages/auth/storage/adaptertest` — public compliance suite any adapter can call via `adaptertest.Run(t, factory)`; covers happy path, every documented error case, cascade deletion, and a 100-goroutine × 10-op race-clean concurrency test
- Tightens `auth.Config.Storage` from `any` to the typed `auth.Storage` interface; `auth.New` panics with a clear message when `Storage` is nil

## Stacks on PR #324

PR #324 (`phase/v0.6-auth-scaffold-#216`) is still **OPEN** at the time of this PR. This branch was cut from `main` which already contains the `packages/auth/` scaffold (it landed directly on main). If PR #324 creates a conflicting version of those files, the rebase agent will resolve it.

## Verification

- `go build ./...` — clean (auth module)
- `go vet ./...` — no issues
- `gofumpt -l packages/auth/` — no output
- `goimports -l -local github.com/binsarjr/sveltego packages/auth/` — no output
- `golangci-lint run ./packages/auth/...` — no issues
- `go test -race ./...` — 37 passed (3 packages), including compliance suite + concurrency test

## Test plan

- [ ] All 37 tests pass under `go test -race ./packages/auth/...`
- [ ] Cascade test: `DeleteUser` removes sessions, accounts, and verifications
- [ ] Concurrency test: 100 goroutines × 10 ops, zero race-detector hits
- [ ] `TestNew_PanicsWithoutStorage`: `auth.New(auth.Config{})` panics
- [ ] CI green

Closes #217