### PR TITLE
fix(playground): upgrade vite-plugin-svelte to ^5 (vite 6 peer compat)

### DIFF
--- a/playgrounds/basic/package.json
+++ b/playgrounds/basic/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "svelte": "^5.0.0",
     "vite": "^6.0.0"
   }


### PR DESCRIPTION
## Summary

- `@sveltejs/vite-plugin-svelte@4.x` requires peer `vite@"^5.0.0"` but `playgrounds/basic/package.json` has `vite@"^6.0.0"`
- npm fails with ERESOLVE during `sveltego compile` → `npm install` in playground-smoke CI
- Upgrade to `@sveltejs/vite-plugin-svelte@"^5.0.0"` which declares peer `vite@"^6.0.0"`

## Root cause

PR #347 (Vite client bundle integration) added `package.json` to `playgrounds/basic/` with `@sveltejs/vite-plugin-svelte@^4.0.0` and `vite@^6.0.0`. These have an incompatible peer dependency: v4.x requires vite 5.x, v5.x requires vite 6.x.

## Test plan

- [x] `package.json` change is a 1-line bump; no code changes
- CI: `playground-smoke (basic)` Compile + Build step should now succeed