### PR TITLE
chore(server): v0.1 polish bundle (closes #321)

### DIFF
--- a/packages/sveltego/server/actions.go
+++ b/packages/sveltego/server/actions.go
@@ -14,6 +14,10 @@ import (
 // PageData struct alias the codegen emits with `Form any`; routes
 // without that field receive data unchanged. nil data falls through:
 // PageData zero value carries Form=nil so the page reads it as nil.
+//
+// The reflective path is the v0.1 fallback. Once #143 (form-field
+// collision detection) lands, codegen can emit a typed setter that
+// skips reflection entirely.
 func injectFormField(data, formValue any) any {
 	if data == nil {
 		return nil

--- a/packages/sveltego/server/cron.go
+++ b/packages/sveltego/server/cron.go
@@ -8,6 +8,12 @@ import (
 	"github.com/binsarjr/sveltego/exports/kit"
 )
 
+// Log keys used exclusively by cron task logging.
+const (
+	logKeyName = "name"
+	logKeySpec = "spec"
+)
+
 // runCronTasks starts one goroutine per task. Each goroutine fires the task
 // on its parsed interval and exits when ctx is cancelled. Errors from the
 // task function are logged via logger but do not stop the loop — a failing

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -21,8 +21,6 @@ const (
 	logKeyStatus   = "status"
 	logKeyLocation = "location"
 	logKeyFailCode = "fail_code"
-	logKeyName     = "name"
-	logKeySpec     = "spec"
 	logKeyStreamID = "stream_id"
 )
 
@@ -156,11 +154,14 @@ func (s *Server) handlePipelineError(w http.ResponseWriter, r *http.Request, ev 
 		return
 	}
 
-	// Preserve the legacy httpStatuser observation: when the user did
-	// not author HandleError, the identity default returns 500 — but
-	// pre-hooks behavior promoted any error implementing HTTPStatus()
-	// to that status. Honor that path so existing user errors that
-	// expose a status keep doing so.
+	// Preserve the legacy httpStatuser observation. HandleError now takes
+	// (SafeError, error) and may return a short-circuit error; when the
+	// user did NOT author HandleError the identity default returns a 500
+	// SafeError. Pre-hooks behavior promoted errors that implement
+	// HTTPStatus() to that status, so we honor that path here. This branch
+	// is therefore still reachable (not dead): it fires whenever HandleError
+	// returns exactly the identity-default 500 and the original error
+	// carries an HTTPStatus() method.
 	if safe.Code == http.StatusInternalServerError && safe.Message == http.StatusText(http.StatusInternalServerError) {
 		var hs httpStatuser
 		if errors.As(err, &hs) {

--- a/packages/sveltego/server/server.go
+++ b/packages/sveltego/server/server.go
@@ -1,10 +1,15 @@
 // Package server is the runtime entry point a sveltego app composes in
 // its main package: feed it the codegen-emitted route slice, the user's
 // app.html shell, and an optional matchers and hooks bundle, and it
-// returns an http.Handler that runs the SvelteKit-shaped Reroute → Handle
-// → Match → Load → Render → Response pipeline. Form actions remain out
-// of scope for Phase 0; layouts and hooks (Handle, HandleError,
-// HandleFetch, Reroute, Init) are wired.
+// returns an http.Handler that runs the SvelteKit-shaped request pipeline:
+//
+//	CSP nonce → Reroute → Handle → Match → Load → Render → Response
+//
+// The CSP middleware (applyCSP) runs before Handle so the
+// Content-Security-Policy header and nonce are present on every response
+// path — success, error boundary, redirect, and short-circuit alike.
+//
+// Hooks wired: Handle, HandleError, HandleFetch, Reroute, Init.
 package server
 
 import (
@@ -90,6 +95,12 @@ type Config struct {
 }
 
 // Server is the http.Handler implementation that drives a sveltego app.
+//
+// Logger is a public field for ergonomic access in tests and single-binary
+// apps. Do not mutate Logger after calling New or once the server begins
+// serving; concurrent reads in ServeHTTP vs writes from the caller are
+// racy. A future stable release will replace this with an unexported field
+// and a Logger() accessor.
 type Server struct {
 	tree          *router.Tree
 	Logger        *slog.Logger

--- a/packages/sveltego/server/static.go
+++ b/packages/sveltego/server/static.go
@@ -174,8 +174,14 @@ func safeRelPath(urlPath string) (string, bool) {
 }
 
 // acceptsEncoding reports whether tok appears as a non-zero-quality
-// token in an Accept-Encoding header value. Quality parsing is minimal
-// — `;q=0` (with optional whitespace and decimals) suppresses the token.
+// token in an Accept-Encoding header value. Quality parsing is minimal:
+// `;q=0` (with optional whitespace and decimals) suppresses the token.
+// Any qualifier that is not a well-formed `q=<float>` is treated as
+// acceptable — this is a deliberate short-circuit. RFC 9110 §12.5.4
+// defines extension parameters (e.g. `;d=4`) that are not parsed here;
+// the failure mode is conservative: the handler may serve an encoding the
+// client did not prefer but can silently ignore. A full parser is future
+// work not required for v0.1.
 func acceptsEncoding(header, tok string) bool {
 	if header == "" {
 		return false


### PR DESCRIPTION
## Summary

P2 polish bundle for `packages/sveltego/server/` from the v0.1 master code-quality review (§3.5). All changes are godoc, comment, and naming-only — no behavioural or public API changes.

- **errors.go** — update `httpStatuser` branch comment to explicitly reference the new `(SafeError, error)` HandleError contract; the branch is reachable (not dead code).
- **actions.go** — add tracking note that `injectFormField`'s reflective path is the v0.1 fallback; typed emit deferred to #143.
- **cron.go** — move `logKeyName`/`logKeySpec` constants from `errors.go` to `cron.go` (cron is the only consumer).
- **static.go** — expand `acceptsEncoding` godoc to document the deliberate non-`q=` short-circuit (RFC 9110 §12.5.4 note).
- **server.go** — document CSP middleware order in package godoc (`applyCSP` runs before Handle; header present on all response paths).
- **server.go** — add race-risk note on `Server.Logger` public field; a future stable release will unexport it with a `Logger()` accessor.

Closes #321.

## Checklist

- [x] `errors.go:158-169` httpStatuser comment updated
- [x] `actions.go` injectFormField tracking note for #143
- [x] `logKeyName`/`logKeySpec` moved to `cron.go`
- [x] `acceptsEncoding` godoc expanded with RFC note
- [x] CSP middleware order documented in package godoc
- [x] `Server.Logger` race note added

## Test plan

- [x] `go build ./packages/sveltego/server/...` — clean
- [x] `go vet ./packages/sveltego/server/...` — clean
- [x] `go test -race ./packages/sveltego/server/...` — 189 passed
- [x] `gofumpt -l` — no output
- [x] `goimports -l` — no output
- [x] `golangci-lint run` — only pre-existing sloglint issues (5 in pipeline.go/server.go/cron.go that predate this PR)