### PR TITLE
fix(server): make TestCronTask_stopsOnShutdown non-flaky on macOS/race

### DIFF
--- a/packages/sveltego/server/cron_test.go
+++ b/packages/sveltego/server/cron_test.go
@@ -85,14 +85,16 @@ func TestCronTask_stopsOnShutdown(t *testing.T) {
 		t.Fatalf("Shutdown: %v", err)
 	}
 
-	after := count.Load()
-	// Give goroutines a short window to exit.
-	time.Sleep(80 * time.Millisecond)
-	final := count.Load()
+	// Give goroutines time to exit. Use two observations to confirm the
+	// counter has actually stopped rather than just paused.
+	time.Sleep(200 * time.Millisecond)
+	snap1 := count.Load()
+	time.Sleep(100 * time.Millisecond)
+	snap2 := count.Load()
 
-	// Counter must not keep climbing after shutdown.
-	if final > after+1 {
-		t.Fatalf("cron kept running after shutdown: count went from %d to %d", after, final)
+	// Counter must be stable after the drain window.
+	if snap2 != snap1 {
+		t.Fatalf("cron kept running after shutdown: count %d → %d", snap1, snap2)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes `TestCronTask_stopsOnShutdown` flaking on macOS with `-race` detector
- Root cause: `select` on `ctx.Done()` vs `ticker.C` is non-deterministic; under race detector overhead, goroutine processes 2+ extra ticks before selecting the cancel case
- Switch from fixed-window `after+1` assertion to a two-observation stability check (wait 200ms → snap1, wait 100ms → snap2, assert `snap1 == snap2`)

## Root cause autopsy

The original test:
```
after := count.Load()
time.Sleep(80ms)
final := count.Load()
if final > after+1 { FAIL }
```

After `Shutdown()`, the cron goroutine cancels ctx but may still be inside `task.Fn`. On re-entry to `select`, when both `ctx.Done()` and `ticker.C` are ready, Go picks randomly. On a slow macOS race-detector runner, the goroutine can process 1-2 extra ticks within the 80ms window before selecting `ctx.Done()`. The `after+1` tolerance was insufficient.

New pattern: don't race against a fixed deadline. Wait 200ms (10 tick intervals) for the goroutine to stabilize, then confirm no further growth in 100ms.

## Test plan

- [x] `go test ./packages/sveltego/server/... -run TestCronTask_stopsOnShutdown -race -count=3` — 3/3 pass
- [x] `go test ./packages/sveltego/server/... -race` — 189 pass
- [x] `gofumpt -l` — clean
- [x] `go vet ./packages/sveltego/server/...` — clean