### PR TITLE
fix(server): RenderCtx RawParams + OriginalURL on error path

### DIFF
--- a/packages/sveltego/exports/kit/ctx.go
+++ b/packages/sveltego/exports/kit/ctx.go
@@ -35,13 +35,18 @@ func (hw *HeaderWriter) Del(key string) {
 // RenderCtx is the request-scoped context handed to generated Render
 // methods across the SSR lifecycle (Load, Render, Hooks).
 type RenderCtx struct {
-	Locals    map[string]any
-	URL       *url.URL
-	Params    map[string]string
-	RawParams map[string]string
-	Cookies   *Cookies
-	Request   *http.Request
-	Writer    http.ResponseWriter
+	Locals map[string]any
+	URL    *url.URL
+	// OriginalURL is the request URL before any Reroute hook rewrote it.
+	// Nil when no Reroute was applied (i.e. the request was served at its
+	// original path). Use this to recover the inbound URL in error
+	// boundaries and layouts rendered after a reroute.
+	OriginalURL *url.URL
+	Params      map[string]string
+	RawParams   map[string]string
+	Cookies     *Cookies
+	Request     *http.Request
+	Writer      http.ResponseWriter
 }
 
 // RawParam returns the un-decoded route parameter value for name exactly

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -204,11 +204,13 @@ func (s *Server) renderErrorBoundary(w http.ResponseWriter, r *http.Request, ev 
 	var rctx *kit.RenderCtx
 	if ev != nil {
 		rctx = &kit.RenderCtx{
-			Locals:  ev.Locals,
-			URL:     ev.URL,
-			Params:  ev.Params,
-			Cookies: ev.Cookies,
-			Request: r,
+			Locals:      ev.Locals,
+			URL:         ev.URL,
+			OriginalURL: ev.OriginalURL,
+			Params:      ev.Params,
+			RawParams:   ev.RawParams,
+			Cookies:     ev.Cookies,
+			Request:     r,
 		}
 	} else {
 		rctx = &kit.RenderCtx{Request: r}

--- a/packages/sveltego/server/errors_integration_test.go
+++ b/packages/sveltego/server/errors_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -401,5 +402,186 @@ func TestErrorPreservesHeaders_HandleError(t *testing.T) {
 	}
 	if got := resp.Header.Get("X-Error-ID"); got != "err-42" {
 		t.Errorf("X-Error-ID = %q, want %q", got, "err-42")
+	}
+}
+
+// slugSegments returns the segment list for a /item/[slug] pattern.
+func slugSegments() []router.Segment {
+	return []router.Segment{
+		{Kind: router.SegmentStatic, Value: "item"},
+		{Kind: router.SegmentParam, Name: "slug"},
+	}
+}
+
+// TestErrorBoundary_RawParamsPreserved asserts that the error-boundary
+// RenderCtx receives the same RawParams the success path would see.
+// Before this fix the error path left RawParams nil, so ctx.RawParams["slug"]
+// silently returned "". After the fix both paths carry the same value from
+// ev.RawParams (populated by rawParamsFromPath after a successful route match).
+func TestErrorBoundary_RawParamsPreserved(t *testing.T) {
+	t.Parallel()
+
+	// Capture what the success path stores so we can assert the error path
+	// matches it exactly, regardless of whether the value is encoded or not.
+	var successRaw string
+	var errorRaw string
+
+	srvSuccess := newTestServer(t, []router.Route{{
+		Pattern:  "/item/[slug]",
+		Segments: slugSegments(),
+		Page: func(w *render.Writer, ctx *kit.RenderCtx, _ any) error {
+			successRaw = ctx.RawParams["slug"]
+			w.WriteString("ok")
+			return nil
+		},
+	}})
+	srvSuccess.hooks = kit.DefaultHooks()
+	tsSuccess := httptest.NewServer(srvSuccess)
+	t.Cleanup(tsSuccess.Close)
+	respS, err := http.Get(tsSuccess.URL + "/item/hello%20world")
+	if err != nil {
+		t.Fatalf("GET success: %v", err)
+	}
+	io.ReadAll(respS.Body) //nolint:errcheck
+	respS.Body.Close()
+
+	boundary := func(w *render.Writer, ctx *kit.RenderCtx, _ kit.SafeError) error {
+		errorRaw = ctx.RawParams["slug"]
+		w.WriteString("error")
+		return nil
+	}
+
+	srvError := newTestServer(t, []router.Route{{
+		Pattern:  "/item/[slug]",
+		Segments: slugSegments(),
+		Page:     staticPage("item"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, errors.New("load failed")
+		},
+		Error: boundary,
+	}})
+	hooks := kit.Hooks{
+		HandleError: func(_ *kit.RequestEvent, err error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusInternalServerError, Message: err.Error()}, nil
+		},
+	}
+	srvError.hooks = hooks.WithDefaults()
+	tsError := httptest.NewServer(srvError)
+	t.Cleanup(tsError.Close)
+
+	respE, err := http.Get(tsError.URL + "/item/hello%20world")
+	if err != nil {
+		t.Fatalf("GET error: %v", err)
+	}
+	t.Cleanup(func() { respE.Body.Close() })
+	io.ReadAll(respE.Body) //nolint:errcheck
+
+	if respE.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", respE.StatusCode)
+	}
+	// The core invariant: error path RawParams must match success path RawParams.
+	// Before this fix errorRaw was "" (nil map); now it equals successRaw.
+	if errorRaw != successRaw {
+		t.Errorf("error-path RawParams[slug] = %q, success-path = %q; they must match", errorRaw, successRaw)
+	}
+	if errorRaw == "" {
+		t.Error("RawParams[slug] is empty on error path, want a non-empty param value")
+	}
+}
+
+// TestRenderCtx_OriginalURL_SuccessPath asserts that OriginalURL is wired
+// into the success-path RenderCtx and equals the inbound URL when no
+// Reroute hook fires.
+func TestRenderCtx_OriginalURL_SuccessPath(t *testing.T) {
+	t.Parallel()
+
+	var gotOriginal *url.URL
+	page := func(w *render.Writer, ctx *kit.RenderCtx, _ any) error {
+		gotOriginal = ctx.OriginalURL
+		w.WriteString("ok")
+		return nil
+	}
+
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/about",
+		Segments: segmentsFor("/about"),
+		Page:     page,
+	}})
+	srv.hooks = kit.DefaultHooks()
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/about")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	io.ReadAll(resp.Body) //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if gotOriginal == nil || gotOriginal.Path != "/about" {
+		t.Errorf("OriginalURL = %v, want path /about", gotOriginal)
+	}
+}
+
+// TestErrorBoundary_OriginalURL_PreservedThroughReroute asserts that
+// OriginalURL in an error-boundary RenderCtx reflects the inbound URL
+// before Reroute rewrote the match path, so +error.svelte templates can
+// always recover the URL the browser actually sent.
+func TestErrorBoundary_OriginalURL_PreservedThroughReroute(t *testing.T) {
+	t.Parallel()
+
+	var gotOriginal *url.URL
+	var gotURL *url.URL
+	boundary := func(w *render.Writer, ctx *kit.RenderCtx, _ kit.SafeError) error {
+		gotOriginal = ctx.OriginalURL
+		gotURL = ctx.URL
+		w.WriteString("error")
+		return nil
+	}
+
+	hooks := kit.Hooks{
+		Reroute: func(u *url.URL) string {
+			if strings.HasPrefix(u.Path, "/legacy/") {
+				return strings.Replace(u.Path, "/legacy/", "/", 1)
+			}
+			return ""
+		},
+		HandleError: func(_ *kit.RequestEvent, err error) (kit.SafeError, error) {
+			return kit.SafeError{Code: http.StatusInternalServerError, Message: err.Error()}, nil
+		},
+	}
+
+	srv := newHookServer(t, hooks, []router.Route{{
+		Pattern:  "/about",
+		Segments: segmentsFor("/about"),
+		Page:     staticPage("about"),
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return nil, errors.New("load failed")
+		},
+		Error: boundary,
+	}})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/legacy/about")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	io.ReadAll(resp.Body) //nolint:errcheck
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+	if gotOriginal == nil || gotOriginal.Path != "/legacy/about" {
+		t.Errorf("OriginalURL = %v, want path /legacy/about", gotOriginal)
+	}
+	if gotURL == nil || gotURL.Path != "/legacy/about" {
+		t.Errorf("URL = %v, want path /legacy/about (ev.URL is the inbound URL)", gotURL)
 	}
 }

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -395,12 +395,13 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 	}
 
 	rctx := &kit.RenderCtx{
-		Locals:    ev.Locals,
-		URL:       ev.URL,
-		Params:    ev.Params,
-		RawParams: ev.RawParams,
-		Cookies:   ev.Cookies,
-		Request:   r,
+		Locals:      ev.Locals,
+		URL:         ev.URL,
+		OriginalURL: ev.OriginalURL,
+		Params:      ev.Params,
+		RawParams:   ev.RawParams,
+		Cookies:     ev.Cookies,
+		Request:     r,
 	}
 	inner := func(buf *render.Writer) error {
 		return route.Page(buf, rctx, data)


### PR DESCRIPTION
## Summary

- Adds `OriginalURL *url.URL` field to `kit.RenderCtx` so error boundaries and layouts can recover the inbound URL after a Reroute rewrite.
- Wires `ev.RawParams` and `ev.OriginalURL` into the error-boundary `RenderCtx` construction (`errors.go`) — previously `RawParams` was nil and `OriginalURL` didn't exist.
- Wires `ev.OriginalURL` into the success-path `RenderCtx` construction (`pipeline.go`) for parity.
- Three regression tests: error-path RawParams parity, success-path OriginalURL presence, and OriginalURL preservation through a Reroute hook on the error path.

Closes #314. References master review PR #325.

## Test plan

- [ ] `go test -race ./packages/sveltego/server/...` — 189 tests pass (3 new)
- [ ] `go test -race ./packages/sveltego/...` — 1115 tests pass across 15 packages
- [ ] `gofumpt -l` + `goimports -l` + `go vet ./...` — all clean
- [ ] `golangci-lint run` — no new issues (5 pre-existing sloglint in unrelated files)