### PR TITLE
ci: bump matrix to Go 1.25.x to match go.work directive

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -17,7 +17,7 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
 
@@ -233,13 +233,26 @@ Generated output lives under `.gen/` (gitignored). Every `.gen/*.go` starts with
 
 ## 7. Out of scope (do not propose)
 
+See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) revisits expression semantics — consult it before proposing a JS-runtime or full-Svelte alternative.
+
+Quick reference:
+
 - Svelte 4 legacy reactivity (`$:`, store autoload).
 - Server-side dynamic JS execution.
 - A native Go bundler replacing Vite for the client.
 - Multi-tenant / RBAC primitives in `kit`.
 - Universal (shared client+server) `Load`. Server-only by design.
-
-See issue #94 for the full non-goals RFC once it lands.
+- Universal `+page.ts` / `+layout.ts` loads.
+- `<script context="module">` (deprecated upstream).
+- WebSocket / SSE primitives in core (BYO `gorilla/websocket`).
+- Vercel / Netlify Functions adapters.
+- vitePreprocess / arbitrary preprocessor pipeline in codegen.
+- JSDoc-driven type discovery (Go types only).
+- Deep dynamic-import code splitting beyond per-route.
+- Runtime template interpretation.
+- View Transitions API.
+- Built-in i18n primitives.
+- Built-in form-validation library.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/create-sveltego`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
 
@@ -233,13 +233,26 @@ Generated output lives under `.gen/` (gitignored). Every `.gen/*.go` starts with
 
 ## 7. Out of scope (do not propose)
 
+See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) revisits expression semantics — consult it before proposing a JS-runtime or full-Svelte alternative.
+
+Quick reference:
+
 - Svelte 4 legacy reactivity (`$:`, store autoload).
 - Server-side dynamic JS execution.
 - A native Go bundler replacing Vite for the client.
 - Multi-tenant / RBAC primitives in `kit`.
 - Universal (shared client+server) `Load`. Server-only by design.
-
-See issue #94 for the full non-goals RFC once it lands.
+- Universal `+page.ts` / `+layout.ts` loads.
+- `<script context="module">` (deprecated upstream).
+- WebSocket / SSE primitives in core (BYO `gorilla/websocket`).
+- Vercel / Netlify Functions adapters.
+- vitePreprocess / arbitrary preprocessor pipeline in codegen.
+- JSDoc-driven type discovery (Go types only).
+- Deep dynamic-import code splitting beyond per-route.
+- Runtime template interpretation.
+- View Transitions API.
+- Built-in i18n primitives.
+- Built-in form-validation library.
 
 ---
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Install benchstat and bench-compare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # CI budget split (Phase 0p):
 #
-# - PR runs (lite): 1 OS × 1 Go (ubuntu-latest, 1.23.x) + changes +
+# - PR runs (lite): 1 OS × 1 Go (ubuntu-latest, 1.25.x) + changes +
 #   commit-lint + agents-sync. Roughly 4 jobs per push.
-# - Push to main (full): 3 OS × 2 Go matrix + isolated-modules +
+# - Push to main (full): 3 OS × 1 Go (1.25.x, matching go.work) + isolated-modules +
 #   playground-smoke + agents-sync + changes. Full coverage at merge.
 # - Docs-only diffs (`**.md`, `tasks/**`, `docs/**`) skip CI entirely
 #   via paths-ignore.
@@ -77,7 +77,7 @@ jobs:
               - '.github/workflows/**'
               - 'test-utils/**'
 
-  # Lite matrix on PRs: ubuntu-latest, go1.23.x. ~1 job.
+  # Lite matrix on PRs: ubuntu-latest, go1.25.x. ~1 job.
   lint-and-test-pr:
     name: lint-and-test (${{ matrix.os }}, go${{ matrix.go }})
     if: github.event_name == 'pull_request'
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        go: ['1.23.x']
+        go: ['1.25.x']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -334,14 +334,14 @@ jobs:
           done
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.23.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.25.x'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: coverage
           fail_ci_if_error: false
 
-  # Full matrix on push to main: 3 OS × 2 Go. ~6 jobs.
+  # Full matrix on push to main: 3 OS × 1 Go (1.25.x, matching go.work). ~3 jobs.
   lint-and-test-main:
     name: lint-and-test (${{ matrix.os }}, go${{ matrix.go }})
     if: github.event_name == 'push'
@@ -350,7 +350,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.22.x', '1.23.x']
+        go: ['1.25.x']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -598,7 +598,7 @@ jobs:
           done
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.23.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.25.x'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -618,7 +618,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Cache Go module and build artifacts
@@ -627,9 +627,9 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-1.22.x-isolated-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.25.x-isolated-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.22.x-isolated-
+            ${{ runner.os }}-go-1.25.x-isolated-
 
       - name: Build and test each module in isolation
         shell: bash
@@ -697,7 +697,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Compile + Build

--- a/packages/auth/storage/pgx/pgx.go
+++ b/packages/auth/storage/pgx/pgx.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5"
+	pgxv5 "github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -61,7 +61,7 @@ func (s *Store) UserByID(ctx context.Context, id string) (*auth.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectOneRow(rows, scanUser)
+	return pgxv5.CollectOneRow(rows, scanUser)
 }
 
 // UserByEmail returns the user with the given email. Returns ErrNotFound if absent.
@@ -72,17 +72,17 @@ func (s *Store) UserByEmail(ctx context.Context, email string) (*auth.User, erro
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectOneRow(rows, scanUser)
+	return pgxv5.CollectOneRow(rows, scanUser)
 }
 
-func scanUser(row pgx.CollectableRow) (*auth.User, error) {
+func scanUser(row pgxv5.CollectableRow) (*auth.User, error) {
 	var u auth.User
 	err := row.Scan(
 		&u.ID, &u.Email, &u.EmailVerified, &u.Name, &u.Image,
 		&u.CreatedAt, &u.UpdatedAt,
 	)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, pgxv5.ErrNoRows) {
 			return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
 		}
 		return nil, err
@@ -113,7 +113,7 @@ func (s *Store) UpdateUser(ctx context.Context, u *auth.User) error {
 // DeleteUser removes the user and cascades to sessions, accounts, and
 // verifications inside a single transaction. Returns ErrNotFound if absent.
 func (s *Store) DeleteUser(ctx context.Context, id string) error {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.ReadCommitted})
+	tx, err := s.pool.BeginTx(ctx, pgxv5.TxOptions{IsoLevel: pgxv5.ReadCommitted})
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (s *Store) DeleteUser(ctx context.Context, id string) error {
 
 	var dummy int
 	err = tx.QueryRow(ctx, `SELECT 1 FROM auth_users WHERE id = $1`, id).Scan(&dummy)
-	if errors.Is(err, pgx.ErrNoRows) {
+	if errors.Is(err, pgxv5.ErrNoRows) {
 		_ = tx.Rollback(ctx)
 		return fmt.Errorf("auth: %w", auth.ErrNotFound)
 	}
@@ -174,7 +174,7 @@ func (s *Store) SessionByToken(ctx context.Context, token string) (*auth.Session
 		return nil, err
 	}
 
-	sess, err := pgx.CollectOneRow(rows, func(row pgx.CollectableRow) (*auth.Session, error) {
+	sess, err := pgxv5.CollectOneRow(rows, func(row pgxv5.CollectableRow) (*auth.Session, error) {
 		var s auth.Session
 		if scanErr := row.Scan(
 			&s.ID, &s.UserID, &s.Token,
@@ -182,7 +182,7 @@ func (s *Store) SessionByToken(ctx context.Context, token string) (*auth.Session
 			&s.IPAddress, &s.UserAgent,
 			&s.CreatedAt, &s.UpdatedAt,
 		); scanErr != nil {
-			if errors.Is(scanErr, pgx.ErrNoRows) {
+			if errors.Is(scanErr, pgxv5.ErrNoRows) {
 				return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
 			}
 			return nil, scanErr
@@ -194,7 +194,7 @@ func (s *Store) SessionByToken(ctx context.Context, token string) (*auth.Session
 		return &s, nil
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, pgxv5.ErrNoRows) {
 			return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
 		}
 		return nil, err
@@ -266,7 +266,7 @@ func (s *Store) AccountsByUser(ctx context.Context, userID string) ([]*auth.Acco
 	}
 	defer rows.Close()
 
-	accs, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (*auth.Account, error) {
+	accs, err := pgxv5.CollectRows(rows, func(row pgxv5.CollectableRow) (*auth.Account, error) {
 		var a auth.Account
 		if scanErr := row.Scan(
 			&a.ID, &a.UserID, &a.Provider, &a.ProviderAccountID,
@@ -335,13 +335,13 @@ func (s *Store) VerificationByCode(ctx context.Context, code string) (*auth.Veri
 		return nil, err
 	}
 
-	v, err := pgx.CollectOneRow(rows, func(row pgx.CollectableRow) (*auth.Verification, error) {
+	v, err := pgxv5.CollectOneRow(rows, func(row pgxv5.CollectableRow) (*auth.Verification, error) {
 		var ver auth.Verification
 		if scanErr := row.Scan(
 			&ver.ID, &ver.UserID, &ver.Kind, &ver.Token,
 			&ver.ExpiresAt, &ver.CreatedAt,
 		); scanErr != nil {
-			if errors.Is(scanErr, pgx.ErrNoRows) {
+			if errors.Is(scanErr, pgxv5.ErrNoRows) {
 				return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
 			}
 			return nil, scanErr
@@ -351,7 +351,7 @@ func (s *Store) VerificationByCode(ctx context.Context, code string) (*auth.Veri
 		return &ver, nil
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, pgxv5.ErrNoRows) {
 			return nil, fmt.Errorf("auth: %w", auth.ErrNotFound)
 		}
 		return nil, err


### PR DESCRIPTION
Fixes broken CI on main from 87586fa + 82f7674.

Root cause: `go.work` directive is `go 1.25` but the CI matrix was pinned to `go: ['1.22.x', '1.23.x']`. Go toolchain rejects workspace files that require a newer version than the running toolchain, causing all `lint-and-test-main` (6 jobs), `isolated-modules`, and the `lint-and-test-pr` jobs to fail immediately.

**Option A chosen**: Bump CI matrix to 1.25.x — simplest fix with no dep changes.

Changes:
- `lint-and-test-pr`: `1.23.x` → `1.25.x`
- `lint-and-test-main`: `['1.22.x', '1.23.x']` → `['1.25.x']` (3 OS × 1 Go instead of 3 OS × 2 Go)
- `isolated-modules`: `1.22.x` → `1.25.x`
- `playground-smoke`: `1.23.x` → `1.25.x`
- `bench.yml`: `1.23.x` → `1.25.x`
- Updated header comments and codecov condition to match

## Test plan
- [ ] `lint-and-test (ubuntu-latest, go1.25.x)` on PR — green
- [ ] All push-to-main jobs green on merge: `lint-and-test` (3 OS), `isolated-modules`, `playground-smoke`
- [ ] `bench` workflow green on next push-to-main