### PR TITLE
docs: post-wave-14 drift audit + quickstart polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@ server.go               ──→  REST endpoints              (//go:build svelt
                    single binary deploy
 ```
 
+## Quickstart
+
+Pre-alpha — expect rough edges. The baseline scaffold writes files; it does **not** yet wire up `cmd/app/main.go` or the Vite shell. Until [#356](https://github.com/binsarjr/sveltego/issues/356) closes, the path of least resistance is to copy [`playgrounds/basic/`](playgrounds/basic/) and edit it.
+
+```sh
+go install github.com/binsarjr/sveltego/cmd/sveltego@latest
+go install github.com/binsarjr/sveltego/init/cmd/sveltego-init@latest
+
+# Option A — copy the working playground (recommended today):
+git clone https://github.com/binsarjr/sveltego
+cd sveltego/playgrounds/basic
+sveltego build && ./build/app           # listens on :3000
+
+# Option B — scaffold + finish manually (gap tracked in #356):
+sveltego-init --ai ./hello
+cd hello
+# Add cmd/app/main.go, app.html, package.json, vite.config.js
+# (copy them from playgrounds/basic/ for now)
+sveltego build && ./build/app
+```
+
+`sveltego build` chains codegen → Vite → `go build` in one step; you do not need a separate `go build` invocation. The full quickstart with annotated layout lives in [docs/guide/quickstart.md](docs/guide/quickstart.md).
+
 ## Expression philosophy
 
 Inside `.svelte`, `{...}` mustaches are **Go expressions**, not JS:
@@ -83,7 +106,7 @@ This is a Go workspace (`go.work`) with one module per package:
 packages/
   sveltego/             # Core: parser, codegen, runtime, kit, router, server, CLI
   auth/                 # First-party auth library (ADR 0006; #216–#255)
-  init/                 # `sveltego init` scaffolder
+  init/                 # `sveltego-init` scaffolder (standalone binary)
   lsp/                  # Language server for `.svelte` with Go expressions
   mcp/                  # Model Context Protocol server (search_docs, lookup_api, …)
   enhanced-img/         # Image optimization helpers

--- a/docs/ai-development.md
+++ b/docs/ai-development.md
@@ -31,13 +31,13 @@ The `sveltego mcp` command lands with #71. Until then, the Copy-for-LLM buttons 
 
 ### Cursor
 
-Drop `.cursorrules` from `sveltego init --ai` into your project root. Cursor reads it automatically and applies it to every chat.
+Drop `.cursorrules` from `sveltego-init --ai` into your project root. Cursor reads it automatically and applies it to every chat.
 
 For MCP: Cursor Settings → MCP → add `sveltego mcp`.
 
 ### GitHub Copilot
 
-`sveltego init --ai` writes `.github/copilot-instructions.md`. Copilot Chat picks it up automatically; Copilot inline completion uses it as additional context where supported.
+`sveltego-init --ai` writes `.github/copilot-instructions.md`. Copilot Chat picks it up automatically; Copilot inline completion uses it as additional context where supported.
 
 ### Continue
 
@@ -53,10 +53,12 @@ Continue resolves `AGENTS.md` as the master rules file; the project keeps `.curs
 ## Project templates
 
 ```sh
-sveltego init --ai
+sveltego-init --ai ./my-app
 ```
 
-Adds `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`. AGENTS.md is the master; the other three are generated from it. Edit AGENTS.md and re-run the sync to update the rest.
+Adds `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md` to the scaffold. `AGENTS.md` is the master; the other three are generated from it via `scripts/sync-ai-docs.sh`. Edit `AGENTS.md` and re-run the sync to update the rest.
+
+To copy AI templates into an existing project (without scaffolding a new tree), use the same binary against the existing dir — non-template files are not touched, conflicts skip-by-default.
 
 ## Prompting tips
 

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -54,14 +54,15 @@ Layout values cascade to descendants; page values override the cascade. The mani
 
 ## Tooling commands
 
-| Command | Purpose |
-|---|---|
-| `sveltego build` | Full codegen + go build. |
-| `sveltego compile` | Codegen only. |
-| `sveltego dev` | Watch + regenerate. |
-| `sveltego check` | Validate without writing output. |
-| `sveltego routes` | Print the route table. |
-| `sveltego version` | Print version. |
+| Command | Purpose | Status |
+|---|---|---|
+| `sveltego build` | Full codegen + Vite + `go build`. | Shipped. |
+| `sveltego compile` | Codegen only (no `go build`). | Shipped. |
+| `sveltego routes` | Print the resolved route table. | Shipped. |
+| `sveltego version` | Print version. | Shipped. |
+| `sveltego dev` | Watch + regenerate + HMR proxy. | Stub — deferred to v0.3 ([#42](https://github.com/binsarjr/sveltego/issues/42)). |
+| `sveltego check` | Validate without writing output. | Stub — milestone TBD. |
+| `sveltego-init` | Scaffold a new project (separate binary under `packages/init`). | Shipped (with [#356](https://github.com/binsarjr/sveltego/issues/356) gap). |
 
 ## Determinism
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -26,7 +26,7 @@ Markup mostly. Mustaches must be rewritten to Go. Component scripts must be rewr
 
 ## Where is hot reload?
 
-`sveltego dev` watches `src/routes/**` and regenerates `.gen/*.go` on change. The Go server restart is the primary feedback loop. Browser HMR for the Vite client bundle works as in any Vite project.
+`sveltego dev` is the planned watch + regenerate + HMR proxy command, but today it is a stub (deferred to v0.3, [#42](https://github.com/binsarjr/sveltego/issues/42)). For now, re-run `sveltego compile` after editing templates and restart the server. Once it ships, the Go server restart will be the primary feedback loop, with browser HMR for the Vite client bundle handled by Vite as in any other project.
 
 ## How do I serve static files?
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -12,31 +12,44 @@ sveltego is pre-alpha. Expect rough edges and breaking changes. The shape below 
 
 ```sh
 go install github.com/binsarjr/sveltego/cmd/sveltego@latest
+go install github.com/binsarjr/sveltego/init/cmd/sveltego-init@latest
 sveltego version
 ```
 
-The CLI is a single binary. No Node runtime is required to run a built app; Node is only needed at build time for the Vite client bundle.
+Two binaries today: `sveltego` (build / compile / routes / version) and `sveltego-init` (project scaffolder, separate module under `packages/init`). No Node runtime is required to run a built app; Node is only needed at build time for the Vite client bundle.
 
 ## Scaffold
 
 ```sh
-mkdir hello && cd hello
-sveltego init
+sveltego-init ./hello
+cd hello
 ```
 
-This produces:
+This writes the baseline tree:
 
 ```
 hello/
   src/
     routes/
       +page.svelte
-      page.server.go       # //go:build sveltego (no `+` prefix on user .go files)
-    hooks.server.go        # //go:build sveltego (optional)
-    lib/                   # $lib alias target
+      page.server.go         # //go:build sveltego (no `+` prefix on user .go files)
+      +layout.svelte
+    lib/                     # $lib alias target ($lib/.gitkeep)
+  hooks.server.go            # //go:build sveltego
+  sveltego.config.go         # //go:build sveltego
   go.mod
-  package.json             # Vite client bundle
-  sveltego.config.go
+  README.md
+  .gitignore
+```
+
+::: warning Scaffold gap (#356)
+The scaffold does not yet emit `cmd/app/main.go`, `app.html`, `package.json`, or `vite.config.js`. To run the project end-to-end today, copy those four files from [`playgrounds/basic/`](https://github.com/binsarjr/sveltego/tree/main/playgrounds/basic) into your scaffold output. Tracked in [#356](https://github.com/binsarjr/sveltego/issues/356).
+:::
+
+Add `--ai` to also write `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `.github/copilot-instructions.md` from the bundled AI templates:
+
+```sh
+sveltego-init --ai ./hello
 ```
 
 ## A minimal route
@@ -69,21 +82,21 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
 
 ## Develop
 
-```sh
-sveltego dev
-```
+`sveltego dev` is a stub today (deferred to v0.3, [#42](https://github.com/binsarjr/sveltego/issues/42)). For now: re-run `sveltego compile` after editing `.svelte` or user `.go` files, then re-run the binary.
 
-This starts the dev server, watches `src/routes/**`, regenerates `.gen/*.go`, and proxies the Vite dev server for the client bundle.
+```sh
+sveltego compile         # regenerate .gen/*.go
+go run ./cmd/app         # boot the server
+```
 
 ## Build
 
 ```sh
-sveltego build
-go build -o app ./cmd/app
-./app
+sveltego build           # codegen + Vite + go build, in one step
+./build/app              # listens on :3000
 ```
 
-The `build` step writes `.gen/*.go`; the standard `go build` produces a single binary. Deploy that binary plus the `dist/` Vite output as static assets.
+`sveltego build` runs codegen, runs Vite for the client bundle, then chains directly into `go build -o build/app ./cmd/app`. You do not need a separate `go build` invocation. Deploy `./build/app` plus the Vite `dist/` output (static assets) as a single artifact.
 
 ## Next steps
 

--- a/docs/guide/tailwind.md
+++ b/docs/guide/tailwind.md
@@ -11,10 +11,10 @@ Tailwind integrates with sveltego through Vite's plugin system. The server binar
 ## Quickstart (Tailwind v4, preferred)
 
 ```sh
-sveltego init --tailwind
+sveltego-init --tailwind ./my-app
 ```
 
-The `--tailwind` flag (tracked in [#207](https://github.com/binsarjr/sveltego/issues/207)) wires up the Vite plugin and inserts the `@source` directive automatically. Until that flag ships, follow the manual steps below.
+The `--tailwind` flag (tracked in [#207](https://github.com/binsarjr/sveltego/issues/207)) is **not yet implemented**; it will wire up the Vite plugin and insert the `@source` directive automatically when it ships. Until then, scaffold without `--tailwind` and follow the manual steps below.
 
 ### Manual setup
 
@@ -179,7 +179,7 @@ sveltego has no built-in dark-mode helper. Toggle a `dark` class on `<html>` fro
 **Can I use Tailwind v3 and v4 at the same time?**
 No. They use different plugin architectures. Pick one per project.
 
-**How do I opt out of Tailwind after running `sveltego init --tailwind`?**
+**How do I opt out of Tailwind after running `sveltego-init --tailwind`?**
 Remove `@tailwindcss/vite` from `vite.config.ts` and `@import "tailwindcss"` from your CSS. No sveltego-specific cleanup is needed.
 
 **Does the scope hash affect Tailwind's JIT output?**

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,10 +6,11 @@ summary: sveltego command reference — build, compile, dev, check, routes, vers
 
 # CLI
 
-`sveltego` is the project's command-line entry point. Install with:
+`sveltego` is the project's primary command-line entry point. Project scaffolding lives in a separate binary, `sveltego-init`. Install with:
 
 ```sh
 go install github.com/binsarjr/sveltego/cmd/sveltego@latest
+go install github.com/binsarjr/sveltego/init/cmd/sveltego-init@latest
 ```
 
 ## Global flags
@@ -26,7 +27,7 @@ Verbosity defaults to warn-level. Logs use `slog` with a text handler on stderr.
 
 ### `sveltego build`
 
-Full pipeline: codegen → Vite client bundle → `go build`.
+Full pipeline: codegen → Vite client bundle → `go build -o build/app ./cmd/app`. Single command; no separate `go build` step needed.
 
 ### `sveltego compile`
 
@@ -34,11 +35,11 @@ Codegen only. Writes `.gen/*.go`. Use this when iterating on templates without r
 
 ### `sveltego dev`
 
-Watch + regenerate. Restarts the server on `.gen/` change. Proxies the Vite dev server for client HMR.
+**Stub today** — deferred to v0.3 ([#42](https://github.com/binsarjr/sveltego/issues/42)). Will watch `src/routes/**`, regenerate `.gen/*.go` on change, restart the server, and proxy the Vite dev server for client HMR.
 
 ### `sveltego check`
 
-Validate without writing output. Runs the parser and Go expression validator over every `+page.svelte` / `+layout.svelte`. Use this in CI before `build`.
+**Stub today.** Will validate without writing output: parser pass + Go expression validator over every `+page.svelte` / `+layout.svelte`, intended for CI before `build`. Milestone TBD.
 
 ### `sveltego routes`
 
@@ -46,7 +47,20 @@ Print the route table. One line per route with: pattern, file, presence of `Load
 
 ### `sveltego version`
 
-Print version, commit, build date.
+Print version, Go runtime version, OS, and architecture.
+
+## `sveltego-init` (separate binary)
+
+Project scaffolder. See [`packages/init/README.md`](https://github.com/binsarjr/sveltego/blob/main/packages/init/README.md) for the full flag list. Quickly:
+
+```sh
+sveltego-init ./my-app                    # baseline scaffold
+sveltego-init --ai ./my-app               # baseline + AI-assistant templates
+sveltego-init --module example.com/x ./my-app
+sveltego-init --force ./my-app            # overwrite existing files
+```
+
+Scaffold output is incomplete pending [#356](https://github.com/binsarjr/sveltego/issues/356) — copy `cmd/app/main.go`, `app.html`, `package.json`, and `vite.config.js` from `playgrounds/basic/` until that lands.
 
 ## Exit codes
 


### PR DESCRIPTION
## Summary

Post-wave-14 doc-drift audit. Fix the biggest friction points for a fresh user trying to run sveltego today, and call out the scaffold gap as a tracked follow-up.

- README + docs: replace the non-existent `sveltego init` subcommand with the real `sveltego-init` binary (separate module under `packages/init`).
- README + docs: correct the build recipe — `sveltego build` already chains codegen, Vite, and `go build`. The previous docs implied a separate `go build` step.
- Mark `sveltego dev` and `sveltego check` as stubs (deferred to v0.3 / future milestone). Both currently print "not implemented".
- Add an honest README "Quickstart" section pointing at `playgrounds/basic/` as the recommended starter path until #356 closes.
- File [#356](https://github.com/binsarjr/sveltego/issues/356) for the scaffold gap: `sveltego-init` does not emit `cmd/app/main.go`, `app.html`, `package.json`, or `vite.config.js`, so its output is not runnable without manual copy from `playgrounds/basic/`.

## Verification

Live milestone counts re-verified against `gh api repos/binsarjr/sveltego/milestones`:

| Milestone | Live (closed/total) | README/CLAUDE.md table |
|---|---|---|
| MVP | 42/42 | 42 |
| v0.2 | 15/15 | 15 |
| v0.3 | 6/21 | 21 |
| v0.4 | 19/19 | 19 |
| v0.5 | 19/23 | 23 |
| v0.6 | 9/40 | 40 |
| v1.0 | 16/25 | 25 |
| v1.1 | 6/6 | 6 |

Totals match existing tables. No count edits needed this round.

`scripts/sync-ai-docs.sh` ran clean — `.cursorrules` and `.github/copilot-instructions.md` already in sync with `AGENTS.md` (which did not need edits this round; only docs under `docs/` and `README.md` changed).

## Files

- `README.md` — Quickstart section, init binary clarified.
- `docs/guide/quickstart.md` — full rewrite of Install/Scaffold/Develop/Build sections.
- `docs/ai-development.md` — `sveltego init --ai` → `sveltego-init --ai`.
- `docs/guide/build.md` — Status column on tooling-commands table.
- `docs/guide/faq.md` — hot-reload answer reflects stub state.
- `docs/guide/tailwind.md` — `sveltego init --tailwind` → `sveltego-init --tailwind`, mark unimplemented.
- `docs/reference/cli.md` — install both binaries, mark stubs, add `sveltego-init` section.

## Test plan

- [ ] CI: docs-only diff. The `ci.yml` workflow's `paths-ignore` covers `**.md` and `docs/**`, so no jobs are expected to run on this PR. Verify the merge queue accepts it without required-check waits.
- [ ] Visual scan of the new README Quickstart section.
- [ ] Confirm #356 issue body is accurate.

## Out of scope

- Actually fixing the scaffold gap (covered by #356).
- Editing `tasks/lessons/**` (append-only).
- Touching `packages/auth/**` and `packages/cookiesession/**` docs (on hold per `feedback_focus_core`).
- Code changes (`.go`, `.svelte`).