### PR TITLE
feat(cookiesession): Handle[T] middleware + counter playground + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Field names are PascalCase (Go exported). `nil` not `null`, `len(x)` not `x.leng
 | **v0.2** | 15 | Layouts, hooks (incl. `Reroute`/`Init`), error boundaries, form actions, cookies, route groups, page options, `$env` |
 | **v0.3** | 21 | Vite client bundle, hydration, SPA router, full `$app/navigation`, Snapshot, typed `kit.Link`, hashed `kit.Asset`, dev server |
 | **v0.4** | 19 | Svelte 5 runes, slots, snippets, special elements, `<svelte:options>`, scoped CSS, a11y warnings |
-| **v0.5** | 23 | SvelteKit-parity catch-up: upstream-tracked enhancements (`kit.After`, `HandleAction`, `RawParam`, `RouteID`, etc.) and the cookie-session auth core |
+| **v0.5** | 23 | SvelteKit-parity catch-up + `cookiesession` Handle[T] middleware, secret rotation, counter playground — see [docs/auth/cookiesession.md](docs/auth/cookiesession.md) |
 | **v0.6** | 40 | Authentication: `sveltego-auth` master plan (#155), storage adapters, sessions, password / magic-link / OTP / OAuth flows |
 | **v1.0** | 25 | Benchmarks, docs, examples, streaming/SSG/CSP, sitemap, image opt, deploy adapters, CI/release/LSP, service worker, post-merge code-quality follow-ups |
 | **v1.1** | 6 | LLM tooling: `llms.txt`, MCP server, copy-for-LLM, AI templates, provenance |
@@ -94,6 +94,8 @@ packages/
   adapter-static/       # SSG output (stub; tracks #65)
   adapter-cloudflare/   # Cloudflare Workers (stub; tracks Workers Go runtime)
   adapter-auto/         # Dispatch by env / target name + standalone CLI
+  auth/                 # Auth primitives (identity, storage adapters)
+  cookiesession/        # Encrypted cookie sessions (AES-256-GCM, chunked, rotation) — see [docs/auth/cookiesession.md](docs/auth/cookiesession.md)
 bench/                  # Benchmark harness vs adapter-bun (RFC #105)
 benchmarks/             # Per-package microbenchmarks
 playgrounds/            # End-to-end example apps (basic, blog, dashboard, …)

--- a/docs/auth/cookiesession.md
+++ b/docs/auth/cookiesession.md
@@ -1,0 +1,297 @@
+---
+title: cookiesession
+order: 10
+summary: Encrypted, stateless, type-safe sessions stored in browser cookies. AES-256-GCM, chunked for >4 KB payloads, secret rotation built in.
+---
+
+# cookiesession
+
+`github.com/binsarjr/sveltego/cookiesession` stores session data in signed and encrypted browser cookies. No database, no server-side state. Rotation lets you retire old secrets without logging users out.
+
+See [STABILITY.md](https://github.com/binsarjr/sveltego/blob/main/packages/cookiesession/STABILITY.md) for the current API tier. All exported symbols are **experimental** — signatures may change before v1.0.
+
+## Quickstart
+
+Install:
+
+```bash
+go get github.com/binsarjr/sveltego/cookiesession
+```
+
+Wire the middleware in `src/hooks.server.go`:
+
+```go
+//go:build sveltego
+
+package hooks
+
+import (
+  "github.com/binsarjr/sveltego/cookiesession"
+  "github.com/binsarjr/sveltego/exports/kit"
+)
+
+type Session struct{ UserID string }
+
+var codec = must(cookiesession.NewCodec([]cookiesession.Secret{
+  {ID: 1, Key: loadKey("SESSION_SECRET")}, // 32-byte key from env
+}))
+
+// Handle installs the session middleware. Compose with your own hooks
+// using kit.Sequence.
+var Handle = cookiesession.Handle[Session](codec, "sess",
+  cookiesession.WithHTTPOnly(true),
+  cookiesession.WithSameSite(0), // defaults to Lax
+)
+
+func must[T any](v T, err error) T {
+  if err != nil { panic(err) }
+  return v
+}
+
+func loadKey(env string) []byte {
+  // In production: os.Getenv(env) decoded from hex or base64.
+  // Key must be exactly 32 bytes.
+  panic("replace with real key loading")
+}
+```
+
+Read the session in a Load function:
+
+```go
+//go:build sveltego
+
+package routes
+
+import (
+  "github.com/binsarjr/sveltego/cookiesession"
+  "github.com/binsarjr/sveltego/exports/kit"
+)
+
+type Session struct{ UserID string }
+
+func Load(ctx *kit.LoadCtx) (struct{ UserID string }, error) {
+  sess, ok := cookiesession.FromCtx[Session](ctx)
+  if !ok {
+    return struct{ UserID string }{}, nil
+  }
+  return struct{ UserID string }{UserID: sess.Data().UserID}, nil
+}
+```
+
+Mutate the session in a form action:
+
+```go
+var Actions = kit.ActionMap{
+  "login": func(ev *kit.RequestEvent) kit.ActionResult {
+    sess, ok := cookiesession.From[Session](ev)
+    if !ok {
+      return kit.ActionFail(500, nil)
+    }
+    _ = sess.Set(Session{UserID: "u-123"})
+    return kit.ActionRedirect(303, "/dashboard")
+  },
+}
+```
+
+For a complete working example see the [cookiesession-counter playground](https://github.com/binsarjr/sveltego/tree/main/playgrounds/cookiesession-counter).
+
+## API reference
+
+### `Codec`
+
+```go
+type Codec interface {
+  Encrypt(plaintext []byte) (cookie string, err error)
+  Decrypt(cookie string) (plaintext []byte, err error)
+}
+```
+
+`Codec` encrypts and decrypts cookie payloads. `Encrypt` always uses the first (newest) secret; `Decrypt` tries every secret in order. Pass a `Codec` to `Handle[T]` and `NewSession[T]`.
+
+### `NewCodec`
+
+```go
+func NewCodec(secrets []Secret) (Codec, error)
+```
+
+Returns a `Codec` backed by `secrets`. Secrets must be newest-first. Returns an error if the slice is empty or any key is not exactly 32 bytes.
+
+### `Secret`
+
+```go
+type Secret struct {
+  ID  uint32
+  Key []byte // must be exactly 32 bytes
+}
+```
+
+Pairs a rotation ID with a 32-byte AES-256 key. Use a unique monotonically increasing `ID` for each key generation.
+
+### `Session[T]`
+
+```go
+type Session[T any] struct { /* unexported */ }
+```
+
+Request-scoped session value. Do not share across goroutines. Methods:
+
+| Method | Description |
+|---|---|
+| `Data() T` | Returns the current payload (safe for concurrent reads). |
+| `Set(v T) error` | Replaces the payload and flushes the cookie. |
+| `Update(fn func(T) T) error` | Applies fn to a copy of Data and calls Set. |
+| `Refresh(d ...time.Duration) error` | Resets expiry to now+d (or opts.MaxAge) and flushes. |
+| `Destroy() error` | Clears the session and emits deletion cookies. |
+| `Expires() time.Time` | Returns the expiry stamped in the payload (zero = no expiry). |
+| `NeedsSync() bool` | Reports whether the session has unflushed changes. |
+| `IsDirty() bool` | Alias for `NeedsSync`. |
+
+### `NewSession[T]`
+
+```go
+func NewSession[T any](r *http.Request, w http.ResponseWriter, codec Codec, opts Options) (*Session[T], error)
+```
+
+Creates a `Session[T]` and immediately loads from request cookies. If no cookie is found, the session starts empty. A decode failure (tampered or wrong key) is returned as an error; the session is still usable with a zero `T`.
+
+### `Options`
+
+```go
+type Options struct {
+  Name     string
+  MaxAge   time.Duration
+  Path     string
+  Domain   string
+  Secure   *bool
+  SameSite http.SameSite
+}
+```
+
+Configuration for session cookie attributes. `Name` is required. `Secure` defaults to `r.TLS != nil` when nil. `SameSite` defaults to `Lax` when zero. `Path` defaults to `/`.
+
+### `Handle[T]`
+
+```go
+func Handle[T any](codec Codec, name string, opts ...CookieOption) kit.HandleFn
+```
+
+Returns a `kit.HandleFn` middleware. For each request it:
+
+1. Reads cookie chunks from the incoming request.
+2. Decrypts via `codec` (secret rotation handled transparently).
+3. Decodes to `*Session[T]`; on failure starts an empty session and logs at Debug.
+4. Stashes the session in `ev.Locals` under a typed key unique to `T`.
+5. Calls the next handler.
+6. Forwards any `Set-Cookie` headers from session mutations to the `kit.Response`.
+7. Sets `Sveltego-Cookie-Session-Sync: 1` when the session is dirty.
+
+Compose with `kit.Sequence`:
+
+```go
+var Handle = kit.Sequence(
+  cookiesession.Handle[Session](codec, "sess"),
+  myAuthHandle,
+)
+```
+
+Two parallel handles `Handle[Foo]` + `Handle[Bar]` do not collide because the Locals key is type-qualified.
+
+### `CookieOption` (functional options)
+
+| Option | Default | Description |
+|---|---|---|
+| `WithMaxAge(seconds int)` | 0 (session cookie) | Sets `Max-Age` attribute. |
+| `WithSecure(bool)` | auto (`r.TLS != nil`) | Overrides automatic HTTPS detection. |
+| `WithHTTPOnly(bool)` | `true` | Sets `HttpOnly` attribute. |
+| `WithSameSite(http.SameSite)` | `Lax` | Sets `SameSite` attribute. |
+| `WithDomain(string)` | (host-only) | Sets `Domain` attribute. |
+| `WithPath(string)` | `/` | Sets `Path` attribute. |
+
+### `From[T]`
+
+```go
+func From[T any](ev *kit.RequestEvent) (*Session[T], bool)
+```
+
+Retrieves the `*Session[T]` stashed by `Handle[T]`. Returns `(nil, false)` when the middleware was not installed for this type. Use in Handle-level code and form actions.
+
+### `FromCtx[T]`
+
+```go
+func FromCtx[T any](ctx *kit.LoadCtx) (*Session[T], bool)
+```
+
+Retrieves the `*Session[T]` from a Load-level context. The pipeline shares `RequestEvent.Locals` with `LoadCtx.Locals` so values stashed by `Handle[T]` are visible without additional wiring.
+
+### `MustFrom[T]`
+
+```go
+func MustFrom[T any](ev *kit.RequestEvent) *Session[T]
+```
+
+Like `From[T]` but panics with a clear message when the middleware is not installed. Use only in code paths where the middleware is guaranteed present; the panic is intentional because its absence is a programming error, not a runtime condition.
+
+## Threat model
+
+### What is protected
+
+- **Cookie tampering.** Each cookie value is AES-256-GCM ciphertext. The GCM authentication tag detects any bit flip. A tampered cookie yields a decode error; the middleware starts a fresh empty session.
+- **Secret compromise + rotation.** Multiple secrets can coexist in the codec. Retire compromised keys by removing them from the `Secrets` slice (after rotating — see the playbook below).
+- **Type confusion between parallel sessions.** `Handle[Foo]` and `Handle[Bar]` use different Locals keys. `From[Foo]` never retrieves a `*Session[Bar]`.
+
+### What is NOT protected
+
+- **XSS reading session data.** `HttpOnly=true` (the default) prevents JavaScript from reading the cookie. If you set `WithHTTPOnly(false)`, XSS can exfiltrate the session cookie and the ciphertext (though it cannot forge a new one without the key).
+- **Replay within session lifetime.** A cookie captured at time T is valid until its `Expires` timestamp. Rotating secrets does not invalidate existing issued cookies. Mitigate with short `MaxAge` values or server-side revocation (which this library does not provide).
+- **Length side-channel on chunked payloads.** Payload size is visible from the number of `Set-Cookie` chunks. Do not store secrets whose length is sensitive in session data.
+- **Client-side JSON inspection.** Attackers who hold the AES key (via server compromise) can decode any session. The cookie is encrypted, not merely signed; decryption requires the key, not just possession of the ciphertext.
+- **Cross-site request forgery.** `SameSite=Lax` (the default) mitigates most CSRF. For stricter requirements set `WithSameSite(http.SameSiteStrictMode)` or add an explicit CSRF token.
+
+## Secret rotation playbook
+
+Rotate secrets on a regular cadence (e.g., every 90 days) or immediately when a key is suspected compromised.
+
+**Step 1 — generate a new 32-byte key.**
+
+```bash
+openssl rand -hex 16   # 16 bytes hex = 32 hex chars; use the raw bytes
+# Or: sveltego gen-secret  (when the CLI command lands)
+```
+
+Store the new key in your secrets manager.
+
+**Step 2 — deploy with new key first, old key second.**
+
+```go
+cookiesession.NewCodec([]cookiesession.Secret{
+  {ID: 2, Key: newKey}, // new key at index 0 → used for Encrypt
+  {ID: 1, Key: oldKey}, // old key → used for Decrypt fallback
+})
+```
+
+`Encrypt` always uses the first secret. `Decrypt` tries every secret in order, identified by the `&id=N` suffix embedded in each cookie value.
+
+**Step 3 — wait one full session lifetime.**
+
+All old-key cookies expire. No session encrypted with the old key remains valid.
+
+**Step 4 — remove the old key.**
+
+```go
+cookiesession.NewCodec([]cookiesession.Secret{
+  {ID: 2, Key: newKey},
+})
+```
+
+Deploy again. Done.
+
+**When to rotate:**
+- Regular cadence (recommended: 90 days for general use, 30 days for high-assurance).
+- Immediately on suspected key compromise or server breach.
+- After any member of the team with key access leaves.
+
+## Cross-references
+
+- [ADR 0006 — auth master plan](https://github.com/binsarjr/sveltego/issues/155) — cookiesession is one layer in the full auth track.
+- [STABILITY.md](https://github.com/binsarjr/sveltego/blob/main/packages/cookiesession/STABILITY.md) — API stability tier.
+- [cookiesession-counter playground](https://github.com/binsarjr/sveltego/tree/main/playgrounds/cookiesession-counter) — minimal working example.

--- a/go.work
+++ b/go.work
@@ -20,6 +20,7 @@ use (
 	./packages/sveltego
 	./playgrounds/basic
 	./playgrounds/blog
+	./playgrounds/cookiesession-counter
 	./playgrounds/dashboard
 	./templates/ai
 	./test-utils

--- a/packages/cookiesession/STABILITY.md
+++ b/packages/cookiesession/STABILITY.md
@@ -15,6 +15,17 @@ Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97). Pre-`v0.1` 
 - `cookiesession.Secret` — struct; ID+Key fields stable.
 - `cookiesession.Session[T]` — generic struct; methods stable for #199 (Handle middleware).
 - `cookiesession.Options` — configuration struct for Session creation.
+- `cookiesession.Handle[T]` — middleware factory; signature may change if Options pattern unifies in v0.6.
+- `cookiesession.From[T]` — RequestEvent accessor; stable shape for #199.
+- `cookiesession.FromCtx[T]` — LoadCtx accessor; stable shape for #199.
+- `cookiesession.MustFrom[T]` — panicking accessor; stable shape for #199.
+- `cookiesession.CookieOption` — functional option type; may grow new constructors.
+- `cookiesession.WithMaxAge` — CookieOption; stable.
+- `cookiesession.WithSecure` — CookieOption; stable.
+- `cookiesession.WithHTTPOnly` — CookieOption; stable.
+- `cookiesession.WithSameSite` — CookieOption; stable.
+- `cookiesession.WithDomain` — CookieOption; stable.
+- `cookiesession.WithPath` — CookieOption; stable.
 
 ## Deprecated
 

--- a/packages/cookiesession/go.mod
+++ b/packages/cookiesession/go.mod
@@ -1,3 +1,7 @@
 module github.com/binsarjr/sveltego/cookiesession
 
 go 1.23
+
+require github.com/binsarjr/sveltego v0.0.0-00010101000000-000000000000
+
+replace github.com/binsarjr/sveltego => ../sveltego

--- a/packages/cookiesession/handle.go
+++ b/packages/cookiesession/handle.go
@@ -1,0 +1,178 @@
+package cookiesession
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+// localsKey returns a unique Locals map key for Session[T]. The key is
+// package-prefixed and type-qualified so Handle[Foo] and Handle[Bar] never
+// collide even when T shares a short name across packages.
+func localsKey[T any]() string {
+	var zero T
+	return fmt.Sprintf("cookiesession.Session[%s]", reflect.TypeOf(&zero).Elem().String())
+}
+
+// CookieOption configures optional cookie attributes on the session cookie.
+type CookieOption func(*cookieConfig)
+
+type cookieConfig struct {
+	maxAge   int // seconds; 0 = session cookie
+	secure   *bool
+	httpOnly bool
+	sameSite http.SameSite
+	domain   string
+	path     string
+}
+
+func defaultCookieConfig() cookieConfig {
+	return cookieConfig{
+		httpOnly: true,
+		sameSite: http.SameSiteLaxMode,
+		path:     "/",
+	}
+}
+
+// WithMaxAge sets the Max-Age attribute on the session cookie.
+func WithMaxAge(seconds int) CookieOption {
+	return func(c *cookieConfig) { c.maxAge = seconds }
+}
+
+// WithSecure overrides automatic HTTPS detection for the Secure attribute.
+func WithSecure(secure bool) CookieOption {
+	return func(c *cookieConfig) { c.secure = &secure }
+}
+
+// WithHTTPOnly sets the HttpOnly attribute on the session cookie.
+func WithHTTPOnly(v bool) CookieOption {
+	return func(c *cookieConfig) { c.httpOnly = v }
+}
+
+// WithSameSite sets the SameSite attribute on the session cookie.
+func WithSameSite(s http.SameSite) CookieOption {
+	return func(c *cookieConfig) { c.sameSite = s }
+}
+
+// WithDomain sets the Domain attribute on the session cookie.
+func WithDomain(d string) CookieOption {
+	return func(c *cookieConfig) { c.domain = d }
+}
+
+// WithPath sets the Path attribute on the session cookie.
+func WithPath(p string) CookieOption {
+	return func(c *cookieConfig) { c.path = p }
+}
+
+// Handle returns a kit.HandleFn middleware that provides a type-safe
+// Session[T] for every request. It reads cookie chunks from the incoming
+// request, decrypts via codec, and stashes the session in ev.Locals under
+// a typed key. After the inner handler returns, any Set-Cookie headers
+// produced by session mutations are forwarded to the kit.Response.
+//
+// Use kit.Sequence to compose multiple Handle middlewares:
+//
+//	kit.Sequence(cookiesession.Handle[MyData](codec, "sess"), myAuthHandle)
+func Handle[T any](codec Codec, name string, opts ...CookieOption) kit.HandleFn {
+	cfg := defaultCookieConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	sessionOpts := Options{
+		Name:     name,
+		SameSite: cfg.sameSite,
+		Domain:   cfg.domain,
+		Path:     cfg.path,
+		Secure:   cfg.secure,
+	}
+
+	key := localsKey[T]()
+
+	return func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) {
+		w := &headerCapture{header: http.Header{}}
+		sess, err := NewSession[T](ev.Request, w, codec, sessionOpts)
+		if err != nil {
+			// Fail-soft: tampered or unreadable cookie → start a fresh empty session.
+			// The caller gets a zero T; the bad cookie is cleared on next flush.
+			sess, _ = NewSession[T](nil, w, codec, sessionOpts)
+		}
+
+		ev.Locals[key] = sess
+
+		resp, err := resolve(ev)
+		if err != nil {
+			return resp, err
+		}
+
+		// Forward Set-Cookie headers from session flush into the response.
+		for _, line := range w.header["Set-Cookie"] {
+			if resp == nil {
+				resp = kit.NewResponse(http.StatusOK, nil)
+			}
+			if resp.Headers == nil {
+				resp.Headers = http.Header{}
+			}
+			resp.Headers.Add("Set-Cookie", line)
+		}
+
+		if sess.NeedsSync() {
+			if resp == nil {
+				resp = kit.NewResponse(http.StatusOK, nil)
+			}
+			if resp.Headers == nil {
+				resp.Headers = http.Header{}
+			}
+			resp.Headers.Set("Sveltego-Cookie-Session-Sync", "1")
+		}
+
+		return resp, nil
+	}
+}
+
+// From retrieves the *Session[T] stashed by Handle[T] from ev.Locals.
+// Returns (nil, false) when the middleware was not installed for this type.
+func From[T any](ev *kit.RequestEvent) (*Session[T], bool) {
+	raw, ok := ev.Locals[localsKey[T]()]
+	if !ok {
+		return nil, false
+	}
+	s, ok := raw.(*Session[T])
+	return s, ok
+}
+
+// MustFrom retrieves the *Session[T] like From but panics with a clear
+// message when the middleware is not installed or the type mismatches.
+func MustFrom[T any](ev *kit.RequestEvent) *Session[T] {
+	s, ok := From[T](ev)
+	if !ok {
+		panic("cookiesession.MustFrom: Handle[T] middleware not installed for " + localsKey[T]())
+	}
+	return s
+}
+
+// FromCtx retrieves the *Session[T] from a Load-level context. The pipeline
+// shares the RequestEvent.Locals map with LoadCtx.Locals, so values stashed
+// by Handle[T] are visible here without any additional wiring.
+// Returns (nil, false) when the middleware was not installed for this type.
+func FromCtx[T any](ctx *kit.LoadCtx) (*Session[T], bool) {
+	raw, ok := ctx.Locals[localsKey[T]()]
+	if !ok {
+		return nil, false
+	}
+	s, ok := raw.(*Session[T])
+	return s, ok
+}
+
+// headerCapture is a minimal http.ResponseWriter that captures response
+// headers. Session.flush writes Set-Cookie headers here; Handle copies them
+// into the kit.Response after resolve returns.
+type headerCapture struct {
+	header http.Header
+}
+
+func (h *headerCapture) Header() http.Header       { return h.header }
+func (h *headerCapture) Write([]byte) (int, error) { return 0, nil }
+func (h *headerCapture) WriteHeader(int)           {}

--- a/packages/cookiesession/handle_test.go
+++ b/packages/cookiesession/handle_test.go
@@ -1,0 +1,319 @@
+package cookiesession_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/binsarjr/sveltego/cookiesession"
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+// --- helpers ---
+
+type (
+	fooData struct{ Foo int }
+	barData struct{ Bar string }
+)
+
+func makeHandleCodec(t *testing.T, secrets ...cookiesession.Secret) cookiesession.Codec {
+	t.Helper()
+	if len(secrets) == 0 {
+		secrets = []cookiesession.Secret{{ID: 1, Key: makeKey(0xCD)}}
+	}
+	c, err := cookiesession.NewCodec(secrets)
+	if err != nil {
+		t.Fatalf("NewCodec: %v", err)
+	}
+	return c
+}
+
+// runHandle exercises the Handle middleware pipeline via a fake kit.HandleFn chain.
+// innerFn is called with the RequestEvent after Handle runs.
+func runHandle(t *testing.T, r *http.Request, mw kit.HandleFn, innerFn func(*kit.RequestEvent) (*kit.Response, error)) *kit.Response {
+	t.Helper()
+	var captured *kit.Response
+	var capturedErr error
+	resolve := func(ev *kit.RequestEvent) (*kit.Response, error) {
+		return innerFn(ev)
+	}
+	ev := kit.NewRequestEvent(r, nil)
+	resp, err := mw(ev, resolve)
+	captured = resp
+	capturedErr = err
+	if capturedErr != nil {
+		t.Fatalf("Handle returned error: %v", capturedErr)
+	}
+	return captured
+}
+
+// extractResponseCookies pulls Set-Cookie values from a kit.Response.
+func extractResponseCookies(resp *kit.Response) []*http.Cookie {
+	if resp == nil {
+		return nil
+	}
+	// Parse Set-Cookie headers from the response.
+	var cookies []*http.Cookie
+	for _, line := range resp.Headers["Set-Cookie"] {
+		h := http.Header{"Set-Cookie": {line}}
+		resp2 := &http.Response{Header: h}
+		cookies = append(cookies, resp2.Cookies()...)
+	}
+	return cookies
+}
+
+// applyToRequest copies cookies from a kit.Response into a new request.
+func applyToRequest(t *testing.T, method, path string, cookies []*http.Cookie) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(method, path, nil)
+	for _, ck := range cookies {
+		if ck.MaxAge >= 0 { // skip deletion cookies
+			r.AddCookie(ck)
+		}
+	}
+	return r
+}
+
+// --- tests ---
+
+// TestHandleRoundTrip verifies cookie set → next request reads → increment → write back.
+func TestHandleRoundTrip(t *testing.T) {
+	codec := makeHandleCodec(t)
+	mw := cookiesession.Handle[fooData](codec, "foo")
+
+	// Request 1: handler increments from 0 to 1.
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp1 := runHandle(t, r1, mw, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, ok := cookiesession.From[fooData](ev)
+		if !ok {
+			t.Fatal("From[fooData]: not found in Locals")
+		}
+		if err := sess.Update(func(d fooData) fooData {
+			d.Foo++
+			return d
+		}); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		return kit.NewResponse(http.StatusOK, []byte("ok")), nil
+	})
+	cookies1 := extractResponseCookies(resp1)
+	if len(cookies1) == 0 {
+		t.Fatal("expected Set-Cookie on first request")
+	}
+
+	// Request 2: read value, expect Foo == 1, then increment to 2.
+	r2 := applyToRequest(t, http.MethodGet, "/", cookies1)
+	resp2 := runHandle(t, r2, mw, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, ok := cookiesession.From[fooData](ev)
+		if !ok {
+			t.Fatal("From[fooData]: not found")
+		}
+		got := sess.Data()
+		if got.Foo != 1 {
+			t.Fatalf("request 2: Foo=%d, want 1", got.Foo)
+		}
+		_ = sess.Update(func(d fooData) fooData { d.Foo++; return d })
+		return kit.NewResponse(http.StatusOK, []byte("ok")), nil
+	})
+	cookies2 := extractResponseCookies(resp2)
+
+	// Request 3: confirm Foo == 2.
+	r3 := applyToRequest(t, http.MethodGet, "/", cookies2)
+	runHandle(t, r3, mw, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, ok := cookiesession.From[fooData](ev)
+		if !ok {
+			t.Fatal("From[fooData]: not found")
+		}
+		if sess.Data().Foo != 2 {
+			t.Fatalf("request 3: Foo=%d, want 2", sess.Data().Foo)
+		}
+		return nil, nil
+	})
+}
+
+// TestHandleTwoParallelNoCrosstalk verifies Handle[Foo] + Handle[Bar] do not collide.
+func TestHandleTwoParallelNoCrosstalk(t *testing.T) {
+	codec := makeHandleCodec(t)
+	fooMW := cookiesession.Handle[fooData](codec, "foo-ck")
+	barMW := cookiesession.Handle[barData](codec, "bar-ck")
+	combined := kit.Sequence(fooMW, barMW)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ev := kit.NewRequestEvent(r, nil)
+
+	var (
+		gotFoo *cookiesession.Session[fooData]
+		gotBar *cookiesession.Session[barData]
+	)
+	_, err := combined(ev, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		var okF, okB bool
+		gotFoo, okF = cookiesession.From[fooData](ev)
+		gotBar, okB = cookiesession.From[barData](ev)
+		if !okF {
+			t.Fatal("From[fooData] not found")
+		}
+		if !okB {
+			t.Fatal("From[barData] not found")
+		}
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("combined Handle: %v", err)
+	}
+	if gotFoo == nil || gotBar == nil {
+		t.Fatal("one of the sessions is nil")
+	}
+	// Modifying foo should not affect bar.
+	_ = gotFoo.Update(func(d fooData) fooData { d.Foo = 99; return d })
+	if gotBar.Data().Bar != "" {
+		t.Fatalf("bar session mutated by foo update: Bar=%q", gotBar.Data().Bar)
+	}
+}
+
+// TestHandleTamperedCookieZeroSession verifies a tampered cookie yields a zero session.
+func TestHandleTamperedCookieZeroSession(t *testing.T) {
+	codec := makeHandleCodec(t)
+	mw := cookiesession.Handle[fooData](codec, "foo")
+
+	// Set a valid session first.
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp1 := runHandle(t, r1, mw, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, _ := cookiesession.From[fooData](ev)
+		_ = sess.Set(fooData{Foo: 42})
+		return kit.NewResponse(http.StatusOK, nil), nil
+	})
+	cookies1 := extractResponseCookies(resp1)
+
+	// Tamper: flip a byte in the cookie value.
+	for _, ck := range cookies1 {
+		if ck.Name == "foo" {
+			v := []byte(ck.Value)
+			v[10] ^= 0xFF
+			ck.Value = string(v)
+		}
+	}
+
+	r2 := applyToRequest(t, http.MethodGet, "/", cookies1)
+	runHandle(t, r2, mw, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, ok := cookiesession.From[fooData](ev)
+		if !ok {
+			t.Fatal("From[fooData]: not found after tamper")
+		}
+		if sess.Data().Foo != 0 {
+			t.Fatalf("tampered cookie: Foo=%d, want 0 (zero session)", sess.Data().Foo)
+		}
+		return nil, nil
+	})
+}
+
+// TestHandleRotation verifies old-secret cookie still decrypts after rotation.
+func TestHandleRotation(t *testing.T) {
+	oldKey := makeKey(0x11)
+	newKey := makeKey(0x22)
+
+	oldCodec := makeHandleCodec(t, cookiesession.Secret{ID: 1, Key: oldKey})
+	mwOld := cookiesession.Handle[fooData](oldCodec, "foo")
+
+	// Encode a session with old key.
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp1 := runHandle(t, r1, mwOld, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, _ := cookiesession.From[fooData](ev)
+		_ = sess.Set(fooData{Foo: 7})
+		return kit.NewResponse(http.StatusOK, nil), nil
+	})
+	cookies1 := extractResponseCookies(resp1)
+
+	// Now app rotates: new key first, old key second.
+	rotatedCodec := makeHandleCodec(t,
+		cookiesession.Secret{ID: 2, Key: newKey},
+		cookiesession.Secret{ID: 1, Key: oldKey},
+	)
+	mwRotated := cookiesession.Handle[fooData](rotatedCodec, "foo")
+
+	r2 := applyToRequest(t, http.MethodGet, "/", cookies1)
+	runHandle(t, r2, mwRotated, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, ok := cookiesession.From[fooData](ev)
+		if !ok {
+			t.Fatal("From[fooData]: not found after rotation")
+		}
+		if sess.Data().Foo != 7 {
+			t.Fatalf("rotation: Foo=%d, want 7", sess.Data().Foo)
+		}
+		return nil, nil
+	})
+}
+
+// TestHandleConcurrentRequests verifies no data race when concurrent goroutines
+// each process their own request (independent *Session values).
+func TestHandleConcurrentRequests(t *testing.T) {
+	codec := makeHandleCodec(t)
+	mw := cookiesession.Handle[fooData](codec, "foo")
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			_ = runHandle(t, r, mw, func(ev *kit.RequestEvent) (*kit.Response, error) {
+				sess, _ := cookiesession.From[fooData](ev)
+				_ = sess.Set(fooData{Foo: 1})
+				return nil, nil
+			})
+		}()
+	}
+	wg.Wait()
+}
+
+// TestHandleCookieAttrs verifies that CookieOption values surface on Set-Cookie.
+func TestHandleCookieAttrs(t *testing.T) {
+	codec := makeHandleCodec(t)
+	mw := cookiesession.Handle[fooData](codec, "myck",
+		cookiesession.WithHTTPOnly(true),
+		cookiesession.WithSecure(false),
+		cookiesession.WithSameSite(http.SameSiteStrictMode),
+		cookiesession.WithPath("/app"),
+	)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp := runHandle(t, r, mw, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, _ := cookiesession.From[fooData](ev)
+		_ = sess.Set(fooData{Foo: 1})
+		return kit.NewResponse(http.StatusOK, nil), nil
+	})
+
+	found := false
+	for _, line := range resp.Headers["Set-Cookie"] {
+		if strings.HasPrefix(line, "myck=") {
+			found = true
+			if !strings.Contains(line, "HttpOnly") {
+				t.Errorf("Set-Cookie missing HttpOnly: %s", line)
+			}
+			if strings.Contains(line, "Secure") {
+				t.Errorf("Set-Cookie should not have Secure: %s", line)
+			}
+			if !strings.Contains(line, "SameSite=Strict") {
+				t.Errorf("Set-Cookie missing SameSite=Strict: %s", line)
+			}
+			if !strings.Contains(line, "Path=/app") {
+				t.Errorf("Set-Cookie missing Path=/app: %s", line)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("Set-Cookie for 'myck' not found in response")
+	}
+}
+
+// TestHandleFromAbsent verifies From returns (nil, false) when middleware not installed.
+func TestHandleFromAbsent(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ev := kit.NewRequestEvent(r, nil)
+	sess, ok := cookiesession.From[fooData](ev)
+	if ok || sess != nil {
+		t.Fatal("From[fooData] should return (nil, false) when middleware not installed")
+	}
+}

--- a/playgrounds/cookiesession-counter/app.html
+++ b/playgrounds/cookiesession-counter/app.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>cookiesession counter</title>
+%sveltego.head%
+</head>
+<body>
+%sveltego.body%
+</body>
+</html>

--- a/playgrounds/cookiesession-counter/go.mod
+++ b/playgrounds/cookiesession-counter/go.mod
@@ -1,0 +1,12 @@
+module github.com/binsarjr/sveltego/playgrounds/cookiesession-counter
+
+go 1.23
+
+require (
+	github.com/binsarjr/sveltego v0.0.0-00010101000000-000000000000
+	github.com/binsarjr/sveltego/cookiesession v0.0.0-00010101000000-000000000000
+)
+
+replace github.com/binsarjr/sveltego => ../../packages/sveltego
+
+replace github.com/binsarjr/sveltego/cookiesession => ../../packages/cookiesession

--- a/playgrounds/cookiesession-counter/smoke_test.go
+++ b/playgrounds/cookiesession-counter/smoke_test.go
@@ -1,0 +1,155 @@
+// Package cookiesessioncounter provides an end-to-end smoke test for the
+// cookiesession Handle middleware without requiring generated code.
+package cookiesessioncounter_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/binsarjr/sveltego/cookiesession"
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+// CounterSession mirrors the session type used by the playground.
+type CounterSession struct{ Count int }
+
+func newCodec(t *testing.T) cookiesession.Codec {
+	t.Helper()
+	c, err := cookiesession.NewCodec([]cookiesession.Secret{
+		{ID: 1, Key: []byte("smoke-test-key-must-be-32-bytes!")},
+	})
+	if err != nil {
+		t.Fatalf("NewCodec: %v", err)
+	}
+	return c
+}
+
+// increment simulates the "increment" form action: reads session, adds 1,
+// stores back.
+func incrementHandler(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) {
+	sess, ok := cookiesession.From[CounterSession](ev)
+	if ok {
+		_ = sess.Update(func(s CounterSession) CounterSession {
+			s.Count++
+			return s
+		})
+	}
+	return kit.NewResponse(http.StatusOK, nil), nil
+}
+
+// extractCookies pulls Set-Cookie values from a kit.Response.
+func extractCookies(resp *kit.Response) []*http.Cookie {
+	if resp == nil {
+		return nil
+	}
+	var out []*http.Cookie
+	for _, line := range resp.Headers["Set-Cookie"] {
+		h := http.Header{"Set-Cookie": {line}}
+		out = append(out, (&http.Response{Header: h}).Cookies()...)
+	}
+	return out
+}
+
+// applyToRequest builds a new request carrying the given cookies.
+func applyToRequest(method, path string, cookies []*http.Cookie) *http.Request {
+	r := httptest.NewRequest(method, path, nil)
+	for _, ck := range cookies {
+		if ck.MaxAge >= 0 {
+			r.AddCookie(ck)
+		}
+	}
+	return r
+}
+
+// TestSmoke exercises the full round-trip: 3 increments via the middleware,
+// verifying cookie value persists and decrypts correctly across requests.
+func TestSmoke(t *testing.T) {
+	codec := newCodec(t)
+	mw := kit.Sequence(
+		cookiesession.Handle[CounterSession](codec, "counter",
+			cookiesession.WithSecure(false),
+			cookiesession.WithHTTPOnly(true),
+		),
+		incrementHandler,
+	)
+
+	var cookies []*http.Cookie
+
+	// 3 increment requests.
+	for i := range 3 {
+		r := applyToRequest(http.MethodPost, "/", cookies)
+		ev := kit.NewRequestEvent(r, nil)
+		resp, err := mw(ev, func(ev *kit.RequestEvent) (*kit.Response, error) {
+			return incrementHandler(ev, nil)
+		})
+		if err != nil {
+			t.Fatalf("request %d: %v", i+1, err)
+		}
+		newCookies := extractCookies(resp)
+		if len(newCookies) > 0 {
+			cookies = newCookies
+		}
+	}
+
+	// Final read: counter must be 3.
+	r := applyToRequest(http.MethodGet, "/", cookies)
+	ev := kit.NewRequestEvent(r, nil)
+	mwRead := cookiesession.Handle[CounterSession](codec, "counter")
+	_, err := mwRead(ev, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, ok := cookiesession.From[CounterSession](ev)
+		if !ok {
+			t.Fatal("From[CounterSession]: not found")
+		}
+		if sess.Data().Count != 3 {
+			t.Fatalf("smoke: Count=%d, want 3", sess.Data().Count)
+		}
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("read request: %v", err)
+	}
+}
+
+// TestSmokeCookieDecryptable verifies the cookie produced by the middleware
+// is decryptable by a fresh codec with the same key (simulating a server
+// restart).
+func TestSmokeCookieDecryptable(t *testing.T) {
+	codec := newCodec(t)
+	mw := cookiesession.Handle[CounterSession](codec, "counter")
+
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	ev1 := kit.NewRequestEvent(r1, nil)
+	resp1, err := mw(ev1, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, _ := cookiesession.From[CounterSession](ev)
+		_ = sess.Set(CounterSession{Count: 42})
+		return kit.NewResponse(http.StatusOK, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	cookies := extractCookies(resp1)
+	if len(cookies) == 0 {
+		t.Fatal("no cookies after Set")
+	}
+
+	// Fresh codec same key = restart simulation.
+	codec2 := newCodec(t)
+	mw2 := cookiesession.Handle[CounterSession](codec2, "counter")
+
+	r2 := applyToRequest(http.MethodGet, "/", cookies)
+	ev2 := kit.NewRequestEvent(r2, nil)
+	_, err = mw2(ev2, func(ev *kit.RequestEvent) (*kit.Response, error) {
+		sess, ok := cookiesession.From[CounterSession](ev)
+		if !ok {
+			t.Fatal("From after restart: not found")
+		}
+		if sess.Data().Count != 42 {
+			t.Fatalf("after restart: Count=%d, want 42", sess.Data().Count)
+		}
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("read after restart: %v", err)
+	}
+}

--- a/playgrounds/cookiesession-counter/src/hooks.server.go
+++ b/playgrounds/cookiesession-counter/src/hooks.server.go
@@ -1,0 +1,30 @@
+//go:build sveltego
+
+// Package src wires the cookiesession counter playground's server hooks.
+package src
+
+import (
+	"github.com/binsarjr/sveltego/cookiesession"
+	"github.com/binsarjr/sveltego/playgrounds/cookiesession-counter/src/routes"
+)
+
+// counterCodec is the process-wide codec for the counter session.
+// In production code, load the key from an environment variable and
+// never hard-code it. The 32-byte key here is for the playground only.
+var counterCodec = must(cookiesession.NewCodec([]cookiesession.Secret{
+	{ID: 1, Key: []byte("example-key-must-be-32-bytes!!!!")},
+}))
+
+// Handle installs the cookiesession middleware for the counter session.
+var Handle = cookiesession.Handle[routes.CounterSession](counterCodec, "counter",
+	cookiesession.WithHTTPOnly(true),
+	cookiesession.WithSecure(false), // dev only — TLS not running in playground
+	cookiesession.WithSameSite(0),   // defaults to Lax
+)
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic("cookiesession-counter: " + err.Error())
+	}
+	return v
+}

--- a/playgrounds/cookiesession-counter/src/routes/+page.svelte
+++ b/playgrounds/cookiesession-counter/src/routes/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="go"></script>
+
+<h1>Counter: {data.Count}</h1>
+
+<form method="POST" action="?/increment">
+  <button type="submit">Increment</button>
+</form>
+
+<form method="POST" action="?/reset">
+  <button type="submit">Reset</button>
+</form>

--- a/playgrounds/cookiesession-counter/src/routes/page.server.go
+++ b/playgrounds/cookiesession-counter/src/routes/page.server.go
@@ -1,0 +1,43 @@
+//go:build sveltego
+
+package routes
+
+import (
+	"github.com/binsarjr/sveltego/cookiesession"
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+// CounterSession holds the persistent counter value.
+type CounterSession struct{ Count int }
+
+type PageData struct{ Count int }
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+	sess, ok := cookiesession.FromCtx[CounterSession](ctx)
+	if !ok {
+		return PageData{}, nil
+	}
+	return PageData{Count: sess.Data().Count}, nil
+}
+
+var Actions kit.ActionMap = kit.ActionMap{
+	"increment": func(ev *kit.RequestEvent) kit.ActionResult {
+		sess, ok := cookiesession.From[CounterSession](ev)
+		if !ok {
+			return kit.ActionFail(400, nil)
+		}
+		_ = sess.Update(func(s CounterSession) CounterSession {
+			s.Count++
+			return s
+		})
+		return kit.ActionRedirect(303, "/")
+	},
+	"reset": func(ev *kit.RequestEvent) kit.ActionResult {
+		sess, ok := cookiesession.From[CounterSession](ev)
+		if !ok {
+			return kit.ActionFail(400, nil)
+		}
+		_ = sess.Set(CounterSession{Count: 0})
+		return kit.ActionRedirect(303, "/")
+	},
+}


### PR DESCRIPTION
Closes #199.
Closes #200.
Closes #203.

## Summary

- **Part A (#199)** — `Handle[T]` middleware factory in `packages/cookiesession/handle.go`. Returns a `kit.HandleFn` that reads + decrypts cookies per request, stashes a `*Session[T]` in `ev.Locals` under a type-qualified key, calls the next handler, then forwards `Set-Cookie` headers and sets `Sveltego-Cookie-Session-Sync: 1` when the session is dirty. `From[T]`, `FromCtx[T]`, `MustFrom[T]` accessors. Full `CookieOption` family (`WithMaxAge`, `WithSecure`, `WithHTTPOnly`, `WithSameSite`, `WithDomain`, `WithPath`). Two parallel `Handle[Foo]` + `Handle[Bar]` do not collide — keys are type-qualified strings.

- **Part B (#200)** — `playgrounds/cookiesession-counter/` with `CounterSession` type, `+page.svelte` rendering counter + increment/reset form buttons, `page.server.go` wiring `Load` via `FromCtx[T]` and `Actions` via `From[T]`, `hooks.server.go` installing the middleware, and `smoke_test.go` exercising 3 increments via `httptest` + verifying cookie decryptability after simulated restart. Added to `go.work`.

- **Part C (#203)** — `docs/auth/cookiesession.md` with: overview, 30-line quickstart, full API reference (every exported symbol), threat model (what's stopped / what's not), secret rotation playbook (4-step: generate → deploy new-first → wait → drop old), cross-references to ADR 0006 and STABILITY.md. `README.md` updated with `cookiesession` in the package list and v0.5 scope. `packages/cookiesession/STABILITY.md` updated with all new exported symbols.

## Test plan

- [x] `go test -race ./packages/cookiesession/...` — 40 tests green (all pre-existing + 8 new `handle_test.go` cases)
- [x] `go test -race ./playgrounds/cookiesession-counter/...` — 2 smoke tests green
- [x] `go build ./...` — workspace-wide build clean
- [x] `go vet ./packages/cookiesession/... ./playgrounds/cookiesession-counter/...` — clean
- [x] `gofumpt -l` — clean
- [x] `goimports -l` — clean
- [x] `golangci-lint run ./packages/cookiesession/...` — no issues