### PR TITLE
chore(kit): v0.1 polish bundle (closes #318)

### DIFF
--- a/packages/sveltego/exports/kit/bind.go
+++ b/packages/sveltego/exports/kit/bind.go
@@ -20,6 +20,9 @@ const DefaultMaxFormMemory int64 = 32 << 20 // 32 MiB
 // and [RequestEvent.BindMultipart]. FieldErrors is keyed by the form
 // name (the `form:"..."` tag value, falling back to the lowercased
 // struct field name).
+//
+// FieldErrors is a public map; callers must not mutate it after BindForm
+// or BindMultipart returns -- the behavior of doing so is undefined.
 type BindError struct {
 	FieldErrors map[string]string
 }

--- a/packages/sveltego/exports/kit/csp.go
+++ b/packages/sveltego/exports/kit/csp.go
@@ -105,7 +105,9 @@ func NewCSPTemplate(cfg CSPConfig) *CSPTemplate {
 }
 
 // Build returns the full Content-Security-Policy header value with nonce
-// spliced into the cached script-src position.
+// spliced into the cached script-src position. A nil receiver returns the
+// empty string so callers that conditionally build the template (e.g. behind
+// a CSP mode check) can call Build without a nil guard.
 func (t *CSPTemplate) Build(nonce string) string {
 	if t == nil {
 		return ""

--- a/packages/sveltego/exports/kit/csp_test.go
+++ b/packages/sveltego/exports/kit/csp_test.go
@@ -163,6 +163,18 @@ func TestBuildCSPHeader_CachedAcrossCalls(t *testing.T) {
 	}
 }
 
+// TestCSPTemplate_NilReceiverBuildReturnsEmpty guards the documented nil-safe
+// behavior of CSPTemplate.Build: a nil *CSPTemplate returns "" rather than
+// panicking, so callers that conditionally build the template can always call
+// Build without a nil check.
+func TestCSPTemplate_NilReceiverBuildReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	var tpl *CSPTemplate
+	if got := tpl.Build("nonce"); got != "" {
+		t.Fatalf("(*CSPTemplate)(nil).Build() = %q, want empty string", got)
+	}
+}
+
 func TestBuildCSPHeader_ZeroAllocOnCacheHit(t *testing.T) {
 	// AllocsPerRun must not run in parallel — it disables GC.
 	cfg := CSPConfig{Mode: CSPStrict, ReportTo: "alloc-test"}

--- a/packages/sveltego/exports/kit/ctx.go
+++ b/packages/sveltego/exports/kit/ctx.go
@@ -34,6 +34,11 @@ func (hw *HeaderWriter) Del(key string) {
 
 // RenderCtx is the request-scoped context handed to generated Render
 // methods across the SSR lifecycle (Load, Render, Hooks).
+//
+// Note: RenderCtx and [LoadCtx] share an identical set of request fields
+// (Locals, URL, Params, RawParams, Cookies, Request). Consolidation into a
+// shared embedded struct is deferred to v0.5 ctx work because it touches
+// generated Render signatures across every page.
 type RenderCtx struct {
 	Locals map[string]any
 	URL    *url.URL
@@ -149,6 +154,8 @@ func (c *LoadCtx) CollectHeaders() http.Header {
 //   - Sec-Purpose: prefetch   — standardized HTTP hint emitted by browsers
 //     on speculative preload requests (RFC 8941 / Fetch spec).
 func (c *LoadCtx) Speculative() bool {
+	// DO NOT promote to a security boundary. These headers are user-forgeable
+	// hints. Gate analytics / rate-limit suppression here, not access control.
 	if c.Request == nil {
 		return false
 	}

--- a/packages/sveltego/exports/kit/doc.go
+++ b/packages/sveltego/exports/kit/doc.go
@@ -5,4 +5,9 @@
 // the hooks pipeline (Handle, HandleError, HandleFetch, Reroute, Init),
 // and Cookies provides the request/response cookie surface with secure
 // defaults.
+//
+// URL building: the typed helpers generated under <module>/.gen/links
+// are the preferred way to build internal URLs because they fail at
+// compile time when a route is renamed. [Link] is the runtime fallback
+// for dynamic patterns that are not known at build time.
 package kit

--- a/packages/sveltego/exports/kit/hooks.go
+++ b/packages/sveltego/exports/kit/hooks.go
@@ -95,6 +95,10 @@ type SafeError struct {
 // pipeline branches. The string form prefers Message; absent that it
 // falls back to the canonical text for Code (or "internal server error"
 // when Code is also unset).
+//
+// Callers should always check Code != 0 before calling Error: the zero
+// value of SafeError is not a meaningful error and Error() on it returns
+// "Internal Server Error" only because Code == 0 maps to 500.
 func (s SafeError) Error() string {
 	if s.Message != "" {
 		return s.Message
@@ -196,6 +200,10 @@ func DefaultHooks() Hooks {
 // WithDefaults returns h with any nil field replaced by the matching
 // identity default. Idempotent: calling on an already-filled bundle is
 // a no-op.
+//
+// Hooks is intentionally a value type; do not share state through it.
+// Hook fields that are pointer-receiver methods on a struct carrying mutable
+// state create an implicit shared reference across all copies of Hooks.
 func (h Hooks) WithDefaults() Hooks {
 	if h.Handle == nil {
 		h.Handle = IdentityHandle

--- a/packages/sveltego/exports/kit/sitemap.go
+++ b/packages/sveltego/exports/kit/sitemap.go
@@ -49,7 +49,9 @@ func NewSitemap(baseURL string) *SitemapBuilder {
 // Add appends an entry. path may be absolute (already including the
 // scheme/host) or relative (joined onto baseURL). lastMod's zero value
 // is treated as "no <lastmod>"; freq's empty string omits <changefreq>;
-// priority outside [0,1] omits <priority>.
+// priority outside [0,1] silently omits the <priority> element -- no
+// error is returned and no warning is logged. Valid priority range is
+// [0.0, 1.0] inclusive.
 func (s *SitemapBuilder) Add(path string, lastMod time.Time, freq ChangeFreq, priority float64) *SitemapBuilder {
 	s.entries = append(s.entries, SitemapEntry{
 		Loc:      s.resolve(path),

--- a/packages/sveltego/exports/kit/streamed.go
+++ b/packages/sveltego/exports/kit/streamed.go
@@ -1,3 +1,17 @@
+// Streaming helpers for sveltego deferred values.
+//
+// Naming convention in this file:
+//   - [Streamed][T] is the noun: the future-style value a Load function
+//     places in PageData to signal a deferred slot.
+//   - [Stream] and [StreamCtx] are constructors (verbs) that spawn a
+//     goroutine and return a *Streamed[T]. They do NOT return *Stream --
+//     the type is Streamed, the constructor is Stream.
+//   - [StreamedAny] is the type-erased view of *Streamed[T] used
+//     internally by the render pipeline.
+//
+// Prefer [StreamCtx] over [Stream] so the producer receives a cancellable
+// context and exits promptly when the request is abandoned.
+
 package kit
 
 import (


### PR DESCRIPTION
## Summary

Godoc tightening, naming-clarity comments, and one nil-receiver guard test for `packages/sveltego/exports/kit/`. All items from the #318 checklist. No public API changes.

- **doc.go**: promote `kit.Link` runtime-fallback note to package-level godoc
- **ctx.go**: add `RenderCtx`/`LoadCtx` deferred-consolidation note (v0.5); add `DO NOT promote to a security boundary` guard inside `Speculative()`
- **hooks.go**: document `Hooks` value-type intent on `WithDefaults`; add `Code != 0` warning on `SafeError.Error()` zero-value
- **bind.go**: document `BindError.FieldErrors` mutation-undefined contract
- **sitemap.go**: reiterate silent-drop contract on `Add()` method godoc
- **csp.go**: document nil-receiver behavior on `CSPTemplate.Build`
- **csp_test.go**: add `TestCSPTemplate_NilReceiverBuildReturnsEmpty` to guard the documented nil-safe behavior
- **streamed.go**: add file-level comment clarifying `Streamed` (noun) vs `Stream` (constructor) naming split

## Test plan

- [ ] `go test -race ./packages/sveltego/exports/kit/...` passes (177 existing + 1 new = 178 total)
- [ ] `gofumpt -l` clean
- [ ] `go vet` clean
- [ ] `golangci-lint run` clean
- [ ] No public API changes — signatures, return types, exported types all unchanged