### PR TITLE
chore(router): v0.1 polish bundle (closes #320)

### DIFF
--- a/packages/sveltego/runtime/router/match.go
+++ b/packages/sveltego/runtime/router/match.go
@@ -215,7 +215,7 @@ func splitAndDecodeInto(p string, buf *[maxStackParams]string) ([]string, bool) 
 				buf[count] = s
 			} else {
 				if heap == nil {
-					heap = make([]string, maxStackParams, count+8)
+					heap = make([]string, maxStackParams, count*2)
 					copy(heap, buf[:])
 				}
 				heap = append(heap, s)

--- a/packages/sveltego/runtime/router/route.go
+++ b/packages/sveltego/runtime/router/route.go
@@ -53,7 +53,9 @@ type ActionsHandler func() any
 // manifest. The router never invokes the handler refs; that is the
 // dispatcher's job.
 type Route struct {
-	// ID is an 8-char FNV-1a hash of Pattern populated by NewTree.
+	// ID is an 8-char hex tag derived from an FNV-1a 32-bit hash of Pattern,
+	// populated by NewTree. It is a tag for logging and manifest correlation,
+	// NOT a collision-free identity. Use Pattern as the unique key.
 	ID string
 	// Pattern is the SvelteKit-style canonical path, e.g. "/post/[id]/[...rest]".
 	Pattern string

--- a/packages/sveltego/runtime/router/tree.go
+++ b/packages/sveltego/runtime/router/tree.go
@@ -100,10 +100,13 @@ func (t *Tree) WithMatchers(m Matchers) (*Tree, error) {
 	return t, nil
 }
 
-// Routes returns the route slice owned by t. Callers must not mutate
-// the returned slice.
+// Routes returns a copy of the tree's route slice. Each call allocates
+// a new slice header and backing array; callers are free to sort or
+// truncate the result without affecting the tree.
 func (t *Tree) Routes() []Route {
-	return t.routes
+	out := make([]Route, len(t.routes))
+	copy(out, t.routes)
+	return out
 }
 
 func (t *Tree) insert(r *Route) error {
@@ -278,6 +281,11 @@ func sortAll(n *node) {
 	}
 }
 
+// routeID returns an 8-char hex tag derived from an FNV-1a 32-bit hash
+// of the route pattern. The tag is used for fast logging and manifest
+// correlation; it is NOT a collision-free identity. Two routes with
+// different patterns may produce the same ID (p ≈ N²/2³² for N routes).
+// Do not use ID as a unique key; use Pattern for that.
 func routeID(pattern string) string {
 	h := fnv.New32a()
 	_, _ = io.WriteString(h, pattern)


### PR DESCRIPTION
## Summary

Three P2 polish items from the v0.1 master code-quality review (§3.4), bundled under umbrella #320.

- **Heap alloc cap** (`match.go:218`): `splitAndDecodeInto` fallback slice was pre-allocated with `count+8` — already equal to `maxStackParams+8` — which triggers grow-and-copy for routes with 9+ segments. Changed to `count*2` to absorb the full tail without realloc.
- **`Tree.Routes()` defensive copy** (`tree.go:103-110`): previously returned the live internal slice. Now returns a copy; callers can sort or truncate without corrupting the matcher.
- **`routeID` / `Route.ID` godoc** (`tree.go:281`, `route.go:56`): both fields now explicitly state the 32-bit FNV-1a hash is a *tag for logging/manifest correlation*, NOT a collision-free identity, and direct callers to use `Pattern` as the unique key.

## Test plan

- [x] `go vet ./packages/sveltego/runtime/router/...` — clean
- [x] `go build ./packages/sveltego/runtime/router/...` — clean
- [x] `go test -race ./packages/sveltego/runtime/router/...` — 33 passed
- [x] `gofumpt -l` + `goimports -l` — no output (clean)
- [x] No public API signatures changed (`Tree`, `Route`, `NewTree` stable)