### PR TITLE
fix(playground): add type=module for ESM vite config compatibility

### DIFF
--- a/playgrounds/basic/package.json
+++ b/playgrounds/basic/package.json
@@ -2,6 +2,7 @@
   "name": "sveltego-playground-basic",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "sveltego build",


### PR DESCRIPTION
## Summary

- Adds `"type": "module"` to `playgrounds/basic/package.json`
- Without it, Node treats `.js` files as CommonJS; `vite.config.gen.js` uses ESM `import`/`export default`, causing vite to fail with: `Failed to resolve "@sveltejs/vite-plugin-svelte". This package is ESM only but it was tried to load by require`
- Also adds to user's `vite.config.js` (which already used ESM imports)

## Root cause

PR #347 generates `vite.config.gen.js` with ESM syntax. The playground `package.json` lacked `"type": "module"`, so Node defaulted to CJS mode for `.js` files. esbuild (used by vite to bundle the config) couldn't resolve the ESM-only `@sveltejs/vite-plugin-svelte` package.

## Test plan

- [x] Change is a 1-line JSON addition
- CI: playground-smoke Compile+Build should pass after `npm install` succeeds (fixed by #351) and vite build runs in ESM mode