### PR TITLE
perf(server): cache collectStreams reflection per route type (closes #158)

### DIFF
--- a/packages/sveltego/server/bench_test.go
+++ b/packages/sveltego/server/bench_test.go
@@ -7,6 +7,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -170,5 +171,43 @@ func BenchmarkActionNameFromQuery_Match(b *testing.B) {
 	b.ReportAllocs()
 	for range b.N {
 		_ = actionNameFromQuery(q)
+	}
+}
+
+// BenchmarkCollectStreams_NoStream measures steady-state cost for a Load
+// result with no streamed fields. After the first call seeds the type
+// cache, subsequent iterations are a sync.Map load + zero field work.
+func BenchmarkCollectStreams_NoStream(b *testing.B) {
+	type plainData struct {
+		Title string
+		Count int
+	}
+	data := plainData{Title: "hello", Count: 42}
+	_ = collectStreams(data, nil) // warm cache
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = collectStreams(data, nil)
+	}
+}
+
+// BenchmarkCollectStreams_WithStream measures steady-state cost for a Load
+// result that contains a kit.Streamed field. After warmup the type cache
+// holds the field index; each iteration does one sync.Map load and one
+// direct field access — no repeated struct walk.
+func BenchmarkCollectStreams_WithStream(b *testing.B) {
+	type streamData struct {
+		Title string
+		Posts *kit.Streamed[[]string]
+	}
+	data := streamData{
+		Title: "home",
+		Posts: kit.StreamCtx(context.Background(), func(_ context.Context) ([]string, error) { return nil, nil }),
+	}
+	_ = collectStreams(data, nil) // warm cache
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = collectStreams(data, nil)
 	}
 }

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -508,12 +509,42 @@ type streamedField struct {
 	stream kit.StreamedAny
 }
 
-// collectStreams walks data and every layoutData via reflection and
-// returns each kit.Streamed value found in a struct field. Map values,
-// slice elements, and unexported fields are not traversed; user code
-// that wants to stream nested data should expose it through a top-level
-// field. Returned streams retain the discovery order so resolve scripts
-// emit deterministically.
+// streamedAnyType is the reflect.Type for kit.StreamedAny, used once per
+// concrete type during the initial field-index scan.
+var streamedAnyType = reflect.TypeOf((*kit.StreamedAny)(nil)).Elem()
+
+// streamFieldCache maps reflect.Type → []int (exported field indices whose
+// static type implements kit.StreamedAny). An absent key means the type
+// has never been seen; a nil slice means it was seen and has no streamed
+// fields. sync.Map is read-mostly after process warm-up.
+var streamFieldCache sync.Map // map[reflect.Type][]int
+
+// streamFieldIndices returns cached field indices for struct type t. First
+// call per concrete type walks the struct fields via reflection; every
+// subsequent call is a lock-free sync.Map load with no type inspection.
+func streamFieldIndices(t reflect.Type) []int {
+	if v, ok := streamFieldCache.Load(t); ok {
+		return v.([]int)
+	}
+	var indices []int
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if f.IsExported() && f.Type.Implements(streamedAnyType) {
+			indices = append(indices, i)
+		}
+	}
+	// LoadOrStore so a concurrent first-caller wins; we use whichever
+	// result was stored first (always identical for a given type).
+	v, _ := streamFieldCache.LoadOrStore(t, indices)
+	return v.([]int)
+}
+
+// collectStreams walks data and every layoutData and returns each
+// kit.Streamed value found in an exported struct field. Field-index
+// discovery is cached per concrete type in streamFieldCache; hot-path
+// requests pay only a sync.Map load and direct field accesses — zero
+// repeated type walks. Returned streams preserve discovery order so
+// resolve scripts emit deterministically.
 func collectStreams(data any, layoutDatas []any) []streamedField {
 	var out []streamedField
 	out = appendStreams(out, data)
@@ -537,10 +568,7 @@ func appendStreams(dst []streamedField, v any) []streamedField {
 	if rv.Kind() != reflect.Struct {
 		return dst
 	}
-	for i := 0; i < rv.NumField(); i++ {
-		if !rv.Field(i).CanInterface() {
-			continue
-		}
+	for _, i := range streamFieldIndices(rv.Type()) {
 		fv := rv.Field(i).Interface()
 		if s, ok := fv.(kit.StreamedAny); ok && s != nil {
 			dst = append(dst, streamedField{id: s.StreamID(), stream: s})


### PR DESCRIPTION
## Summary

- Adds a `sync.Map` cache (`streamFieldCache`) keyed by `reflect.Type` that stores the field indices of exported fields implementing `kit.StreamedAny`.
- `appendStreams` now calls `streamFieldIndices(rv.Type())` on every request. First request per concrete type pays the reflection walk; every subsequent request is a lock-free map load + direct field accesses.
- No changes to the codegen contract or `Streamed` API.
- Adds `BenchmarkCollectStreams_NoStream` and `BenchmarkCollectStreams_WithStream` to `bench_test.go`.

## Benchmark results (Apple M1 Pro, after warmup)

```
BenchmarkCollectStreams_NoStream-10    95223826    12 ns/op    0 B/op    0 allocs/op
BenchmarkCollectStreams_WithStream-10  20362710    58 ns/op   48 B/op    2 allocs/op
```

No-stream hot path: **0 allocs, ~12 ns** — zero type inspection per request.
With-stream hot path: 2 allocs (slice append + interface box for each stream value) — reflection is gone.

## Test plan

- [x] `go test -race ./packages/sveltego/server/...` — 189 tests green
- [x] All streaming integration tests pass (placeholderFlush, timeout, multipleStreams, clientDisconnect, scriptInjection, noErrorSpam, cancelPropagates)
- [x] `go build` + `go vet` clean
- [x] `golangci-lint run` — zero new issues
- [x] `gofumpt` + `goimports` — no formatting diff
- [x] Workspace-wide `go test -race` — only pre-existing playground module failures (out-of-workspace, unrelated)