### PR TITLE
chore(render): v0.1 polish bundle (closes #319)

### DIFF
--- a/packages/sveltego/render/render.go
+++ b/packages/sveltego/render/render.go
@@ -136,8 +136,10 @@ func (w *Writer) WriteEscape(v any) {
 }
 
 // WriteEscapeAttr appends v escaped for an attribute value. Codegen wraps
-// attribute values in double quotes outside this call. error precedes
-// fmt.Stringer; see WriteEscape.
+// attribute values in double quotes outside this call. Numeric and bool values
+// bypass fmt. nil emits an empty string. A value that implements both error
+// and fmt.Stringer is rendered via Error(); types that need Stringer
+// precedence should not also satisfy error.
 func (w *Writer) WriteEscapeAttr(v any) {
 	switch x := v.(type) {
 	case nil:
@@ -211,7 +213,20 @@ func (w *Writer) Len() int {
 	return len(w.buf)
 }
 
-// Reset truncates the buffer to zero length, retaining capacity.
+// maxPooledBufCap is the largest buffer capacity kept when a Writer returns
+// to the pool. Buffers grown beyond this by a single large render are dropped
+// and replaced with a fresh default-capacity buffer so one rogue request
+// cannot permanently bloat the pool's steady-state footprint.
+const maxPooledBufCap = 64 * 1024
+
+// Reset truncates the buffer to zero length. If the buffer's capacity exceeds
+// maxPooledBufCap the backing array is released and replaced with a new
+// default-sized one; this prevents a single large render from permanently
+// bloating the pool.
 func (w *Writer) Reset() {
+	if cap(w.buf) > maxPooledBufCap {
+		w.buf = make([]byte, 0, defaultBufCap)
+		return
+	}
 	w.buf = w.buf[:0]
 }


### PR DESCRIPTION
## Summary

P2 polish bundle for `packages/sveltego/render/` from the v0.1 master code-quality review (§3.3), closing umbrella issue #319.

- **`WriteEscapeAttr` godoc expanded** — now documents nil handling, numeric/bool bypass, and error-before-Stringer dispatch order, matching `WriteEscape`'s existing commentary
- **`Writer.Reset` large-buffer guard** — adds `maxPooledBufCap` constant (64 KiB) and drops oversized buffers instead of pooling them, preventing a single large render from permanently bloating the steady-state pool footprint

The `Bytes()` aliasing contract (third checklist item in #319) is doc-only by design; the existing godoc already commits to it, no code change needed.

## Checklist

- [x] `Writer.Reset` large-buffer cap (64 KiB drop threshold)
- [x] `WriteEscapeAttr` godoc: error-before-Stringer note added
- [x] `Writer.Bytes()` aliasing: doc-only contract confirmed, no adapter needed for v0.1

## Verification

- `gofumpt -l packages/sveltego/render/` — clean
- `go vet ./packages/sveltego/render/...` — clean
- `go test -race ./packages/sveltego/render/...` — 74 passed
- `go build ./packages/sveltego/render/...` — success
- `golangci-lint run ./packages/sveltego/render/...` — clean

Only `packages/sveltego/render/render.go` changed (+18 −3 lines).

Closes #319