### PR TITLE
fix(codegen): entry.ts svelte import path relative to projectRoot

### DIFF
--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -397,8 +397,11 @@ func emitClientEntry(projectRoot, outDir, routesDir string, route routescan.Scan
 
 	entryRelFromRoot := filepath.ToSlash(filepath.Join(outDir, "client", routeKey, "entry.ts"))
 	depth := len(strings.Split(filepath.ToSlash(filepath.Dir(entryRelFromRoot)), "/"))
-	relRouteDir := filepath.ToSlash(relDir)
-	svelteSrc := relRouteDir + "/" + pageName
+	routeDirFromRoot, err := filepath.Rel(projectRoot, route.Dir)
+	if err != nil {
+		return "", fmt.Errorf("codegen: client entry svelte rel path: %w", err)
+	}
+	svelteSrc := filepath.ToSlash(routeDirFromRoot) + "/" + pageName
 	relSvelte := vite.RelativeSveltePath(svelteSrc, depth)
 
 	src := vite.GenerateClientEntry(relSvelte)


### PR DESCRIPTION
## Summary

- Fixes `emitClientEntry` path computation for the Svelte import in generated `entry.ts` files
- `relDir` was relative to `routesParent` (= `src/`), so `svelteSrc` was e.g. `routes/post/[id]/+page.svelte` — missing `src/` prefix
- Vite resolved this relative to project root as `routes/` (doesn't exist), causing: `Could not resolve "../../../../../../routes/post/[id]/+page.svelte" from ".gen/client/routes/post/[id]/+page/entry.ts"`
- Fix: use `filepath.Rel(projectRoot, route.Dir)` → `src/routes/post/[id]` → correct import path

## Root cause

```go
// Bug: relDir = filepath.Rel(routesParent, route.Dir) = "routes/post/[id]"
// (routesParent = src/, missing src/ prefix)
svelteSrc := relRouteDir + "/" + pageName  // → "routes/post/[id]/+page.svelte"

// Fix: use projectRoot as base
routeDirFromRoot = filepath.Rel(projectRoot, route.Dir)  // → "src/routes/post/[id]"
svelteSrc := filepath.ToSlash(routeDirFromRoot) + "/" + pageName  // → "src/routes/post/[id]/+page.svelte"
```

The entry sits at depth 6 from project root, so 6×`../` brings it back to root, and then `src/routes/post/[id]/+page.svelte` resolves correctly.

## Test plan

- [x] `go test ./packages/sveltego/internal/codegen/... -race` — 418 pass
- [x] `go build ./packages/sveltego/...` — clean
- [x] `gofumpt -l` — clean
- CI: playground-smoke Compile+Build should now produce valid entry.ts with correct import path