### PR TITLE
chore(codegen): v0.1 polish bundle (closes #322)

### DIFF
--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -61,6 +61,11 @@ type BuildOptions struct {
 // emitted page or server stub; ManifestPath is the absolute path to the
 // generated manifest. Diagnostics holds non-fatal scanner warnings — fatal
 // diagnostics return through the error channel instead.
+//
+// Note: Diagnostics is typed as []routescan.Diagnostic, which lives in an
+// internal package. Build is currently experimental; if it is ever promoted
+// to stable, Diagnostic must be re-exported or wrapped so that callers
+// outside this module can refer to the type without import tricks.
 type BuildResult struct {
 	Routes       int
 	ManifestPath string

--- a/packages/sveltego/internal/codegen/link_emit.go
+++ b/packages/sveltego/internal/codegen/link_emit.go
@@ -24,6 +24,10 @@ type LinkEmitOptions struct {
 // canonical SvelteKit-style pattern, the Go-ident helper name, and the
 // HTTP method label printed by `sveltego routes` ("GET" for pages and
 // servers; "POST", etc. when a +server.go advertises specific methods).
+//
+// LinkRoute is intentionally part of the public contract: the CLI (`sveltego
+// routes`), the LSP, and AI-codegen tools all consume it to enumerate
+// navigable routes. Do not unexport.
 type LinkRoute struct {
 	Pattern string
 	Helper  string


### PR DESCRIPTION
## Summary

Doc-only polish for `packages/sveltego/internal/codegen/` public entry points per the v0.1 master review (§3.6).

- **`BuildResult.Diagnostics`**: adds a doc note that `routescan.Diagnostic` lives in an internal package; stabilisation of `Build` will require re-exporting or wrapping the type.
- **`LinkRoute`**: adds explicit godoc confirming the type is intentionally public (CLI, LSP, AI-codegen consumers read it); do not unexport.

Remaining checklist items from #322 required no code change:
- `BuildOptions.OutDir` default (`.gen`) was already present in the godoc — confirmed.
- `Generate` multi-walk is a build-time cost tracked by the existing monitor note — confirmed acceptable.

Closes #322.

## Test plan

- [x] `gofumpt -l` — clean
- [x] `goimports -l` — clean
- [x] `go vet ./packages/sveltego/internal/codegen/...` — clean
- [x] `go build ./packages/sveltego/internal/codegen/...` — success
- [x] `go test -race ./packages/sveltego/internal/codegen/...` — 418 tests pass
- [x] `golangci-lint run ./packages/sveltego/internal/codegen/...` — clean