### PR TITLE
feat(codegen): <Image> component with srcset generation (closes #92)

### DIFF
--- a/packages/sveltego/exports/kit/page_options.go
+++ b/packages/sveltego/exports/kit/page_options.go
@@ -44,6 +44,14 @@ func (ts TrailingSlash) String() string {
 // false. Manifest emission stores the effective resolved value per
 // route, so the pipeline does not re-walk the layout chain at request
 // time.
+//
+// ImageWidths configures the variant widths produced by the build-time
+// image pipeline for <Image src="..."> elements (#92). Empty applies the
+// framework default (320, 640, 1280); the field is global rather than
+// per-route because the variants live in a shared static/_app/immutable/
+// pool and cache best when the width set is stable. Only the project
+// root's default value is consulted; per-route overrides are ignored
+// because the pool is not partitioned by route.
 type PageOptions struct {
 	Prerender     bool
 	SSR           bool
@@ -51,6 +59,7 @@ type PageOptions struct {
 	SSROnly       bool
 	CSRF          bool
 	TrailingSlash TrailingSlash
+	ImageWidths   []int
 }
 
 // DefaultPageOptions returns the framework defaults: SSR, CSR, and CSRF
@@ -64,6 +73,29 @@ func DefaultPageOptions() PageOptions {
 		CSRF:          true,
 		TrailingSlash: TrailingSlashNever,
 	}
+}
+
+// Equal reports whether base and other carry the same options. It exists
+// because PageOptions includes a slice (ImageWidths) which the language
+// rejects in == comparisons.
+func (base PageOptions) Equal(other PageOptions) bool {
+	if base.Prerender != other.Prerender ||
+		base.SSR != other.SSR ||
+		base.CSR != other.CSR ||
+		base.SSROnly != other.SSROnly ||
+		base.CSRF != other.CSRF ||
+		base.TrailingSlash != other.TrailingSlash {
+		return false
+	}
+	if len(base.ImageWidths) != len(other.ImageWidths) {
+		return false
+	}
+	for i, w := range base.ImageWidths {
+		if w != other.ImageWidths[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Merge returns base overlaid with override. Each scalar field in

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/binsarjr/sveltego/internal/images"
 	"github.com/binsarjr/sveltego/internal/parser"
 	"github.com/binsarjr/sveltego/internal/routescan"
 	"github.com/binsarjr/sveltego/internal/vite"
@@ -58,6 +59,10 @@ type BuildOptions struct {
 	Provenance bool
 	// NoClient skips emitting Vite client entry files and vite.config.gen.js.
 	NoClient bool
+	// ImageWidths overrides the default variant widths used by the
+	// build-time image pipeline for <Image> elements. Empty applies the
+	// framework default (320, 640, 1280); see images.DefaultWidths.
+	ImageWidths []int
 }
 
 // BuildResult summarizes one [Build] invocation. Routes counts every
@@ -143,6 +148,11 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 		logger.Warn("routescan diagnostic", logKeyDiagnostic, d.String())
 	}
 
+	imageVariants, err := buildImageVariants(opts.ProjectRoot, opts.ImageWidths)
+	if err != nil {
+		return nil, err
+	}
+
 	libDir := filepath.Join(opts.ProjectRoot, "lib")
 	libRefs := 0
 	routeCount := 0
@@ -176,7 +186,7 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 		}
 		switch {
 		case route.HasPage:
-			refs, hasHead, hasSnapshot, err := emitPage(opts.ProjectRoot, outDir, modulePath, route, opts.Release, opts.EnvLookup, opts.Provenance, start)
+			refs, hasHead, hasSnapshot, err := emitPage(opts.ProjectRoot, outDir, modulePath, route, opts.Release, opts.EnvLookup, opts.Provenance, start, imageVariants)
 			if err != nil {
 				return nil, err
 			}
@@ -224,7 +234,7 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 			if i < len(route.LayoutServerFiles) {
 				serverFile = route.LayoutServerFiles[i]
 			}
-			hasHead, err := emitLayout(opts.ProjectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile, opts.Release, opts.EnvLookup, opts.Provenance, start)
+			hasHead, err := emitLayout(opts.ProjectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile, opts.Release, opts.EnvLookup, opts.Provenance, start, imageVariants)
 			if err != nil {
 				return nil, err
 			}
@@ -368,7 +378,7 @@ func serviceWorkerEntry(projectRoot string) string {
 // HeadFn wiring). When release is true, any $lib/dev/** import is a
 // fatal error. lookup is used to resolve env.Static* calls to literal
 // values at build time.
-func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRoute, release bool, lookup EnvLookup, provenance bool, generatedAt time.Time) (int, bool, bool, error) {
+func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRoute, release bool, lookup EnvLookup, provenance bool, generatedAt time.Time, imageVariants map[string]images.Result) (int, bool, bool, error) {
 	pageName := "+page.svelte"
 	if route.HasReset {
 		pageName = "+page@" + route.ResetTarget + ".svelte"
@@ -403,6 +413,7 @@ func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRou
 		Provenance:    provenance,
 		SourceContent: srcForHash,
 		GeneratedAt:   generatedAt,
+		ImageVariants: imageVariants,
 	}
 	if route.HasPageServer {
 		opts.ServerFilePath = filepath.Join(route.Dir, "page.server.go")
@@ -709,7 +720,7 @@ func emitErrorPage(projectRoot, outDir, errorDir, pkgPath, pkgName string, prove
 // struct return is used to infer LayoutData fields. When release is true,
 // any $lib/dev/** import is a fatal error. lookup resolves env.Static*
 // calls to literal string values at build time.
-func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile string, release bool, lookup EnvLookup, provenance bool, generatedAt time.Time) (bool, error) {
+func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile string, release bool, lookup EnvLookup, provenance bool, generatedAt time.Time, imageVariants map[string]images.Result) (bool, error) {
 	layoutPath, err := resolveLayoutSource(layoutDir)
 	if err != nil {
 		return false, err
@@ -738,6 +749,7 @@ func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile str
 		Provenance:     provenance,
 		SourceContent:  src,
 		GeneratedAt:    generatedAt,
+		ImageVariants:  imageVariants,
 	})
 	if err != nil {
 		return false, fmt.Errorf("codegen: generate %s: %w", layoutPath, err)

--- a/packages/sveltego/internal/codegen/cascade_test.go
+++ b/packages/sveltego/internal/codegen/cascade_test.go
@@ -24,7 +24,7 @@ func TestResolvePageOptions_cascade(t *testing.T) {
 	}
 
 	rootDefaults := kit.PageOptions{SSR: true, CSR: true, CSRF: true, TrailingSlash: kit.TrailingSlashAlways}
-	if got["/"] != rootDefaults {
+	if !got["/"].Equal(rootDefaults) {
 		t.Errorf("/ effective options = %+v, want %+v", got["/"], rootDefaults)
 	}
 
@@ -36,7 +36,7 @@ func TestResolvePageOptions_cascade(t *testing.T) {
 		CSRF:          true,
 		TrailingSlash: kit.TrailingSlashIgnore,
 	}
-	if got["/dash/billing"] != billing {
+	if !got["/dash/billing"].Equal(billing) {
 		t.Errorf("/dash/billing effective options = %+v, want %+v", got["/dash/billing"], billing)
 	}
 }

--- a/packages/sveltego/internal/codegen/codegen.go
+++ b/packages/sveltego/internal/codegen/codegen.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/binsarjr/sveltego/internal/ast"
+	"github.com/binsarjr/sveltego/internal/images"
 )
 
 // Options configures Generate.
@@ -39,6 +40,10 @@ type Options struct {
 	// GeneratedAt pins the timestamp in the file-level banner. Zero uses
 	// time.Now() so tests can pass a fixed value for deterministic output.
 	GeneratedAt time.Time
+	// ImageVariants maps each <Image src=...> path the build pipeline
+	// resolved to its generated variant set. The codegen-time lookup
+	// rejects unknown sources with a clear diagnostic.
+	ImageVariants map[string]images.Result
 }
 
 // LayoutOptions configures GenerateLayout.
@@ -57,6 +62,8 @@ type LayoutOptions struct {
 	SourceContent []byte
 	// GeneratedAt mirrors Options.GeneratedAt for layout files.
 	GeneratedAt time.Time
+	// ImageVariants mirrors Options.ImageVariants for layout files.
+	ImageVariants map[string]images.Result
 }
 
 // ErrorPageOptions configures GenerateErrorPage.
@@ -118,6 +125,7 @@ func Generate(frag *ast.Fragment, opts Options) ([]byte, error) {
 	var b Builder
 	b.provenance = opts.Provenance
 	b.srcPath = opts.Filename
+	b.imageVariants = opts.ImageVariants
 	if opts.Filename != "" {
 		ts := opts.GeneratedAt
 		if ts.IsZero() {
@@ -226,6 +234,7 @@ func GenerateLayout(frag *ast.Fragment, opts LayoutOptions) ([]byte, error) {
 	b.hasChildren = true
 	b.provenance = opts.Provenance
 	b.srcPath = opts.Filename
+	b.imageVariants = opts.ImageVariants
 	if opts.Filename != "" {
 		ts := opts.GeneratedAt
 		if ts.IsZero() {

--- a/packages/sveltego/internal/codegen/element.go
+++ b/packages/sveltego/internal/codegen/element.go
@@ -34,6 +34,10 @@ func emitElement(b *Builder, e *ast.Element) {
 		emitSvelteComponent(b, e)
 		return
 	}
+	if e.Name == imageElementName {
+		emitImage(b, e)
+		return
+	}
 	if isComponentName(e.Name) {
 		if strings.Contains(e.Name, ".") {
 			emitNestedComponent(b, e)

--- a/packages/sveltego/internal/codegen/emit.go
+++ b/packages/sveltego/internal/codegen/emit.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/binsarjr/sveltego/internal/images"
 )
 
 // Builder accumulates generated Go source with line and indentation
@@ -50,6 +52,10 @@ type Builder struct {
 	// srcPath is the relative .svelte source path written into span
 	// comments. Set once from Options.Filename before the first emit.
 	srcPath string
+	// imageVariants maps each <Image src=...> path to its build-time
+	// generated variant set. emitImage consults this table to resolve
+	// the hashed URLs and intrinsic dimensions written into the page.
+	imageVariants map[string]images.Result
 }
 
 // Line appends s as one indented source line.

--- a/packages/sveltego/internal/codegen/image.go
+++ b/packages/sveltego/internal/codegen/image.go
@@ -1,0 +1,317 @@
+package codegen
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/binsarjr/sveltego/internal/ast"
+	"github.com/binsarjr/sveltego/internal/images"
+)
+
+// imageElementName is the sveltego built-in component for build-time
+// responsive images. It is intercepted before component dispatch in
+// emitElement so user-written `Image.svelte` files in src/lib/ never
+// shadow it; the name is reserved.
+const imageElementName = "Image"
+
+// emitImage lowers a `<Image src="..." alt="..." width="..." />` element
+// to a static `<img>` tag whose src/srcset point at the build-time
+// generated variants. The src attribute is required and must be a
+// static literal — dynamic `src={...}` is rejected because variant
+// generation is a build-time-only operation in v1.
+func emitImage(b *Builder, e *ast.Element) {
+	src, ok := imageSrcLiteral(e)
+	if !ok {
+		b.Fail(&CodegenError{
+			Pos: e.P,
+			Msg: `<Image> requires a static src="..." attribute (dynamic src is not supported in v1)`,
+		})
+		return
+	}
+	res, ok := b.imageVariants[src]
+	if !ok {
+		b.Fail(&CodegenError{
+			Pos: e.P,
+			Msg: "<Image> source " + strconv.Quote(src) + " was not found in static/assets/ at build time",
+		})
+		return
+	}
+	if len(res.Variants) == 0 {
+		b.Fail(&CodegenError{
+			Pos: e.P,
+			Msg: "<Image> source " + strconv.Quote(src) + " produced no variants",
+		})
+		return
+	}
+
+	sortedVariants := make([]images.Variant, len(res.Variants))
+	copy(sortedVariants, res.Variants)
+	sort.Slice(sortedVariants, func(i, j int) bool {
+		return sortedVariants[i].Width < sortedVariants[j].Width
+	})
+
+	// The fallback `src` always points at the largest variant so non-srcset
+	// browsers (and lighthouse) see a real, full-resolution URL.
+	fallback := sortedVariants[len(sortedVariants)-1]
+
+	width, height, hasWidth, hasHeight := imageDims(e, res)
+	loading, decoding := imageLoadingHints(e)
+
+	var sb strings.Builder
+	sb.WriteString(`<img src="`)
+	sb.WriteString(escapeAttrLiteral(fallback.URL))
+	sb.WriteString(`"`)
+
+	if len(sortedVariants) > 1 {
+		sb.WriteString(` srcset="`)
+		for i, v := range sortedVariants {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(escapeAttrLiteral(v.URL))
+			sb.WriteString(" ")
+			sb.WriteString(strconv.Itoa(v.Width))
+			sb.WriteString("w")
+		}
+		sb.WriteString(`"`)
+	}
+
+	if hasWidth {
+		sb.WriteString(` width="`)
+		sb.WriteString(strconv.Itoa(width))
+		sb.WriteString(`"`)
+	}
+	if hasHeight {
+		sb.WriteString(` height="`)
+		sb.WriteString(strconv.Itoa(height))
+		sb.WriteString(`"`)
+	}
+
+	for _, a := range e.Attributes {
+		if !imagePassthroughAttr(a) {
+			continue
+		}
+		emitImagePassthroughStatic(&sb, &a)
+	}
+
+	hasDynamicPassthrough := false
+	for _, a := range e.Attributes {
+		if !imagePassthroughAttr(a) {
+			continue
+		}
+		if _, ok := a.Value.(*ast.StaticValue); ok {
+			continue
+		}
+		if a.Value != nil {
+			hasDynamicPassthrough = true
+			break
+		}
+	}
+
+	if !hasDynamicPassthrough {
+		sb.WriteString(` loading="`)
+		sb.WriteString(loading)
+		sb.WriteString(`" decoding="`)
+		sb.WriteString(decoding)
+		sb.WriteString(`">`)
+		b.Linef("w.WriteString(%s)", quoteGo(sb.String()))
+		return
+	}
+
+	b.Linef("w.WriteString(%s)", quoteGo(sb.String()))
+	for _, a := range e.Attributes {
+		if !imagePassthroughAttr(a) {
+			continue
+		}
+		emitImagePassthroughDynamic(b, &a)
+	}
+	b.Linef("w.WriteString(%s)", quoteGo(` loading="`+loading+`" decoding="`+decoding+`">`))
+}
+
+// imageSrcLiteral returns the static src= value on an <Image> element
+// and whether one was found. Dynamic src={...} forms return ok=false so
+// emitImage can surface a clear diagnostic.
+func imageSrcLiteral(e *ast.Element) (string, bool) {
+	for i := range e.Attributes {
+		a := &e.Attributes[i]
+		if a.Name != "src" {
+			continue
+		}
+		if a.Kind != ast.AttrStatic {
+			return "", false
+		}
+		if v, ok := a.Value.(*ast.StaticValue); ok {
+			return strings.TrimPrefix(v.Value, "/"), true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// imageDims returns the width/height pair to emit on the <img>. User-
+// supplied static values win; otherwise the intrinsic dimensions of the
+// source image flow through. Returning has-flags lets the caller skip
+// the attribute entirely when neither source provided a value (e.g.
+// pre-decode failure paths).
+func imageDims(e *ast.Element, res images.Result) (w, h int, hasW, hasH bool) {
+	for i := range e.Attributes {
+		a := &e.Attributes[i]
+		if a.Kind != ast.AttrStatic {
+			continue
+		}
+		switch a.Name {
+		case "width":
+			if v, ok := a.Value.(*ast.StaticValue); ok {
+				if n, err := strconv.Atoi(v.Value); err == nil {
+					w = n
+					hasW = true
+				}
+			}
+		case "height":
+			if v, ok := a.Value.(*ast.StaticValue); ok {
+				if n, err := strconv.Atoi(v.Value); err == nil {
+					h = n
+					hasH = true
+				}
+			}
+		}
+	}
+	if !hasW && res.IntrinsicWidth > 0 {
+		w = res.IntrinsicWidth
+		hasW = true
+	}
+	if !hasH && res.IntrinsicHeight > 0 {
+		h = res.IntrinsicHeight
+		hasH = true
+	}
+	return w, h, hasW, hasH
+}
+
+// imageLoadingHints returns the loading and decoding attribute values.
+// Default is loading=lazy, decoding=async. The `eager` boolean prop
+// flips loading to "eager" for above-the-fold imagery; SvelteKit's
+// enhanced-img calls this `priority`, but `eager` mirrors the actual
+// HTML attribute value and reads cleaner in templates.
+func imageLoadingHints(e *ast.Element) (loading, decoding string) {
+	loading = "lazy"
+	decoding = "async"
+	for i := range e.Attributes {
+		a := &e.Attributes[i]
+		if a.Name == "eager" || a.Name == "priority" {
+			loading = "eager"
+		}
+	}
+	return loading, decoding
+}
+
+// imagePassthroughAttr reports whether attr a should flow through to
+// the emitted <img>. We pass alt, sizes, class, id, title, style, role,
+// aria-* and data-*; src/width/height/loading/decoding/eager/priority
+// are handled explicitly above. Dynamic class/style/etc. are not yet
+// supported; treat them as static-only for v1 to keep the lowering
+// simple. Class and style directives on <Image> are similarly ignored.
+func imagePassthroughAttr(a ast.Attribute) bool {
+	switch a.Name {
+	case "src", "width", "height", "loading", "decoding", "eager", "priority":
+		return false
+	}
+	switch a.Kind {
+	case ast.AttrEventHandler, ast.AttrBind, ast.AttrUse,
+		ast.AttrClassDirective, ast.AttrStyleDirective, ast.AttrLet:
+		return false
+	}
+	return true
+}
+
+// emitImagePassthroughStatic appends a static attribute (and the
+// surrounding space + name=) to the in-progress static head buffer.
+// Dynamic forms are deferred to emitImagePassthroughDynamic.
+func emitImagePassthroughStatic(sb *strings.Builder, a *ast.Attribute) {
+	if a.Value == nil {
+		sb.WriteByte(' ')
+		sb.WriteString(a.Name)
+		return
+	}
+	if v, ok := a.Value.(*ast.StaticValue); ok {
+		sb.WriteByte(' ')
+		sb.WriteString(a.Name)
+		sb.WriteString(`="`)
+		sb.WriteString(escapeAttrLiteral(v.Value))
+		sb.WriteString(`"`)
+	}
+}
+
+// emitImagePassthroughDynamic emits the codegen lines required to
+// stream a dynamic alt={...} or sizes={...} value into the open tag.
+// Because the static head is already flushed by the caller, this
+// appends to the running output via b.Line directly.
+func emitImagePassthroughDynamic(b *Builder, a *ast.Attribute) {
+	switch v := a.Value.(type) {
+	case *ast.DynamicValue:
+		b.Linef("w.WriteString(%s)", quoteGo(" "+a.Name+`="`))
+		b.Linef("w.WriteEscapeAttr(%s)", v.Expr)
+		b.Linef("w.WriteString(%s)", quoteGo(`"`))
+	case *ast.InterpolatedValue:
+		b.Linef("w.WriteString(%s)", quoteGo(" "+a.Name+`="`))
+		for _, part := range v.Parts {
+			switch p := part.(type) {
+			case *ast.Text:
+				if p.Value != "" {
+					b.Linef("w.WriteString(%s)", quoteGo(escapeAttrLiteral(p.Value)))
+				}
+			case *ast.Mustache:
+				b.Linef("w.WriteEscapeAttr(%s)", p.Expr)
+			}
+		}
+		b.Linef("w.WriteString(%s)", quoteGo(`"`))
+	}
+}
+
+// collectImageSources walks a parsed fragment and returns every static
+// src referenced by an `<Image>` element. The result is deduplicated and
+// sorted so build-time variant generation is deterministic.
+func collectImageSources(frag *ast.Fragment) []string {
+	if frag == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var visit func([]ast.Node)
+	visit = func(nodes []ast.Node) {
+		for _, n := range nodes {
+			switch v := n.(type) {
+			case *ast.Element:
+				if v.Name == imageElementName {
+					if src, ok := imageSrcLiteral(v); ok {
+						seen[src] = struct{}{}
+					}
+				}
+				visit(v.Children)
+			case *ast.IfBlock:
+				visit(v.Then)
+				for _, eb := range v.Elifs {
+					visit(eb.Body)
+				}
+				visit(v.Else)
+			case *ast.EachBlock:
+				visit(v.Body)
+				visit(v.Else)
+			case *ast.AwaitBlock:
+				visit(v.Pending)
+				visit(v.Then)
+				visit(v.Catch)
+			case *ast.KeyBlock:
+				visit(v.Body)
+			case *ast.SnippetBlock:
+				visit(v.Body)
+			}
+		}
+	}
+	visit(frag.Children)
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/packages/sveltego/internal/codegen/image_build_test.go
+++ b/packages/sveltego/internal/codegen/image_build_test.go
@@ -1,0 +1,141 @@
+package codegen
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBuild_ImageVariantsEndToEnd exercises the build pipeline with one
+// page that references a real JPEG under static/assets/. The pipeline
+// must produce sized variants on disk and emit the matching <img>
+// markup with srcset into the generated page.
+func TestBuild_ImageVariantsEndToEnd(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.23\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "+page.svelte"),
+		`<Image src="hero.jpg" alt="Hero" width="800" height="600" />`+"\n")
+
+	writeJPEGFixture(t, filepath.Join(root, "static", "assets", "hero.jpg"), 1600, 1200)
+
+	res, err := Build(BuildOptions{
+		ProjectRoot: root,
+		NoClient:    true,
+		ImageWidths: []int{320, 640, 1280},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if res.Routes != 1 {
+		t.Errorf("Routes = %d, want 1", res.Routes)
+	}
+
+	stageDir := filepath.Join(root, "static", "_app", "immutable", "assets")
+	entries, err := os.ReadDir(stageDir)
+	if err != nil {
+		t.Fatalf("read stage dir: %v", err)
+	}
+	// 4 variants: 320, 640, 1280, plus intrinsic 1600. Existing assets
+	// pipeline may also stage the original hero.jpg via static/assets
+	// hashing — count only image-pipeline outputs.
+	wantVariants := []string{".320.jpg", ".640.jpg", ".1280.jpg", ".1600.jpg"}
+	for _, want := range wantVariants {
+		found := false
+		for _, e := range entries {
+			if strings.Contains(e.Name(), want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("variant ending in %q not found under %s", want, stageDir)
+		}
+	}
+
+	pageBytes, err := os.ReadFile(filepath.Join(root, ".gen", "routes", "page.gen.go"))
+	if err != nil {
+		t.Fatalf("read page.gen.go: %v", err)
+	}
+	body := string(pageBytes)
+	for _, want := range []string{
+		`width="800"`,
+		`height="600"`,
+		`alt="Hero"`,
+		`loading="lazy"`,
+		`decoding="async"`,
+		`srcset=`,
+		`320w`,
+		`640w`,
+		`1280w`,
+		`1600w`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page.gen.go missing %q:\n%s", want, body)
+		}
+	}
+
+	// Verify the actual variant file is a valid JPEG of the expected width.
+	var anyVariant string
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".640.jpg") {
+			anyVariant = filepath.Join(stageDir, e.Name())
+			break
+		}
+	}
+	if anyVariant == "" {
+		t.Fatal("no .640.jpg variant found")
+	}
+	f, err := os.Open(anyVariant)
+	if err != nil {
+		t.Fatalf("open variant: %v", err)
+	}
+	defer f.Close()
+	img, _, err := image.Decode(f)
+	if err != nil {
+		t.Fatalf("decode variant: %v", err)
+	}
+	if got := img.Bounds().Dx(); got != 640 {
+		t.Errorf("variant width = %d, want 640", got)
+	}
+}
+
+// TestBuild_NoImagesShortCircuits confirms a project without <Image>
+// elements does not invoke the image pipeline (no errors when
+// static/assets is missing entirely).
+func TestBuild_NoImagesShortCircuits(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.23\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "+page.svelte"),
+		"<h1>plain</h1>\n")
+	if _, err := Build(BuildOptions{ProjectRoot: root, NoClient: true}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+}
+
+func writeJPEGFixture(t *testing.T, path string, w, h int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 96, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/packages/sveltego/internal/codegen/image_test.go
+++ b/packages/sveltego/internal/codegen/image_test.go
@@ -1,0 +1,263 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/internal/images"
+	"github.com/binsarjr/sveltego/internal/parser"
+)
+
+func TestEmitImage_BasicMarkup(t *testing.T) {
+	t.Parallel()
+	src := []byte(`<Image src="hero.jpg" alt="Logo" width="800" height="600" />` + "\n")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{
+		PackageName: "page",
+		ImageVariants: map[string]images.Result{
+			"hero.jpg": {
+				Source:          "hero.jpg",
+				IntrinsicWidth:  1600,
+				IntrinsicHeight: 1200,
+				Variants: []images.Variant{
+					{Width: 320, Height: 240, URL: "/_app/immutable/assets/hero.deadbeef.320.jpg"},
+					{Width: 640, Height: 480, URL: "/_app/immutable/assets/hero.deadbeef.640.jpg"},
+					{Width: 1280, Height: 960, URL: "/_app/immutable/assets/hero.deadbeef.1280.jpg"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		`src="/_app/immutable/assets/hero.deadbeef.1280.jpg"`,
+		`srcset="/_app/immutable/assets/hero.deadbeef.320.jpg 320w, /_app/immutable/assets/hero.deadbeef.640.jpg 640w, /_app/immutable/assets/hero.deadbeef.1280.jpg 1280w"`,
+		`width="800"`,
+		`height="600"`,
+		`alt="Logo"`,
+		`loading="lazy"`,
+		`decoding="async"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in:\n%s", want, s)
+		}
+	}
+}
+
+func TestEmitImage_EagerOptIn(t *testing.T) {
+	t.Parallel()
+	src := []byte(`<Image src="hero.jpg" alt="" eager />` + "\n")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{
+		PackageName: "page",
+		ImageVariants: map[string]images.Result{
+			"hero.jpg": {
+				Source:          "hero.jpg",
+				IntrinsicWidth:  800,
+				IntrinsicHeight: 600,
+				Variants: []images.Variant{
+					{Width: 800, Height: 600, URL: "/_app/immutable/assets/hero.deadbeef.800.jpg"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `loading="eager"`) {
+		t.Errorf("expected loading=eager, got:\n%s", s)
+	}
+	if strings.Contains(s, `loading="lazy"`) {
+		t.Errorf("expected no loading=lazy, got:\n%s", s)
+	}
+}
+
+func TestEmitImage_IntrinsicDimsFallback(t *testing.T) {
+	t.Parallel()
+	src := []byte(`<Image src="hero.jpg" alt="x" />` + "\n")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{
+		PackageName: "page",
+		ImageVariants: map[string]images.Result{
+			"hero.jpg": {
+				IntrinsicWidth:  1024,
+				IntrinsicHeight: 768,
+				Variants: []images.Variant{
+					{Width: 1024, Height: 768, URL: "/_app/immutable/assets/hero.deadbeef.1024.jpg"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `width="1024"`) {
+		t.Errorf("expected intrinsic width=1024, got:\n%s", s)
+	}
+	if !strings.Contains(s, `height="768"`) {
+		t.Errorf("expected intrinsic height=768, got:\n%s", s)
+	}
+}
+
+func TestEmitImage_SingleVariantNoSrcset(t *testing.T) {
+	t.Parallel()
+	src := []byte(`<Image src="logo.png" alt="" />` + "\n")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{
+		PackageName: "page",
+		ImageVariants: map[string]images.Result{
+			"logo.png": {
+				IntrinsicWidth:  100,
+				IntrinsicHeight: 100,
+				Variants: []images.Variant{
+					{Width: 100, Height: 100, URL: "/_app/immutable/assets/logo.cafe.100.png"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, `srcset=`) {
+		t.Errorf("expected no srcset for single variant, got:\n%s", s)
+	}
+}
+
+func TestEmitImage_DynamicAlt(t *testing.T) {
+	t.Parallel()
+	src := []byte(`<Image src="hero.jpg" alt={data.Title} />` + "\n")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{
+		PackageName: "page",
+		ImageVariants: map[string]images.Result{
+			"hero.jpg": {
+				IntrinsicWidth:  800,
+				IntrinsicHeight: 600,
+				Variants: []images.Variant{
+					{Width: 800, Height: 600, URL: "/_app/immutable/assets/hero.deadbeef.800.jpg"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `w.WriteEscapeAttr(data.Title)`) {
+		t.Errorf("expected dynamic alt emission, got:\n%s", s)
+	}
+}
+
+func TestEmitImage_UnknownSourceFails(t *testing.T) {
+	t.Parallel()
+	src := []byte(`<Image src="missing.jpg" alt="" />` + "\n")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	_, err := Generate(frag, Options{
+		PackageName:   "page",
+		ImageVariants: map[string]images.Result{},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown <Image> src, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing.jpg") {
+		t.Errorf("error should mention source, got: %v", err)
+	}
+}
+
+func TestEmitImage_DynamicSrcRejected(t *testing.T) {
+	t.Parallel()
+	src := []byte(`<Image src={data.Hero} alt="" />` + "\n")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	_, err := Generate(frag, Options{PackageName: "page"})
+	if err == nil {
+		t.Fatal("expected error for dynamic src, got nil")
+	}
+	if !strings.Contains(err.Error(), "dynamic src") {
+		t.Errorf("error should mention dynamic src, got: %v", err)
+	}
+}
+
+func TestCollectImageSources(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+<Image src="a.jpg" />
+<div>
+  {#if Cond}
+    <Image src="b.png" />
+  {:else}
+    <Image src="c.jpg" />
+  {/if}
+</div>
+{#each List as item}
+  <Image src="d.jpg" />
+{/each}
+`)
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	got := collectImageSources(frag)
+	want := []string{"a.jpg", "b.png", "c.jpg", "d.jpg"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestEmitImage_LeadingSlashNormalized(t *testing.T) {
+	t.Parallel()
+	// User can write src="/hero.jpg" or src="hero.jpg"; both must resolve.
+	src := []byte(`<Image src="/hero.jpg" alt="" />` + "\n")
+	frag, errs := parser.Parse(src)
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	out, err := Generate(frag, Options{
+		PackageName: "page",
+		ImageVariants: map[string]images.Result{
+			"hero.jpg": {
+				IntrinsicWidth:  100,
+				IntrinsicHeight: 100,
+				Variants: []images.Variant{
+					{Width: 100, Height: 100, URL: "/_app/immutable/assets/hero.x.100.jpg"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !strings.Contains(string(out), "hero.x.100.jpg") {
+		t.Errorf("expected hashed URL, got:\n%s", out)
+	}
+}

--- a/packages/sveltego/internal/codegen/imagescan.go
+++ b/packages/sveltego/internal/codegen/imagescan.go
@@ -1,0 +1,96 @@
+package codegen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/binsarjr/sveltego/internal/images"
+)
+
+// imageSrcPattern captures the literal src= value on an <Image> opening
+// tag. Only the static double- or single-quoted form is recognized;
+// dynamic src={...} surfaces as a codegen error at emit time so a typo
+// never silently disables the variant pipeline.
+var imageSrcPattern = regexp.MustCompile(`<Image\b[^>]*?\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)')`)
+
+// scanProjectImages walks the project for every .svelte file and
+// returns the deduplicated set of <Image src=...> values. Paths are
+// normalized to forward slashes and stripped of any leading slash so
+// they match the keys produced by the asset pipeline.
+//
+// The walker covers src/routes/, src/lib/, and any other src/ subtree
+// because <Image> may appear in a component imported from anywhere.
+func scanProjectImages(projectRoot string) ([]string, error) {
+	srcRoot := filepath.Join(projectRoot, "src")
+	if _, err := os.Stat(srcRoot); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("codegen: stat %s: %w", srcRoot, err)
+	}
+	seen := make(map[string]struct{})
+	walkErr := filepath.WalkDir(srcRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".svelte") {
+			return nil
+		}
+		body, rerr := os.ReadFile(path) //nolint:gosec // path comes from the WalkDir under projectRoot
+		if rerr != nil {
+			return fmt.Errorf("codegen: read %s: %w", path, rerr)
+		}
+		matches := imageSrcPattern.FindAllSubmatch(body, -1)
+		for _, m := range matches {
+			var src string
+			if len(m[1]) > 0 {
+				src = string(m[1])
+			} else if len(m[2]) > 0 {
+				src = string(m[2])
+			}
+			if src == "" {
+				continue
+			}
+			seen[strings.TrimPrefix(src, "/")] = struct{}{}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// buildImageVariants runs the image pipeline against every <Image> source
+// referenced in the project. An empty source list short-circuits to a
+// nil map so projects with no <Image> elements pay no I/O cost.
+func buildImageVariants(projectRoot string, widths []int) (map[string]images.Result, error) {
+	sources, err := scanProjectImages(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	plan, err := images.Build(images.BuildOptions{
+		StaticDir: filepath.Join(projectRoot, "static"),
+		Sources:   sources,
+		Widths:    widths,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("codegen: build images: %w", err)
+	}
+	return plan.Results, nil
+}

--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -249,7 +249,7 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	if opts.RouteOptions != nil {
 		def := kit.DefaultPageOptions()
 		for _, e := range entries {
-			if v, ok := opts.RouteOptions[e.route.Pattern]; ok && v != def {
+			if v, ok := opts.RouteOptions[e.route.Pattern]; ok && !v.Equal(def) {
 				hasNonDefaultOptions = true
 				break
 			}
@@ -659,7 +659,7 @@ func emitOptionsField(b *Builder, pattern string, routeOptions map[string]kit.Pa
 	if !ok {
 		opts = kit.DefaultPageOptions()
 	}
-	if opts == (kit.DefaultPageOptions()) {
+	if opts.Equal(kit.DefaultPageOptions()) {
 		return
 	}
 	b.Linef("Options: %s,", formatPageOptions(opts))

--- a/packages/sveltego/internal/images/build.go
+++ b/packages/sveltego/internal/images/build.go
@@ -1,0 +1,313 @@
+// Package images implements the build-time pipeline that generates
+// responsive size variants for source images referenced by <Image>
+// elements. The output filenames carry both the source content hash and
+// the target width so a downstream cache-busting URL is stable across
+// builds and unique per (source, width) pair.
+//
+// The encoder set is JPEG and PNG only; WebP and AVIF are intentionally
+// out of scope for v1 to avoid pulling in cgo or third-party encoders.
+// The resampler is stdlib-only (a small bilinear filter implemented in
+// scale.go) so the package keeps Go 1.23 vanilla.
+package images
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/binsarjr/sveltego/exports/kit"
+)
+
+// HashLength is the number of hex characters of SHA-256 used in the
+// staged filename. Eight characters keeps URLs short while making
+// accidental collisions vanishingly rare in a single project.
+const HashLength = 8
+
+// jpegQuality is the libjpeg-equivalent quality factor used for every
+// JPEG variant. 82 is the same default disintegration/imaging chose; it
+// trades ~10% file size for visually-identical output versus 90.
+const jpegQuality = 82
+
+// DefaultWidths is the variant width set used when [BuildOptions.Widths]
+// is empty. The values match the SvelteKit enhanced-img defaults so
+// downstream guidance carries over.
+var DefaultWidths = []int{320, 640, 1280}
+
+// Variant describes one emitted size of a source image. Width and Height
+// are the post-resize pixel dimensions; URL is the hashed public path
+// (e.g. "/_app/immutable/assets/hero.abc12345.640.jpg") served by the
+// runtime static handler.
+type Variant struct {
+	Width  int
+	Height int
+	URL    string
+	Path   string
+}
+
+// Result describes the variant set generated for one source image.
+// Intrinsic{Width,Height} are the source dimensions; Variants is sorted
+// ascending by Width.
+type Result struct {
+	Source          string
+	IntrinsicWidth  int
+	IntrinsicHeight int
+	Variants        []Variant
+}
+
+// BuildOptions configures [Build].
+type BuildOptions struct {
+	// StaticDir is the absolute path to the project's static/ directory.
+	// Source images live under StaticDir/assets/; outputs are staged under
+	// StaticDir/_app/immutable/assets/.
+	StaticDir string
+	// Sources lists forward-slash relative paths under StaticDir/assets/
+	// that <Image> references. Non-image files and missing files surface
+	// as errors so a typo'd src never silently disappears from the page.
+	Sources []string
+	// Widths overrides [DefaultWidths]. Negative or duplicate entries are
+	// dropped; a width >= the intrinsic width is skipped (no upscaling).
+	Widths []int
+	// Concurrency caps the number of goroutines decoding/encoding in
+	// parallel. Zero defaults to runtime.NumCPU().
+	Concurrency int
+}
+
+// Plan summarizes a [Build] invocation. Results is keyed by source path
+// (the forward-slash relative path supplied in [BuildOptions.Sources]).
+type Plan struct {
+	Results map[string]Result
+}
+
+// Build resizes every entry in opts.Sources to the configured widths and
+// stages the encoded variants under StaticDir/_app/immutable/assets/.
+// Sources are processed concurrently (capped at opts.Concurrency or
+// runtime.NumCPU()); the function returns once every variant has been
+// written or the first error surfaces.
+//
+// Re-running Build is idempotent: identical inputs produce identical
+// hashes and bytes, so the staging directory converges across runs.
+func Build(opts BuildOptions) (Plan, error) {
+	if opts.StaticDir == "" {
+		return Plan{}, errors.New("images: empty StaticDir")
+	}
+	if !filepath.IsAbs(opts.StaticDir) {
+		return Plan{}, fmt.Errorf("images: StaticDir must be absolute (got %q)", opts.StaticDir)
+	}
+
+	widths := normalizeWidths(opts.Widths)
+	if len(widths) == 0 {
+		widths = DefaultWidths
+	}
+
+	srcRoot := filepath.Join(opts.StaticDir, "assets")
+	stageRoot := filepath.Join(opts.StaticDir, "_app", "immutable", "assets")
+	if err := os.MkdirAll(stageRoot, 0o755); err != nil {
+		return Plan{}, fmt.Errorf("images: mkdir %s: %w", stageRoot, err)
+	}
+
+	conc := opts.Concurrency
+	if conc <= 0 {
+		conc = runtime.NumCPU()
+	}
+	if conc > len(opts.Sources) && len(opts.Sources) > 0 {
+		conc = len(opts.Sources)
+	}
+
+	results := make(map[string]Result, len(opts.Sources))
+	var (
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+		errOnce  sync.Once
+		firstErr error
+	)
+	sem := make(chan struct{}, conc)
+	for _, src := range opts.Sources {
+		src := src
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			res, err := processSource(srcRoot, stageRoot, src, widths)
+			if err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+			mu.Lock()
+			results[src] = res
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return Plan{}, firstErr
+	}
+
+	return Plan{Results: results}, nil
+}
+
+// processSource decodes one source image, generates every applicable
+// width variant, and writes them to stageRoot. The original file's
+// content hash seeds every variant's filename so cache-busting is stable
+// across runs.
+func processSource(srcRoot, stageRoot, src string, widths []int) (Result, error) {
+	if strings.Contains(src, "..") {
+		return Result{}, fmt.Errorf("images: source %q contains path traversal", src)
+	}
+	abs := filepath.Join(srcRoot, filepath.FromSlash(src))
+	f, err := os.Open(abs) //nolint:gosec // path is validated under srcRoot
+	if err != nil {
+		return Result{}, fmt.Errorf("images: open %s: %w", abs, err)
+	}
+	defer f.Close()
+
+	hash, err := hashReader(f)
+	if err != nil {
+		return Result{}, fmt.Errorf("images: hash %s: %w", abs, err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return Result{}, fmt.Errorf("images: seek %s: %w", abs, err)
+	}
+
+	img, format, err := image.Decode(f)
+	if err != nil {
+		return Result{}, fmt.Errorf("images: decode %s: %w", abs, err)
+	}
+	if format != "jpeg" && format != "png" {
+		return Result{}, fmt.Errorf("images: %s: unsupported format %q (only jpeg and png in v1)", abs, format)
+	}
+
+	intrinsic := img.Bounds().Size()
+	stem := strings.TrimSuffix(filepath.Base(src), filepath.Ext(src))
+
+	variants := make([]Variant, 0, len(widths)+1)
+	// Always emit the intrinsic-size variant so the <img src=...> can fall
+	// back to a stable URL even when every configured width upscales.
+	intrinsicV, err := emitVariant(stageRoot, stem, hash, format, img, intrinsic.X, intrinsic.X, intrinsic.Y)
+	if err != nil {
+		return Result{}, err
+	}
+	variants = append(variants, intrinsicV)
+
+	for _, w := range widths {
+		if w >= intrinsic.X {
+			continue
+		}
+		h := scaledHeight(intrinsic.X, intrinsic.Y, w)
+		resized := scaleBilinear(img, w, h)
+		v, err := emitVariant(stageRoot, stem, hash, format, resized, w, w, h)
+		if err != nil {
+			return Result{}, err
+		}
+		variants = append(variants, v)
+	}
+
+	sort.Slice(variants, func(i, j int) bool { return variants[i].Width < variants[j].Width })
+
+	return Result{
+		Source:          src,
+		IntrinsicWidth:  intrinsic.X,
+		IntrinsicHeight: intrinsic.Y,
+		Variants:        variants,
+	}, nil
+}
+
+// emitVariant encodes one resized (or intrinsic-size) image to the
+// staging directory and returns the variant descriptor.
+func emitVariant(stageRoot, stem, hash, format string, img image.Image, width, w, h int) (Variant, error) {
+	ext := "." + format
+	if format == "jpeg" {
+		ext = ".jpg"
+	}
+	name := stem + "." + hash + "." + strconv.Itoa(width) + ext
+	abs := filepath.Join(stageRoot, name)
+	out, err := os.OpenFile(abs, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644) //nolint:gosec // public assets are world-readable on purpose
+	if err != nil {
+		return Variant{}, fmt.Errorf("images: create %s: %w", abs, err)
+	}
+	if encErr := encodeImage(out, img, format); encErr != nil {
+		_ = out.Close()
+		return Variant{}, encErr
+	}
+	if err := out.Close(); err != nil {
+		return Variant{}, fmt.Errorf("images: close %s: %w", abs, err)
+	}
+	return Variant{
+		Width:  w,
+		Height: h,
+		URL:    kit.DefaultAssetsImmutablePrefix + name,
+		Path:   abs,
+	}, nil
+}
+
+// encodeImage dispatches to the right encoder for format. format must be
+// either "jpeg" or "png"; the caller checks this upstream.
+func encodeImage(w io.Writer, img image.Image, format string) error {
+	switch format {
+	case "jpeg":
+		if err := jpeg.Encode(w, img, &jpeg.Options{Quality: jpegQuality}); err != nil {
+			return fmt.Errorf("images: encode jpeg: %w", err)
+		}
+	case "png":
+		enc := png.Encoder{CompressionLevel: png.BestCompression}
+		if err := enc.Encode(w, img); err != nil {
+			return fmt.Errorf("images: encode png: %w", err)
+		}
+	default:
+		return fmt.Errorf("images: unsupported format %q", format)
+	}
+	return nil
+}
+
+// scaledHeight returns the height that preserves the source aspect ratio
+// when resizing to targetWidth. Rounds to nearest int.
+func scaledHeight(srcW, srcH, targetW int) int {
+	if srcW == 0 {
+		return targetW
+	}
+	return int(float64(targetW)*float64(srcH)/float64(srcW) + 0.5)
+}
+
+// hashReader returns the first [HashLength] hex characters of the
+// SHA-256 of r. Reading is streaming so very large source files do not
+// pull the whole file into memory.
+func hashReader(r io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil))[:HashLength], nil
+}
+
+// normalizeWidths sorts, deduplicates, and drops non-positive entries.
+func normalizeWidths(widths []int) []int {
+	if len(widths) == 0 {
+		return nil
+	}
+	seen := make(map[int]struct{}, len(widths))
+	out := make([]int, 0, len(widths))
+	for _, w := range widths {
+		if w <= 0 {
+			continue
+		}
+		if _, ok := seen[w]; ok {
+			continue
+		}
+		seen[w] = struct{}{}
+		out = append(out, w)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/packages/sveltego/internal/images/build_test.go
+++ b/packages/sveltego/internal/images/build_test.go
@@ -1,0 +1,204 @@
+package images
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuild_GeneratesVariantsBelowIntrinsic(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJPEG(t, filepath.Join(root, "assets", "hero.jpg"), 1024, 768)
+
+	plan, err := Build(BuildOptions{
+		StaticDir: root,
+		Sources:   []string{"hero.jpg"},
+		Widths:    []int{320, 640, 1280},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	res, ok := plan.Results["hero.jpg"]
+	if !ok {
+		t.Fatalf("Results missing hero.jpg: %#v", plan.Results)
+	}
+	if res.IntrinsicWidth != 1024 || res.IntrinsicHeight != 768 {
+		t.Fatalf("intrinsic = %dx%d, want 1024x768", res.IntrinsicWidth, res.IntrinsicHeight)
+	}
+	// 1280 is >= 1024, must be skipped. 320, 640 generated, plus intrinsic 1024.
+	wantWidths := []int{320, 640, 1024}
+	if len(res.Variants) != len(wantWidths) {
+		t.Fatalf("variants = %d, want %d (%+v)", len(res.Variants), len(wantWidths), res.Variants)
+	}
+	for i, w := range wantWidths {
+		if res.Variants[i].Width != w {
+			t.Errorf("variants[%d].Width = %d, want %d", i, res.Variants[i].Width, w)
+		}
+		if _, err := os.Stat(res.Variants[i].Path); err != nil {
+			t.Errorf("variants[%d].Path missing: %v", i, err)
+		}
+	}
+	// Aspect ratio preserved: 320 wide -> 240 tall.
+	if got := res.Variants[0].Height; got != 240 {
+		t.Errorf("variants[0].Height = %d, want 240", got)
+	}
+}
+
+func TestBuild_PNGSource(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writePNG(t, filepath.Join(root, "assets", "logo.png"), 800, 400)
+
+	plan, err := Build(BuildOptions{
+		StaticDir: root,
+		Sources:   []string{"logo.png"},
+		Widths:    []int{320},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	res := plan.Results["logo.png"]
+	if len(res.Variants) != 2 {
+		t.Fatalf("variants = %d, want 2 (320 + intrinsic 800)", len(res.Variants))
+	}
+	for _, v := range res.Variants {
+		if !strings.HasSuffix(v.Path, ".png") {
+			t.Errorf("variant path %q should end with .png", v.Path)
+		}
+	}
+}
+
+func TestBuild_DefaultWidths(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJPEG(t, filepath.Join(root, "assets", "wide.jpg"), 2000, 1000)
+
+	plan, err := Build(BuildOptions{
+		StaticDir: root,
+		Sources:   []string{"wide.jpg"},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	res := plan.Results["wide.jpg"]
+	// DefaultWidths = 320, 640, 1280 — all below 2000. Plus intrinsic.
+	wantWidths := []int{320, 640, 1280, 2000}
+	if len(res.Variants) != len(wantWidths) {
+		t.Fatalf("variants = %d, want %d", len(res.Variants), len(wantWidths))
+	}
+	for i, w := range wantWidths {
+		if res.Variants[i].Width != w {
+			t.Errorf("variants[%d].Width = %d, want %d", i, res.Variants[i].Width, w)
+		}
+	}
+}
+
+func TestBuild_MissingFileFails(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "assets"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, err := Build(BuildOptions{
+		StaticDir: root,
+		Sources:   []string{"missing.jpg"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing source, got nil")
+	}
+}
+
+func TestBuild_IdempotentURLs(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJPEG(t, filepath.Join(root, "assets", "pic.jpg"), 800, 600)
+
+	a, err := Build(BuildOptions{StaticDir: root, Sources: []string{"pic.jpg"}, Widths: []int{320}})
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	b, err := Build(BuildOptions{StaticDir: root, Sources: []string{"pic.jpg"}, Widths: []int{320}})
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if a.Results["pic.jpg"].Variants[0].URL != b.Results["pic.jpg"].Variants[0].URL {
+		t.Errorf("URLs not stable: %q vs %q", a.Results["pic.jpg"].Variants[0].URL, b.Results["pic.jpg"].Variants[0].URL)
+	}
+}
+
+func TestBuild_RejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "assets"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, err := Build(BuildOptions{
+		StaticDir: root,
+		Sources:   []string{"../../etc/passwd.jpg"},
+	})
+	if err == nil {
+		t.Fatal("expected error on path traversal, got nil")
+	}
+}
+
+func TestNormalizeWidths(t *testing.T) {
+	t.Parallel()
+	got := normalizeWidths([]int{640, 320, 640, -10, 0, 1280})
+	want := []int{320, 640, 1280}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func writeJPEG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 128, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func writePNG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: uint8(x % 256), B: uint8(y % 256), A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/packages/sveltego/internal/images/scale.go
+++ b/packages/sveltego/internal/images/scale.go
@@ -1,0 +1,77 @@
+package images
+
+import "image"
+
+// scaleBilinear returns a new RGBA image that is src downscaled to
+// (dstW, dstH) using bilinear interpolation. The implementation is
+// stdlib-only so the package keeps Go 1.23 vanilla; for v1's
+// build-time-only resampling at 320/640/1280-wide targets, bilinear
+// quality is well above acceptable.
+//
+// Upscaling is allowed but the caller is expected to gate it (see
+// processSource which skips widths >= the intrinsic width).
+func scaleBilinear(src image.Image, dstW, dstH int) image.Image {
+	if dstW <= 0 || dstH <= 0 {
+		return src
+	}
+	srcBounds := src.Bounds()
+	srcW := srcBounds.Dx()
+	srcH := srcBounds.Dy()
+	if srcW == 0 || srcH == 0 {
+		return src
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, dstW, dstH))
+
+	// xRatio/yRatio map the destination pixel center back into the source
+	// coordinate space. Subtracting one from the source extents and the
+	// destination extents keeps the corner samples aligned to the corner
+	// pixels rather than off-grid by half a pixel.
+	xRatio := float64(srcW-1) / float64(dstW)
+	yRatio := float64(srcH-1) / float64(dstH)
+
+	for y := 0; y < dstH; y++ {
+		fy := float64(y) * yRatio
+		y0 := int(fy)
+		y1 := y0 + 1
+		if y1 >= srcH {
+			y1 = srcH - 1
+		}
+		dy := fy - float64(y0)
+		for x := 0; x < dstW; x++ {
+			fx := float64(x) * xRatio
+			x0 := int(fx)
+			x1 := x0 + 1
+			if x1 >= srcW {
+				x1 = srcW - 1
+			}
+			dx := fx - float64(x0)
+
+			c00r, c00g, c00b, c00a := src.At(srcBounds.Min.X+x0, srcBounds.Min.Y+y0).RGBA()
+			c10r, c10g, c10b, c10a := src.At(srcBounds.Min.X+x1, srcBounds.Min.Y+y0).RGBA()
+			c01r, c01g, c01b, c01a := src.At(srcBounds.Min.X+x0, srcBounds.Min.Y+y1).RGBA()
+			c11r, c11g, c11b, c11a := src.At(srcBounds.Min.X+x1, srcBounds.Min.Y+y1).RGBA()
+
+			r := bilerp(c00r, c10r, c01r, c11r, dx, dy)
+			g := bilerp(c00g, c10g, c01g, c11g, dx, dy)
+			b := bilerp(c00b, c10b, c01b, c11b, dx, dy)
+			a := bilerp(c00a, c10a, c01a, c11a, dx, dy)
+
+			off := dst.PixOffset(x, y)
+			dst.Pix[off+0] = uint8(r >> 8)
+			dst.Pix[off+1] = uint8(g >> 8)
+			dst.Pix[off+2] = uint8(b >> 8)
+			dst.Pix[off+3] = uint8(a >> 8)
+		}
+	}
+	return dst
+}
+
+// bilerp performs bilinear interpolation between four 16-bit channel
+// samples, with weights dx (column) and dy (row), and returns the
+// interpolated 16-bit value. Operating on the full 16-bit channel keeps
+// resampling precision higher than collapsing to 8 bits up front.
+func bilerp(c00, c10, c01, c11 uint32, dx, dy float64) uint32 {
+	top := float64(c00)*(1-dx) + float64(c10)*dx
+	bot := float64(c01)*(1-dx) + float64(c11)*dx
+	return uint32(top*(1-dy) + bot*dy + 0.5)
+}

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -296,7 +296,7 @@ func isDataJSONRequest(r *http.Request) bool {
 // together — used here as a proxy for "no options were resolved" so
 // the legacy render path stays the default for older manifests.
 func optionsAllowSSR(opts kit.PageOptions) bool {
-	if opts == (kit.PageOptions{}) {
+	if opts.Equal(kit.PageOptions{}) {
 		return true
 	}
 	return opts.SSR


### PR DESCRIPTION
## Summary

Closes #92. Implements a build-time responsive image pipeline for `<Image>` elements.

- `<Image src="hero.jpg" alt="..." width="800" height="600" />` lowers to a static `<img>` with content-hashed `src` + `srcset` pointing at sized variants.
- Variants generated under `static/_app/immutable/assets/` using stdlib-only encoders (`image/jpeg`, `image/png`) and a bilinear resampler.
- Parallel encode capped at `runtime.NumCPU()`.
- `BuildOptions.ImageWidths` / `kit.PageOptions.ImageWidths` configure widths (default `320, 640, 1280`).
- `loading="lazy"` default; `eager` (or `priority`) prop opts above-the-fold imagery into `loading="eager"`.
- `decoding="async"` always.
- Intrinsic-width fallback: omit `width=`/`height=` and the build pipeline reads them from the source bytes.

## Out of scope (v1)

- AVIF / WebP encoding (decoder-only in stdlib; tracked as follow-up).
- CDN integration.
- LQIP / blur-up placeholders.
- Client-side responsive image polyfill.

## Sample output

For `<Image src="hero.jpg" alt="Logo" width="800" height="600" sizes="(min-width:768px) 50vw, 100vw" />`:

```html
<img src="/_app/immutable/assets/hero.deadbeef.1280.jpg"
     srcset="/_app/immutable/assets/hero.deadbeef.320.jpg 320w,
             /_app/immutable/assets/hero.deadbeef.640.jpg 640w,
             /_app/immutable/assets/hero.deadbeef.1280.jpg 1280w"
     width="800" height="600"
     alt="Logo"
     sizes="(min-width:768px) 50vw, 100vw"
     loading="lazy" decoding="async">
```

## API change

`kit.PageOptions` gained an `ImageWidths []int` field. Slices break `==`, so `PageOptions` lost direct struct comparability. Added an `Equal()` method and updated the two internal callers (`internal/codegen/manifest.go`, `server/pipeline.go`) to use it. No external API broke.

## Test plan

- [x] `go test ./internal/images/` — 7 unit tests for resize, format dispatch, hashing, idempotence, traversal rejection.
- [x] `go test ./internal/codegen/ -run TestEmitImage` — 8 emitter tests covering basic markup, eager opt-in, intrinsic dims, single-variant short-circuit, dynamic alt, unknown source rejection, dynamic-src rejection, leading-slash normalization.
- [x] `go test ./internal/codegen/ -run TestBuild_Image` — end-to-end build with a real JPEG fixture: variants land on disk at the right pixel widths, `<img>` markup carries the full srcset.
- [x] `go test ./...` — full workspace 1267 tests pass.
- [x] `go test -race ./internal/codegen/ ./internal/images/` — race detector clean.
- [x] `go vet ./...` clean. `gofumpt` clean. `golangci-lint` clean for changed packages (5 pre-existing sloglint hits in `server/cron.go` + `server.go` are unchanged from main).