### PR TITLE
feat(tooling): npm create-sveltego scaffold wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       adapter-static: ${{ steps.filter.outputs.adapter-static }}
       enhanced-img: ${{ steps.filter.outputs.enhanced-img }}
       create-sveltego: ${{ steps.filter.outputs.create-sveltego }}
+      init: ${{ steps.filter.outputs.init }}
       mcp: ${{ steps.filter.outputs.mcp }}
       lsp: ${{ steps.filter.outputs.lsp }}
       playground: ${{ steps.filter.outputs.playground }}
@@ -63,6 +64,7 @@ jobs:
             adapter-static: 'packages/adapter-static/**'
             enhanced-img: 'packages/enhanced-img/**'
             create-sveltego: 'packages/create-sveltego/**'
+            init: 'packages/init/**'
             mcp: 'packages/mcp/**'
             lsp: 'packages/lsp/**'
             playground: ['playgrounds/basic/**', 'playgrounds/blog/**', 'playgrounds/dashboard/**']
@@ -153,6 +155,7 @@ jobs:
           ADAPTER_STATIC: ${{ needs.changes.outputs.adapter-static }}
           ENHANCED_IMG: ${{ needs.changes.outputs.enhanced-img }}
           CREATE_SVELTEGO: ${{ needs.changes.outputs.create-sveltego }}
+          INIT: ${{ needs.changes.outputs.init }}
           MCP: ${{ needs.changes.outputs.mcp }}
           LSP: ${{ needs.changes.outputs.lsp }}
           PLAYGROUND: ${{ needs.changes.outputs.playground }}
@@ -176,6 +179,7 @@ jobs:
                 */packages/adapter-static)       [[ "$ADAPTER_STATIC" == "true" ]]      || continue ;;
                 */packages/enhanced-img)         [[ "$ENHANCED_IMG" == "true" ]]        || continue ;;
                 */packages/create-sveltego)      [[ "$CREATE_SVELTEGO" == "true" ]]     || continue ;;
+                */packages/init)                 [[ "$INIT" == "true" ]]                || continue ;;
                 */packages/mcp)                  [[ "$MCP" == "true" ]]                 || continue ;;
                 */packages/lsp)                  [[ "$LSP" == "true" ]]                 || continue ;;
                 */benchmarks)                    [[ "$BENCHMARKS" == "true" ]]          || continue ;;
@@ -200,6 +204,7 @@ jobs:
           ADAPTER_STATIC: ${{ needs.changes.outputs.adapter-static }}
           ENHANCED_IMG: ${{ needs.changes.outputs.enhanced-img }}
           CREATE_SVELTEGO: ${{ needs.changes.outputs.create-sveltego }}
+          INIT: ${{ needs.changes.outputs.init }}
           MCP: ${{ needs.changes.outputs.mcp }}
           LSP: ${{ needs.changes.outputs.lsp }}
           PLAYGROUND: ${{ needs.changes.outputs.playground }}
@@ -222,6 +227,7 @@ jobs:
                 */packages/adapter-static)       [[ "$ADAPTER_STATIC" == "true" ]]      || continue ;;
                 */packages/enhanced-img)         [[ "$ENHANCED_IMG" == "true" ]]        || continue ;;
                 */packages/create-sveltego)      [[ "$CREATE_SVELTEGO" == "true" ]]     || continue ;;
+                */packages/init)                 [[ "$INIT" == "true" ]]                || continue ;;
                 */packages/mcp)                  [[ "$MCP" == "true" ]]                 || continue ;;
                 */packages/lsp)                  [[ "$LSP" == "true" ]]                 || continue ;;
                 */benchmarks)                    [[ "$BENCHMARKS" == "true" ]]          || continue ;;
@@ -246,6 +252,7 @@ jobs:
           ADAPTER_STATIC: ${{ needs.changes.outputs.adapter-static }}
           ENHANCED_IMG: ${{ needs.changes.outputs.enhanced-img }}
           CREATE_SVELTEGO: ${{ needs.changes.outputs.create-sveltego }}
+          INIT: ${{ needs.changes.outputs.init }}
           MCP: ${{ needs.changes.outputs.mcp }}
           LSP: ${{ needs.changes.outputs.lsp }}
           PLAYGROUND: ${{ needs.changes.outputs.playground }}
@@ -269,6 +276,7 @@ jobs:
                 */packages/adapter-static)       [[ "$ADAPTER_STATIC" == "true" ]]      || continue ;;
                 */packages/enhanced-img)         [[ "$ENHANCED_IMG" == "true" ]]        || continue ;;
                 */packages/create-sveltego)      [[ "$CREATE_SVELTEGO" == "true" ]]     || continue ;;
+                */packages/init)                 [[ "$INIT" == "true" ]]                || continue ;;
                 */packages/mcp)                  [[ "$MCP" == "true" ]]                 || continue ;;
                 */packages/lsp)                  [[ "$LSP" == "true" ]]                 || continue ;;
                 */benchmarks)                    [[ "$BENCHMARKS" == "true" ]]          || continue ;;
@@ -297,6 +305,7 @@ jobs:
           ADAPTER_STATIC: ${{ needs.changes.outputs.adapter-static }}
           ENHANCED_IMG: ${{ needs.changes.outputs.enhanced-img }}
           CREATE_SVELTEGO: ${{ needs.changes.outputs.create-sveltego }}
+          INIT: ${{ needs.changes.outputs.init }}
           MCP: ${{ needs.changes.outputs.mcp }}
           LSP: ${{ needs.changes.outputs.lsp }}
           PLAYGROUND: ${{ needs.changes.outputs.playground }}
@@ -319,6 +328,7 @@ jobs:
                 */packages/adapter-static)       [[ "$ADAPTER_STATIC" == "true" ]]      || continue ;;
                 */packages/enhanced-img)         [[ "$ENHANCED_IMG" == "true" ]]        || continue ;;
                 */packages/create-sveltego)      [[ "$CREATE_SVELTEGO" == "true" ]]     || continue ;;
+                */packages/init)                 [[ "$INIT" == "true" ]]                || continue ;;
                 */packages/mcp)                  [[ "$MCP" == "true" ]]                 || continue ;;
                 */packages/lsp)                  [[ "$LSP" == "true" ]]                 || continue ;;
                 */benchmarks)                    [[ "$BENCHMARKS" == "true" ]]          || continue ;;
@@ -417,6 +427,7 @@ jobs:
           ADAPTER_STATIC: ${{ needs.changes.outputs.adapter-static }}
           ENHANCED_IMG: ${{ needs.changes.outputs.enhanced-img }}
           CREATE_SVELTEGO: ${{ needs.changes.outputs.create-sveltego }}
+          INIT: ${{ needs.changes.outputs.init }}
           MCP: ${{ needs.changes.outputs.mcp }}
           LSP: ${{ needs.changes.outputs.lsp }}
           PLAYGROUND: ${{ needs.changes.outputs.playground }}
@@ -440,6 +451,7 @@ jobs:
                 */packages/adapter-static)       [[ "$ADAPTER_STATIC" == "true" ]]      || continue ;;
                 */packages/enhanced-img)         [[ "$ENHANCED_IMG" == "true" ]]        || continue ;;
                 */packages/create-sveltego)      [[ "$CREATE_SVELTEGO" == "true" ]]     || continue ;;
+                */packages/init)                 [[ "$INIT" == "true" ]]                || continue ;;
                 */packages/mcp)                  [[ "$MCP" == "true" ]]                 || continue ;;
                 */packages/lsp)                  [[ "$LSP" == "true" ]]                 || continue ;;
                 */benchmarks)                    [[ "$BENCHMARKS" == "true" ]]          || continue ;;
@@ -464,6 +476,7 @@ jobs:
           ADAPTER_STATIC: ${{ needs.changes.outputs.adapter-static }}
           ENHANCED_IMG: ${{ needs.changes.outputs.enhanced-img }}
           CREATE_SVELTEGO: ${{ needs.changes.outputs.create-sveltego }}
+          INIT: ${{ needs.changes.outputs.init }}
           MCP: ${{ needs.changes.outputs.mcp }}
           LSP: ${{ needs.changes.outputs.lsp }}
           PLAYGROUND: ${{ needs.changes.outputs.playground }}
@@ -486,6 +499,7 @@ jobs:
                 */packages/adapter-static)       [[ "$ADAPTER_STATIC" == "true" ]]      || continue ;;
                 */packages/enhanced-img)         [[ "$ENHANCED_IMG" == "true" ]]        || continue ;;
                 */packages/create-sveltego)      [[ "$CREATE_SVELTEGO" == "true" ]]     || continue ;;
+                */packages/init)                 [[ "$INIT" == "true" ]]                || continue ;;
                 */packages/mcp)                  [[ "$MCP" == "true" ]]                 || continue ;;
                 */packages/lsp)                  [[ "$LSP" == "true" ]]                 || continue ;;
                 */benchmarks)                    [[ "$BENCHMARKS" == "true" ]]          || continue ;;
@@ -510,6 +524,7 @@ jobs:
           ADAPTER_STATIC: ${{ needs.changes.outputs.adapter-static }}
           ENHANCED_IMG: ${{ needs.changes.outputs.enhanced-img }}
           CREATE_SVELTEGO: ${{ needs.changes.outputs.create-sveltego }}
+          INIT: ${{ needs.changes.outputs.init }}
           MCP: ${{ needs.changes.outputs.mcp }}
           LSP: ${{ needs.changes.outputs.lsp }}
           PLAYGROUND: ${{ needs.changes.outputs.playground }}
@@ -533,6 +548,7 @@ jobs:
                 */packages/adapter-static)       [[ "$ADAPTER_STATIC" == "true" ]]      || continue ;;
                 */packages/enhanced-img)         [[ "$ENHANCED_IMG" == "true" ]]        || continue ;;
                 */packages/create-sveltego)      [[ "$CREATE_SVELTEGO" == "true" ]]     || continue ;;
+                */packages/init)                 [[ "$INIT" == "true" ]]                || continue ;;
                 */packages/mcp)                  [[ "$MCP" == "true" ]]                 || continue ;;
                 */packages/lsp)                  [[ "$LSP" == "true" ]]                 || continue ;;
                 */benchmarks)                    [[ "$BENCHMARKS" == "true" ]]          || continue ;;
@@ -561,6 +577,7 @@ jobs:
           ADAPTER_STATIC: ${{ needs.changes.outputs.adapter-static }}
           ENHANCED_IMG: ${{ needs.changes.outputs.enhanced-img }}
           CREATE_SVELTEGO: ${{ needs.changes.outputs.create-sveltego }}
+          INIT: ${{ needs.changes.outputs.init }}
           MCP: ${{ needs.changes.outputs.mcp }}
           LSP: ${{ needs.changes.outputs.lsp }}
           PLAYGROUND: ${{ needs.changes.outputs.playground }}
@@ -583,6 +600,7 @@ jobs:
                 */packages/adapter-static)       [[ "$ADAPTER_STATIC" == "true" ]]      || continue ;;
                 */packages/enhanced-img)         [[ "$ENHANCED_IMG" == "true" ]]        || continue ;;
                 */packages/create-sveltego)      [[ "$CREATE_SVELTEGO" == "true" ]]     || continue ;;
+                */packages/init)                 [[ "$INIT" == "true" ]]                || continue ;;
                 */packages/mcp)                  [[ "$MCP" == "true" ]]                 || continue ;;
                 */packages/lsp)                  [[ "$LSP" == "true" ]]                 || continue ;;
                 */benchmarks)                    [[ "$BENCHMARKS" == "true" ]]          || continue ;;
@@ -791,3 +809,69 @@ jobs:
         shell: bash
         run: |
           if [ -f server.pid ]; then kill "$(cat server.pid)" 2>/dev/null || true; fi
+
+  # End-to-end smoke for `npm create sveltego` + sveltego-init.
+  # Builds sveltego-init from source, points the wrapper at it via
+  # SVELTEGO_INIT_LOCAL_PATH, and asserts the produced tree matches
+  # what `sveltego-init` writes directly. Both paths must agree.
+  create-sveltego-smoke:
+    name: create-sveltego-smoke
+    needs: changes
+    if: |
+      (needs.changes.outputs.shared == 'true' ||
+       needs.changes.outputs.create-sveltego == 'true' ||
+       needs.changes.outputs.init == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.x'
+          cache: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build sveltego-init
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin"
+          go build -o "$RUNNER_TEMP/bin/sveltego-init" ./packages/init/cmd/sveltego-init
+
+      - name: Build npm wrapper (tsc)
+        working-directory: packages/create-sveltego
+        shell: bash
+        run: |
+          npm install --no-save typescript@5.4 @types/node@20
+          npx tsc -p tsconfig.json
+
+      - name: Run wrapper unit tests
+        working-directory: packages/create-sveltego
+        shell: bash
+        run: node --test test/*.test.mjs
+
+      - name: Wrapper produces a tree (via SVELTEGO_INIT_LOCAL_PATH)
+        shell: bash
+        run: |
+          set -euo pipefail
+          out_a="$RUNNER_TEMP/path-a"
+          rm -rf "$out_a"
+          SVELTEGO_INIT_LOCAL_PATH="$RUNNER_TEMP/bin/sveltego-init" \
+            node packages/create-sveltego/bin/create-sveltego.js \
+              --non-interactive --module example.com/x "$out_a"
+          test -f "$out_a/go.mod"
+          test -f "$out_a/cmd/app/main.go"
+          test -f "$out_a/src/routes/+page.svelte"
+
+      - name: Direct sveltego-init produces identical tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          out_a="$RUNNER_TEMP/path-a"
+          out_b="$RUNNER_TEMP/path-b"
+          rm -rf "$out_b"
+          "$RUNNER_TEMP/bin/sveltego-init" --non-interactive \
+            --module example.com/x "$out_b"
+          diff -r "$out_a" "$out_b"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ vendor/
 
 # sveltego build artifacts
 bin/
+# create-sveltego ships a Node CLI entry under bin/; keep it.
+!packages/create-sveltego/bin/
 coverage*.out
 coverage*.html
 *.prof

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,6 +8,7 @@
   "packages/adapter-static": "0.0.0",
   "packages/enhanced-img": "0.0.0",
   "packages/create-sveltego": "0.0.0",
+  "packages/init": "0.0.0",
   "packages/mcp": "0.0.0",
   "packages/lsp": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -43,26 +43,40 @@ server.go               ──→  REST endpoints              (//go:build svelt
 
 ## Quickstart
 
-Pre-alpha — expect rough edges. The baseline scaffold writes files; it does **not** yet wire up `cmd/app/main.go` or the Vite shell. Until [#356](https://github.com/binsarjr/sveltego/issues/356) closes, the path of least resistance is to copy [`playgrounds/basic/`](playgrounds/basic/) and edit it.
+Pre-alpha — expect rough edges. One command from any terminal — no clone, no global install:
+
+```sh
+# Recommended: npm/npx (Node >= 20)
+npm create sveltego@latest ./hello
+cd hello
+sveltego build && ./build/app           # listens on :3000
+
+# Or, if you have Go on PATH:
+go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest ./hello
+```
+
+`npm create sveltego@latest` downloads the scaffold engine (or falls back to `go run @latest` when Go is on PATH) and produces the same project tree either way. Add `--ai` for `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and the Copilot rules; `--tailwind=v4|v3|none` to opt into Tailwind; `--service-worker` for a starter `src/service-worker.ts`.
+
+Build the framework CLI separately (until release binaries land in [#368](https://github.com/binsarjr/sveltego/issues/368)):
 
 ```sh
 go install github.com/binsarjr/sveltego/cmd/sveltego@latest
-go install github.com/binsarjr/sveltego/init/cmd/sveltego-init@latest
-
-# Option A — copy the working playground (recommended today):
-git clone https://github.com/binsarjr/sveltego
-cd sveltego/playgrounds/basic
-sveltego build && ./build/app           # listens on :3000
-
-# Option B — scaffold + finish manually (gap tracked in #356):
-sveltego-init --ai ./hello
-cd hello
-# Add cmd/app/main.go, app.html, package.json, vite.config.js
-# (copy them from playgrounds/basic/ for now)
-sveltego build && ./build/app
+sveltego version
 ```
 
 `sveltego build` chains codegen → Vite → `go build` in one step; you do not need a separate `go build` invocation. The full quickstart with annotated layout lives in [docs/guide/quickstart.md](docs/guide/quickstart.md).
+
+<details><summary>From-source path (clone the repo)</summary>
+
+```sh
+git clone https://github.com/binsarjr/sveltego
+cd sveltego
+go install ./packages/sveltego/cmd/sveltego
+go install ./packages/init/cmd/sveltego-init
+sveltego-init ./hello
+```
+
+</details>
 
 ## Expression philosophy
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -8,20 +8,32 @@ summary: Install the sveltego CLI, scaffold a project, run dev, build, ship.
 
 sveltego is pre-alpha. Expect rough edges and breaking changes. The shape below tracks the v1.0 milestone; commands and flags may shift.
 
-## Install
+## Scaffold
+
+One command from any terminal. Pick whichever you have:
+
+```sh
+# Node >= 20 — downloads the scaffold engine on demand
+npm create sveltego@latest ./hello
+
+# Go >= 1.23 — resolves the binary via the Go module proxy
+go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest ./hello
+```
+
+Both paths produce the same project tree. `npm create sveltego@latest` falls back to `go run @latest` automatically when Go is on `PATH` and a release binary is not yet available (release binaries are pending [#368](https://github.com/binsarjr/sveltego/issues/368)).
+
+## Install the framework CLI
 
 ```sh
 go install github.com/binsarjr/sveltego/cmd/sveltego@latest
-go install github.com/binsarjr/sveltego/init/cmd/sveltego-init@latest
 sveltego version
 ```
 
-Two binaries today: `sveltego` (build / compile / routes / version) and `sveltego-init` (project scaffolder, separate module under `packages/init`). No Node runtime is required to run a built app; Node is only needed at build time for the Vite client bundle.
+`sveltego` (build / compile / routes / version) is the only binary you need installed locally; the scaffold engine (`sveltego-init`) runs through `npm create` or `go run @latest` as shown above. No Node runtime is required at run time; Node is only needed at build time for the Vite client bundle.
 
-## Scaffold
+## Scaffold flags
 
 ```sh
-sveltego-init ./hello
 cd hello
 ```
 
@@ -42,15 +54,15 @@ hello/
   .gitignore
 ```
 
-::: warning Scaffold gap (#356)
-The scaffold does not yet emit `cmd/app/main.go`, `app.html`, `package.json`, or `vite.config.js`. To run the project end-to-end today, copy those four files from [`playgrounds/basic/`](https://github.com/binsarjr/sveltego/tree/main/playgrounds/basic) into your scaffold output. Tracked in [#356](https://github.com/binsarjr/sveltego/issues/356).
-:::
-
 Add `--ai` to also write `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `.github/copilot-instructions.md` from the bundled AI templates:
 
 ```sh
-sveltego-init --ai ./hello
+npm create sveltego@latest --ai ./hello
+# or:
+go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest --ai ./hello
 ```
+
+Other flags supported by both paths: `--tailwind=v4|v3|none` (Tailwind opt-in), `--service-worker` (starter `src/service-worker.ts`), `--module <path>` (override the generated Go module path), `--force` (overwrite existing files), `--non-interactive` (never prompt).
 
 ## A minimal route
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,11 +6,10 @@ summary: sveltego command reference — build, compile, dev, check, routes, vers
 
 # CLI
 
-`sveltego` is the project's primary command-line entry point. Project scaffolding lives in a separate binary, `sveltego-init`. Install with:
+`sveltego` is the project's primary command-line entry point. Project scaffolding lives in a separate binary, `sveltego-init`, that is normally invoked through `npm create sveltego@latest` or `go run @latest` rather than installed globally. Install the framework CLI with:
 
 ```sh
 go install github.com/binsarjr/sveltego/cmd/sveltego@latest
-go install github.com/binsarjr/sveltego/init/cmd/sveltego-init@latest
 ```
 
 ## Global flags
@@ -51,16 +50,19 @@ Print version, Go runtime version, OS, and architecture.
 
 ## `sveltego-init` (separate binary)
 
-Project scaffolder. See [`packages/init/README.md`](https://github.com/binsarjr/sveltego/blob/main/packages/init/README.md) for the full flag list. Quickly:
+Project scaffolder. Two zero-clone entry points, plus `npm create sveltego@latest` (recommended). See [`packages/init/README.md`](https://github.com/binsarjr/sveltego/blob/main/packages/init/README.md) for the full flag list.
 
 ```sh
-sveltego-init ./my-app                    # baseline scaffold
-sveltego-init --ai ./my-app               # baseline + AI-assistant templates
-sveltego-init --module example.com/x ./my-app
-sveltego-init --force ./my-app            # overwrite existing files
+# npm wrapper (Node >= 20). Auto-falls-back to `go run @latest`.
+npm create sveltego@latest ./my-app
+npm create sveltego@latest --ai ./my-app
+npm create sveltego@latest --tailwind=v4 --module example.com/x ./my-app
+
+# Go-only path (no clone required).
+go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest ./my-app
 ```
 
-Scaffold output is incomplete pending [#356](https://github.com/binsarjr/sveltego/issues/356) — copy `cmd/app/main.go`, `app.html`, `package.json`, and `vite.config.js` from `playgrounds/basic/` until that lands.
+The npm wrapper and the Go binary share the same flag surface; both paths produce identical project trees.
 
 ## Exit codes
 

--- a/packages/create-sveltego/.gitignore
+++ b/packages/create-sveltego/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tgz

--- a/packages/create-sveltego/.npmignore
+++ b/packages/create-sveltego/.npmignore
@@ -1,0 +1,9 @@
+src/
+test/
+tsconfig.json
+node_modules/
+.gitignore
+.npmignore
+*.go
+go.mod
+go.sum

--- a/packages/create-sveltego/CHANGELOG.md
+++ b/packages/create-sveltego/CHANGELOG.md
@@ -3,3 +3,9 @@
 All notable changes to this package will be documented in this file. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Features
+
+- npm wrapper that exec's `sveltego-init` for `npm create sveltego@latest`
+  with a `go run @latest` fallback when no release binary is available
+  (#374).

--- a/packages/create-sveltego/README.md
+++ b/packages/create-sveltego/README.md
@@ -1,5 +1,54 @@
 # create-sveltego
 
-Project scaffolding CLI and templates.
+Zero-clone scaffold launcher for sveltego. Run from any terminal with Node >= 20:
 
-Status: pre-alpha. See repo root [`README.md`](../../README.md) for the project overview and [`STABILITY.md`](./STABILITY.md) for API tiers.
+```sh
+npm create sveltego@latest ./hello
+# or, for Go users:
+go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest ./hello
+```
+
+`npm create sveltego@latest` is a thin wrapper that delegates to the canonical
+`sveltego-init` Go binary. It tries, in order:
+
+1. A cached binary under `~/.cache/sveltego/` (or `$XDG_CACHE_HOME/sveltego/`).
+2. A platform-matched release asset from GitHub (pending [#368](https://github.com/binsarjr/sveltego/issues/368) — currently always falls through).
+3. `go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest`, when `go` is on `PATH`.
+
+If none of the three apply the wrapper exits non-zero with a single-line message
+pointing the user at either Go install or the release-binary issue.
+
+Status: pre-alpha. See [`STABILITY.md`](./STABILITY.md) for the API tier.
+
+## Flags
+
+The wrapper passes every flag through to `sveltego-init` unchanged, so the flag
+surface is identical to [packages/init](../init/README.md):
+
+```sh
+npm create sveltego@latest --ai ./hello
+npm create sveltego@latest --tailwind=v4 ./hello
+npm create sveltego@latest --service-worker ./hello
+npm create sveltego@latest --module example.com/x ./hello
+```
+
+Wrapper-only flags / env vars:
+
+| Flag | Env | Effect |
+|---|---|---|
+| `--no-binary-download` | `SVELTEGO_NO_BINARY_DOWNLOAD=1` | Skip cache + release-binary lookup; jump straight to the `go run @latest` fallback. CI uses this. |
+| | `SVELTEGO_INIT_LOCAL_PATH=<file>` | Run the named binary directly. CI escape hatch — point at a freshly built `sveltego-init`. |
+| | `SVELTEGO_VERSION=<v>` | Override the version slug used in the cache filename. Defaults to `latest`. |
+| | `SVELTEGO_CACHE_DIR=<dir>` | Override `~/.cache/sveltego`. |
+
+## Develop
+
+```sh
+npm install                       # install dev deps (typescript, @types/node)
+npm run build                     # tsc → dist/
+npm test                          # node --test test/*.test.mjs
+node bin/create-sveltego.js ...   # invoke locally
+```
+
+`dist/` is gitignored and produced by `npm run build`. The published tarball
+ships `bin/`, `dist/`, and the markdown files only.

--- a/packages/create-sveltego/STABILITY.md
+++ b/packages/create-sveltego/STABILITY.md
@@ -1,6 +1,6 @@
 # Stability — create-sveltego
 
-Last updated: 2026-04-29 · Version: pre-alpha
+Last updated: 2026-05-01 · Version: pre-alpha
 
 Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97). Pre-`v0.1` every export is implicitly experimental; this file populates as APIs land.
 
@@ -10,7 +10,12 @@ Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97). Pre-`v0.1` 
 
 ## Experimental
 
-(none yet)
+- npm CLI: `create-sveltego [flags] <dir>`. The wrapper passes every flag
+  through to the underlying `sveltego-init` Go binary verbatim, so any
+  flag the binary accepts is in scope.
+- Wrapper-only flags / env vars (`--no-binary-download`,
+  `SVELTEGO_NO_BINARY_DOWNLOAD`, `SVELTEGO_INIT_LOCAL_PATH`,
+  `SVELTEGO_VERSION`, `SVELTEGO_CACHE_DIR`).
 
 ## Deprecated
 

--- a/packages/create-sveltego/bin/create-sveltego.js
+++ b/packages/create-sveltego/bin/create-sveltego.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// create-sveltego CLI entry. Loads the compiled wrapper from dist/.
+import { main } from '../dist/index.js';
+
+main(process.argv.slice(2)).catch((err) => {
+  process.stderr.write(`create-sveltego: ${err?.message ?? err}\n`);
+  process.exit(1);
+});

--- a/packages/create-sveltego/doc.go
+++ b/packages/create-sveltego/doc.go
@@ -1,2 +1,5 @@
-// Package createsveltego provides the project scaffolding CLI and templates.
+// Package createsveltego is a placeholder for go.work bookkeeping. The
+// real entry point is the npm package defined alongside this file in
+// package.json. The npm wrapper exec's `sveltego-init` (release binary
+// or `go run @latest`) — there is no Go-side CLI in this package.
 package createsveltego

--- a/packages/create-sveltego/package.json
+++ b/packages/create-sveltego/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "create-sveltego",
+  "version": "0.1.0",
+  "description": "Scaffold a fresh sveltego project. Wraps the sveltego-init Go binary, with go-run-@latest fallback.",
+  "type": "module",
+  "bin": {
+    "create-sveltego": "./bin/create-sveltego.js"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "README.md",
+    "STABILITY.md",
+    "CHANGELOG.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test test/*.test.mjs",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/node": "^20.0.0"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/binsarjr/sveltego",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/binsarjr/sveltego.git",
+    "directory": "packages/create-sveltego"
+  },
+  "bugs": {
+    "url": "https://github.com/binsarjr/sveltego/issues"
+  },
+  "keywords": [
+    "sveltego",
+    "svelte",
+    "go",
+    "scaffold",
+    "create"
+  ]
+}

--- a/packages/create-sveltego/src/download.ts
+++ b/packages/create-sveltego/src/download.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Platform } from './platform.js';
+
+export interface ResolveBinaryOpts {
+	platform: Platform;
+	cacheDir: string;
+	env: NodeJS.ProcessEnv;
+	// Test seam: provide a custom fetch impl for unit tests. Defaults to
+	// the global fetch shipped in Node 20+.
+	fetchFn?: typeof fetch;
+	// Test seam: pretend the version probe returned this string. Used by
+	// tests so they never hit the network.
+	versionOverride?: string;
+}
+
+export type BinaryResolveResult =
+	| { kind: 'cached'; path: string }
+	| { kind: 'downloaded'; path: string }
+	| { kind: 'unavailable'; reason: string };
+
+// resolveBinary tries the cache first, then a remote download. Until
+// release binaries land (#368) the remote path always returns
+// `unavailable` so the caller can fall back to `go run @latest`.
+export async function resolveBinary(
+	opts: ResolveBinaryOpts,
+): Promise<BinaryResolveResult> {
+	const version = opts.versionOverride ?? opts.env.SVELTEGO_VERSION ?? 'latest';
+	const cachePath = join(
+		opts.cacheDir,
+		`sveltego-init-${version}-${opts.platform.assetSuffix}${
+			opts.platform.os === 'windows' ? '.exe' : ''
+		}`,
+	);
+	if (existsSync(cachePath)) {
+		return { kind: 'cached', path: cachePath };
+	}
+	// Release binaries are not published yet (#368). Returning a typed
+	// "unavailable" lets the wrapper print a single-line note and fall
+	// back to `go run @latest` instead of hanging on a 404.
+	return {
+		kind: 'unavailable',
+		reason: 'release binaries not yet published (#368)',
+	};
+}

--- a/packages/create-sveltego/src/index.ts
+++ b/packages/create-sveltego/src/index.ts
@@ -1,0 +1,125 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolvePlatform, type Platform } from './platform.js';
+import { resolveBinary, type BinaryResolveResult } from './download.js';
+
+export interface RunOptions {
+	argv: string[];
+	env: NodeJS.ProcessEnv;
+	stderr: NodeJS.WritableStream;
+	platform: Platform;
+	resolveBinaryFn?: typeof resolveBinary;
+	spawnFn?: typeof spawnSync;
+	hasGoOnPathFn?: () => boolean;
+}
+
+export const FALLBACK_GO_MODULE =
+	'github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest';
+
+export async function main(rawArgv: string[]): Promise<void> {
+	const code = await run({
+		argv: rawArgv,
+		env: process.env,
+		stderr: process.stderr,
+		platform: resolvePlatform(process.platform, process.arch),
+	});
+	process.exit(code);
+}
+
+export async function run(opts: RunOptions): Promise<number> {
+	const argv = opts.argv;
+	const spawn = opts.spawnFn ?? spawnSync;
+	const resolveFn = opts.resolveBinaryFn ?? resolveBinary;
+	const hasGo = opts.hasGoOnPathFn ?? hasGoOnPath;
+
+	const skipBinary =
+		argv.includes('--no-binary-download') ||
+		opts.env.SVELTEGO_NO_BINARY_DOWNLOAD === '1';
+
+	const passthrough = argv.filter((a) => a !== '--no-binary-download');
+
+	// CI escape hatch: SVELTEGO_INIT_LOCAL_PATH points at a pre-built
+	// sveltego-init binary (e.g. `go build -o $tmp/sveltego-init
+	// ./packages/init/cmd/sveltego-init` produced by the workflow).
+	// Lets the smoke test exercise the wrapper end-to-end before the
+	// release proxy carries the right commit.
+	if (opts.env.SVELTEGO_INIT_LOCAL_PATH) {
+		const r = spawn(opts.env.SVELTEGO_INIT_LOCAL_PATH, passthrough, {
+			stdio: 'inherit',
+			env: opts.env,
+		});
+		return exitCode(r);
+	}
+
+	if (!skipBinary) {
+		let resolved: BinaryResolveResult;
+		try {
+			resolved = await resolveFn({
+				platform: opts.platform,
+				cacheDir: cacheDirFor(opts.env),
+				env: opts.env,
+			});
+		} catch (err) {
+			opts.stderr.write(
+				`create-sveltego: binary resolve failed: ${(err as Error).message}\n`,
+			);
+			resolved = { kind: 'unavailable', reason: (err as Error).message };
+		}
+		if (resolved.kind === 'cached' || resolved.kind === 'downloaded') {
+			const r = spawn(resolved.path, passthrough, {
+				stdio: 'inherit',
+				env: opts.env,
+			});
+			return exitCode(r);
+		}
+		opts.stderr.write(
+			`create-sveltego: ${resolved.reason}; falling back to \`go run @latest\` (release binaries pending #368)\n`,
+		);
+	}
+
+	if (hasGo()) {
+		const r = spawn('go', ['run', FALLBACK_GO_MODULE, ...passthrough], {
+			stdio: 'inherit',
+			env: opts.env,
+		});
+		return exitCode(r);
+	}
+
+	opts.stderr.write(
+		'create-sveltego: no scaffold path available.\n' +
+			'  - install Go >= 1.23 (https://go.dev/dl/) so we can fall back to `go run @latest`, OR\n' +
+			'  - wait for sveltego release binaries (https://github.com/binsarjr/sveltego/issues/368).\n',
+	);
+	return 1;
+}
+
+function exitCode(r: SpawnSyncReturns<Buffer>): number {
+	if (r.error) {
+		throw r.error;
+	}
+	if (typeof r.status === 'number') {
+		return r.status;
+	}
+	return r.signal ? 1 : 0;
+}
+
+export function hasGoOnPath(): boolean {
+	const r = spawnSync('go', ['version'], { stdio: 'ignore' });
+	return r.status === 0;
+}
+
+function cacheDirFor(env: NodeJS.ProcessEnv): string {
+	if (env.SVELTEGO_CACHE_DIR) return env.SVELTEGO_CACHE_DIR;
+	const xdg = env.XDG_CACHE_HOME;
+	if (xdg) return joinPath(xdg, 'sveltego');
+	const home = env.HOME ?? env.USERPROFILE ?? '.';
+	return joinPath(home, '.cache', 'sveltego');
+}
+
+function joinPath(...parts: string[]): string {
+	return parts.join('/').replace(/\\/g, '/');
+}
+
+export { resolvePlatform } from './platform.js';
+export { resolveBinary } from './download.js';
+export { existsSync };

--- a/packages/create-sveltego/src/platform.ts
+++ b/packages/create-sveltego/src/platform.ts
@@ -1,0 +1,52 @@
+export interface Platform {
+	os: 'linux' | 'darwin' | 'windows';
+	arch: 'amd64' | 'arm64';
+	assetSuffix: string;
+	binaryName: string;
+}
+
+export class UnsupportedPlatformError extends Error {
+	constructor(platform: string, arch: string) {
+		super(
+			`unsupported platform ${platform}/${arch}; supported: linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64`,
+		);
+		this.name = 'UnsupportedPlatformError';
+	}
+}
+
+// resolvePlatform maps Node's process.platform/arch to GoReleaser asset
+// suffixes (linux-amd64, darwin-arm64, windows-amd64, ...). Unsupported
+// combos throw — there is no point silently downloading the wrong binary.
+export function resolvePlatform(nodePlatform: string, nodeArch: string): Platform {
+	let os: Platform['os'];
+	switch (nodePlatform) {
+		case 'linux':
+			os = 'linux';
+			break;
+		case 'darwin':
+			os = 'darwin';
+			break;
+		case 'win32':
+			os = 'windows';
+			break;
+		default:
+			throw new UnsupportedPlatformError(nodePlatform, nodeArch);
+	}
+	let arch: Platform['arch'];
+	switch (nodeArch) {
+		case 'x64':
+			arch = 'amd64';
+			break;
+		case 'arm64':
+			arch = 'arm64';
+			break;
+		default:
+			throw new UnsupportedPlatformError(nodePlatform, nodeArch);
+	}
+	if (os === 'windows' && arch !== 'amd64') {
+		throw new UnsupportedPlatformError(nodePlatform, nodeArch);
+	}
+	const assetSuffix = `${os}-${arch}`;
+	const binaryName = os === 'windows' ? 'sveltego-init.exe' : 'sveltego-init';
+	return { os, arch, assetSuffix, binaryName };
+}

--- a/packages/create-sveltego/test/download.test.mjs
+++ b/packages/create-sveltego/test/download.test.mjs
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveBinary } from '../dist/download.js';
+
+const PLATFORM = { os: 'linux', arch: 'amd64', assetSuffix: 'linux-amd64', binaryName: 'sveltego-init' };
+
+test('returns unavailable until release binaries land (#368)', async () => {
+	const r = await resolveBinary({ platform: PLATFORM, cacheDir: '/non-existent', env: {} });
+	assert.equal(r.kind, 'unavailable');
+	assert.match(r.reason, /#368/);
+});

--- a/packages/create-sveltego/test/platform.test.mjs
+++ b/packages/create-sveltego/test/platform.test.mjs
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolvePlatform, UnsupportedPlatformError } from '../dist/platform.js';
+
+test('maps darwin/arm64 to darwin-arm64', () => {
+	const p = resolvePlatform('darwin', 'arm64');
+	assert.equal(p.os, 'darwin');
+	assert.equal(p.arch, 'arm64');
+	assert.equal(p.assetSuffix, 'darwin-arm64');
+	assert.equal(p.binaryName, 'sveltego-init');
+});
+
+test('maps linux/x64 to linux-amd64', () => {
+	const p = resolvePlatform('linux', 'x64');
+	assert.equal(p.assetSuffix, 'linux-amd64');
+});
+
+test('maps win32/x64 to windows-amd64 with .exe suffix', () => {
+	const p = resolvePlatform('win32', 'x64');
+	assert.equal(p.assetSuffix, 'windows-amd64');
+	assert.equal(p.binaryName, 'sveltego-init.exe');
+});
+
+test('rejects windows on arm64 (no GoReleaser asset planned)', () => {
+	assert.throws(() => resolvePlatform('win32', 'arm64'), UnsupportedPlatformError);
+});
+
+test('rejects unknown platforms', () => {
+	assert.throws(() => resolvePlatform('freebsd', 'x64'), UnsupportedPlatformError);
+});
+
+test('rejects unknown arch', () => {
+	assert.throws(() => resolvePlatform('linux', 'ia32'), UnsupportedPlatformError);
+});

--- a/packages/create-sveltego/test/run.test.mjs
+++ b/packages/create-sveltego/test/run.test.mjs
@@ -1,0 +1,162 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { run, FALLBACK_GO_MODULE } from '../dist/index.js';
+
+const PLATFORM = { os: 'linux', arch: 'amd64', assetSuffix: 'linux-amd64', binaryName: 'sveltego-init' };
+
+function fakeStderr() {
+	const buf = [];
+	return {
+		write: (s) => buf.push(String(s)),
+		text: () => buf.join(''),
+	};
+}
+
+function fakeSpawn(record) {
+	return (cmd, args, _opts) => {
+		record.calls.push({ cmd, args });
+		return record.next ?? { status: 0, signal: null, error: null };
+	};
+}
+
+test('falls back to go run @latest when binary unavailable and go on PATH', async () => {
+	const stderr = fakeStderr();
+	const record = { calls: [] };
+	const code = await run({
+		argv: ['/tmp/hello'],
+		env: {},
+		stderr,
+		platform: PLATFORM,
+		resolveBinaryFn: async () => ({ kind: 'unavailable', reason: 'no release yet' }),
+		spawnFn: fakeSpawn(record),
+		hasGoOnPathFn: () => true,
+	});
+	assert.equal(code, 0);
+	assert.equal(record.calls.length, 1);
+	assert.equal(record.calls[0].cmd, 'go');
+	assert.deepEqual(record.calls[0].args, ['run', FALLBACK_GO_MODULE, '/tmp/hello']);
+	assert.match(stderr.text(), /falling back to `go run @latest`/);
+});
+
+test('uses cached binary when present', async () => {
+	const stderr = fakeStderr();
+	const record = { calls: [] };
+	const code = await run({
+		argv: ['--non-interactive', '/tmp/hello'],
+		env: {},
+		stderr,
+		platform: PLATFORM,
+		resolveBinaryFn: async () => ({ kind: 'cached', path: '/cache/sveltego-init' }),
+		spawnFn: fakeSpawn(record),
+		hasGoOnPathFn: () => false,
+	});
+	assert.equal(code, 0);
+	assert.equal(record.calls[0].cmd, '/cache/sveltego-init');
+	assert.deepEqual(record.calls[0].args, ['--non-interactive', '/tmp/hello']);
+	assert.equal(stderr.text(), '');
+});
+
+test('passes every flag through unchanged to the binary', async () => {
+	const record = { calls: [] };
+	await run({
+		argv: ['--ai', '--tailwind=v4', '--service-worker', '--module', 'example.com/x', '/tmp/hi'],
+		env: {},
+		stderr: fakeStderr(),
+		platform: PLATFORM,
+		resolveBinaryFn: async () => ({ kind: 'cached', path: '/cache/init' }),
+		spawnFn: fakeSpawn(record),
+		hasGoOnPathFn: () => false,
+	});
+	assert.deepEqual(record.calls[0].args, [
+		'--ai',
+		'--tailwind=v4',
+		'--service-worker',
+		'--module',
+		'example.com/x',
+		'/tmp/hi',
+	]);
+});
+
+test('strips --no-binary-download from passthrough args', async () => {
+	const record = { calls: [] };
+	await run({
+		argv: ['--no-binary-download', '/tmp/hi'],
+		env: {},
+		stderr: fakeStderr(),
+		platform: PLATFORM,
+		resolveBinaryFn: async () => {
+			throw new Error('resolveBinary should not run when --no-binary-download is set');
+		},
+		spawnFn: fakeSpawn(record),
+		hasGoOnPathFn: () => true,
+	});
+	assert.equal(record.calls[0].cmd, 'go');
+	assert.deepEqual(record.calls[0].args, ['run', FALLBACK_GO_MODULE, '/tmp/hi']);
+});
+
+test('SVELTEGO_NO_BINARY_DOWNLOAD=1 also skips binary path', async () => {
+	const record = { calls: [] };
+	await run({
+		argv: ['/tmp/hi'],
+		env: { SVELTEGO_NO_BINARY_DOWNLOAD: '1' },
+		stderr: fakeStderr(),
+		platform: PLATFORM,
+		resolveBinaryFn: async () => {
+			throw new Error('should not call resolveBinary when env opts out');
+		},
+		spawnFn: fakeSpawn(record),
+		hasGoOnPathFn: () => true,
+	});
+	assert.equal(record.calls[0].cmd, 'go');
+});
+
+test('fails with friendly error when neither path is available', async () => {
+	const stderr = fakeStderr();
+	const record = { calls: [] };
+	const code = await run({
+		argv: ['/tmp/hi'],
+		env: {},
+		stderr,
+		platform: PLATFORM,
+		resolveBinaryFn: async () => ({ kind: 'unavailable', reason: 'no release' }),
+		spawnFn: fakeSpawn(record),
+		hasGoOnPathFn: () => false,
+	});
+	assert.equal(code, 1);
+	assert.equal(record.calls.length, 0);
+	assert.match(stderr.text(), /install Go >= 1\.23/);
+	assert.match(stderr.text(), /github\.com\/binsarjr\/sveltego\/issues\/368/);
+});
+
+test('SVELTEGO_INIT_LOCAL_PATH wins over both binary and go-run paths', async () => {
+	const record = { calls: [] };
+	await run({
+		argv: ['/tmp/hi'],
+		env: { SVELTEGO_INIT_LOCAL_PATH: '/tmp/local-bin' },
+		stderr: fakeStderr(),
+		platform: PLATFORM,
+		resolveBinaryFn: async () => {
+			throw new Error('should not call resolveBinary when local path is set');
+		},
+		spawnFn: fakeSpawn(record),
+		hasGoOnPathFn: () => {
+			throw new Error('should not probe go when local path is set');
+		},
+	});
+	assert.equal(record.calls.length, 1);
+	assert.equal(record.calls[0].cmd, '/tmp/local-bin');
+	assert.deepEqual(record.calls[0].args, ['/tmp/hi']);
+});
+
+test('propagates non-zero exit code from underlying binary', async () => {
+	const code = await run({
+		argv: ['/tmp/hi'],
+		env: {},
+		stderr: fakeStderr(),
+		platform: PLATFORM,
+		resolveBinaryFn: async () => ({ kind: 'cached', path: '/cache/init' }),
+		spawnFn: () => ({ status: 2, signal: null, error: null }),
+		hasGoOnPathFn: () => false,
+	});
+	assert.equal(code, 2);
+});

--- a/packages/create-sveltego/tsconfig.json
+++ b/packages/create-sveltego/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": false,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -4,24 +4,35 @@ Standalone scaffolder for fresh sveltego projects.
 
 Status: pre-alpha. The `sveltego-init` binary writes a baseline project
 tree (src/routes, src/lib, hooks, sveltego.config, go.mod, README) and
-optionally copies the AI-assistant templates from
-[`templates/ai`](../../templates/ai). Closes
+optionally copies the AI-assistant templates embedded under
+[`internal/aitemplates`](./internal/aitemplates). Closes
 [#131](https://github.com/binsarjr/sveltego/issues/131).
 
-## Build
+The npm wrapper [`create-sveltego`](../create-sveltego) drives this same
+binary for users who prefer `npm create sveltego@latest ./my-app` over
+`go run @latest`. Both paths produce identical project trees.
+
+## Use (no clone)
+
+```sh
+# npm (Node >= 20). Falls back to `go run @latest` if no release binary.
+npm create sveltego@latest ./my-app
+
+# Go-only (Go >= 1.23). Resolves via the Go module proxy.
+go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest ./my-app
+```
+
+## Use (from-source build)
 
 ```sh
 go build -o sveltego-init ./cmd/sveltego-init
-```
-
-## Use
-
-```sh
 sveltego-init ./my-app                # baseline scaffold, prompts on TTY for --ai
 sveltego-init --ai ./my-app           # baseline + AI templates, no prompt
 sveltego-init --non-interactive ./my-app   # piped/CI: skip prompt, default --ai=false
 sveltego-init --force ./my-app        # overwrite existing files
 sveltego-init --module example.com/my-app ./my-app
+sveltego-init --tailwind=v4 ./my-app  # opt into Tailwind (v4 default, v3 legacy, none)
+sveltego-init --service-worker ./my-app    # emit a starter src/service-worker.ts
 ```
 
 Conflicts skip-by-default; the binary prints the list of skipped paths.
@@ -31,10 +42,12 @@ Re-run with `--force` to overwrite.
 
 - `cmd/sveltego-init/` — binary entry point.
 - `internal/scaffold/` — file writer, baseline templates, AI-template copy.
+- `internal/aitemplates/` — embedded AI-assistant rule files. Mirrored
+  from `templates/ai/` at the repo root and verified byte-equal in tests
+  so the embed and the canonical source never drift.
 
 ## STABILITY
 
-The `--ai`, `--force`, `--non-interactive`, and `--module` flags are the
-public CLI surface. The internal scaffold package is internal-only. AI
-templates are sourced from `github.com/binsarjr/sveltego/templates/ai`
-and validated byte-equal against `embed.FS` in tests.
+The `--ai`, `--force`, `--non-interactive`, `--module`, `--tailwind`, and
+`--service-worker` flags are the public CLI surface. The internal
+scaffold and aitemplates packages are internal-only.

--- a/packages/init/cmd/sveltego-init/main.go
+++ b/packages/init/cmd/sveltego-init/main.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/binsarjr/sveltego/init/internal/scaffold"
+	"github.com/binsarjr/sveltego/packages/init/internal/scaffold"
 )
 
 func main() {

--- a/packages/init/go.mod
+++ b/packages/init/go.mod
@@ -1,7 +1,3 @@
-module github.com/binsarjr/sveltego/init
+module github.com/binsarjr/sveltego/packages/init
 
 go 1.22
-
-require github.com/binsarjr/sveltego/templates/ai v0.0.0-00010101000000-000000000000
-
-replace github.com/binsarjr/sveltego/templates/ai => ../../templates/ai

--- a/packages/init/internal/aitemplates/embed.go
+++ b/packages/init/internal/aitemplates/embed.go
@@ -1,0 +1,27 @@
+// Package aitemplates embeds the AI-assistant rule templates that ship
+// to user projects via `sveltego-init --ai`. Templates live alongside
+// this package so packages/init has no cross-module dependency that
+// would block `go run github.com/binsarjr/sveltego/packages/init/...@latest`.
+//
+// The canonical, human-edited copies still live at templates/ai/ at
+// the repo root. A repo-level check keeps the two trees byte-equal.
+package aitemplates
+
+import "embed"
+
+//go:embed files/AGENTS.md files/CLAUDE.md files/.cursorrules files/.github/copilot-instructions.md
+var raw embed.FS
+
+// FS exposes the four template files under their ship-paths
+// (AGENTS.md, CLAUDE.md, .cursorrules, .github/copilot-instructions.md)
+// by stripping the internal "files/" prefix.
+var FS = stripPrefixFS{inner: raw}
+
+// Files lists every template path inside FS in the order callers
+// should write them to a fresh project.
+var Files = []string{
+	"AGENTS.md",
+	"CLAUDE.md",
+	".cursorrules",
+	".github/copilot-instructions.md",
+}

--- a/packages/init/internal/aitemplates/embed_test.go
+++ b/packages/init/internal/aitemplates/embed_test.go
@@ -1,0 +1,60 @@
+package aitemplates
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestFiles_ListMatchesEmbed(t *testing.T) {
+	for _, name := range Files {
+		if _, err := fs.ReadFile(FS, name); err != nil {
+			t.Errorf("FS missing template %q: %v", name, err)
+		}
+	}
+}
+
+func TestTemplates_NonEmpty(t *testing.T) {
+	for _, name := range Files {
+		body, err := fs.ReadFile(FS, name)
+		if err != nil {
+			t.Fatalf("read %q: %v", name, err)
+		}
+		if len(body) == 0 {
+			t.Errorf("template %q is empty", name)
+		}
+	}
+}
+
+// TestTemplates_MirrorTemplatesAI guards against drift between this
+// embedded copy and the canonical templates/ai/ tree at the repo root.
+// The check only runs when the source tree is reachable on disk
+// (workspace mode); a fresh `go install @latest` from the proxy ships
+// only this package and skips the check.
+func TestTemplates_MirrorTemplatesAI(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("runtime.Caller failed; cannot locate templates/ai")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+	templatesAI := filepath.Join(repoRoot, "templates", "ai")
+	if _, err := os.Stat(templatesAI); err != nil {
+		t.Skipf("templates/ai not on disk (%v); skipping mirror check", err)
+	}
+	for _, name := range Files {
+		want, err := os.ReadFile(filepath.Join(templatesAI, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatalf("read templates/ai/%s: %v", name, err)
+		}
+		got, err := fs.ReadFile(FS, name)
+		if err != nil {
+			t.Fatalf("read embed %s: %v", name, err)
+		}
+		if !bytes.Equal(want, got) {
+			t.Errorf("packages/init/internal/aitemplates/files/%s drifted from templates/ai/%s — re-copy", name, name)
+		}
+	}
+}

--- a/packages/init/internal/aitemplates/files/.cursorrules
+++ b/packages/init/internal/aitemplates/files/.cursorrules
@@ -1,0 +1,162 @@
+# Cursor rules for sveltego
+
+This is a sveltego project. SSR is generated from `.svelte` to Go via `sveltego compile`. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before generating code.
+
+For the master ruleset, see `AGENTS.md` in the project root. This file is the Cursor-specific shim and stays in sync with `AGENTS.md` and `CLAUDE.md`.
+
+## Template expressions are Go, not JavaScript
+
+Inside `{...}` mustaches, write **Go**. Field access is **PascalCase** (Go exported fields).
+
+| Wrong (JS) | Right (Go) |
+|---|---|
+| `{user.name}` | `{Data.User.Name}` |
+| `{posts.length}` | `{len(Data.Posts)}` |
+| `{count + 1}` | `{Count + 1}` |
+| `{n.toString()}` | `{strconv.Itoa(N)}` |
+| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
+| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
+| `null` | `nil` |
+
+Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+
+Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+
+## File conventions
+
+```
+src/routes/
+  +page.svelte           SSR template, Go expressions inside {...}
+  page.server.go         Load(), Actions      — needs //go:build sveltego
+  +layout.svelte         layout chain
+  layout.server.go       layout-level Load    — needs //go:build sveltego
+  server.go              REST endpoints       — needs //go:build sveltego
+  +error.svelte          error boundary
+  (group)/               route group
+  +page@.svelte          layout reset
+  [param]/               route param
+  [[optional]]/          optional segment
+  [...rest]/             catch-all
+src/params/<name>.go     param matchers       — needs //go:build sveltego
+src/lib/                 shared modules ($lib alias)
+hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+```
+
+`+` prefix rules:
+
+- `.svelte` files **keep** the `+`: `+page.svelte`, `+layout.svelte`, `+error.svelte`.
+- User `.go` files **drop** the `+`: `page.server.go`, `layout.server.go`, `server.go`. The scanner rejects `+page.server.go`.
+
+Every user `.go` file under `src/` (and `hooks.server.go` at the project root) **must** start with `//go:build sveltego` so the standard Go toolchain skips it. Codegen reads these files via `go/parser` directly.
+
+## Common patterns
+
+### Load
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+    return PageData{User: currentUser(ctx), Posts: fetchPosts(ctx)}, nil
+}
+
+type PageData struct {
+    User  User
+    Posts []Post
+}
+```
+
+`PageData` is inferred from the `Load` return type; the template references its fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+
+### Actions
+
+```go
+var Actions = kit.ActionMap{
+    "default": func(ev *kit.RequestEvent) kit.ActionResult {
+        var form CreatePostForm
+        if err := ev.BindForm(&form); err != nil {
+            return kit.ActionFail(400, map[string]string{"error": err.Error()})
+        }
+        return kit.ActionRedirect(303, "/posts")
+    },
+}
+```
+
+The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
+
+### Redirect / Fail from Load
+
+`kit.Redirect(code, location)` and `kit.Fail(code, data)` return `error` values. Return them from `Load` to short-circuit. The pipeline detects them via `errors.As`.
+
+```go
+if user == nil {
+    return PageData{}, kit.Redirect(303, "/login")
+}
+```
+
+### Cookies
+
+```go
+ev.Cookies.Set("session", token, kit.CookieOpts{HTTPOnly: true, Secure: true})
+v, ok := ev.Cookies.Get("session")
+ev.Cookies.Delete("session")
+```
+
+### Layout parent data
+
+```go
+parent, _ := ctx.Parent().(LayoutData)
+```
+
+`LoadCtx.Parent()` returns `any`. Type-assert to the immediate parent's data type.
+
+### REST endpoints (`server.go`)
+
+```go
+//go:build sveltego
+
+package api
+
+func GET(ev *kit.RequestEvent) (*kit.Response, error) { ... }
+func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
+```
+
+One verb per Go function; the dispatcher routes by HTTP method.
+
+### Hooks (`hooks.server.go`)
+
+```go
+//go:build sveltego
+
+package hooks
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+```
+
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `+error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+
+## Don't
+
+- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
+- `null` — write `nil`.
+- camelCase field access in templates.
+- A JS server runtime. No Node / Bun / Deno on the server.
+- Editing `.gen/*.go` directly.
+- Universal `Load` (`+page.ts`). sveltego is server-only.
+- `+` prefix on user `.go` files.
+- Omitting `//go:build sveltego` on user `.go` files.
+
+## Where to find more
+
+- Docs: <https://sveltego.dev> (see `llms.txt` for an LLM-optimized index).
+- Source and issue tracker: <https://github.com/binsarjr/sveltego>.
+- MCP server (when available): `sveltego mcp` exposes `search_docs`, `lookup_api`, `validate_template`.
+- See `AGENTS.md` for the master ruleset and `CLAUDE.md` for the Claude Code-specific entry point.

--- a/packages/init/internal/aitemplates/files/.github/copilot-instructions.md
+++ b/packages/init/internal/aitemplates/files/.github/copilot-instructions.md
@@ -1,0 +1,162 @@
+# GitHub Copilot instructions for sveltego
+
+This is a sveltego project. SSR is generated from `.svelte` to Go via `sveltego compile`. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before suggesting code.
+
+For the master ruleset, see `AGENTS.md` in the project root. This file is the GitHub Copilot-specific shim and stays in sync with `AGENTS.md` and `CLAUDE.md`.
+
+## Template expressions are Go, not JavaScript
+
+Inside `{...}` mustaches, write **Go**. Field access is **PascalCase** (Go exported fields).
+
+| Wrong (JS) | Right (Go) |
+|---|---|
+| `{user.name}` | `{Data.User.Name}` |
+| `{posts.length}` | `{len(Data.Posts)}` |
+| `{count + 1}` | `{Count + 1}` |
+| `{n.toString()}` | `{strconv.Itoa(N)}` |
+| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
+| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
+| `null` | `nil` |
+
+Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+
+Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+
+## File conventions
+
+```
+src/routes/
+  +page.svelte           SSR template, Go expressions inside {...}
+  page.server.go         Load(), Actions      — needs //go:build sveltego
+  +layout.svelte         layout chain
+  layout.server.go       layout-level Load    — needs //go:build sveltego
+  server.go              REST endpoints       — needs //go:build sveltego
+  +error.svelte          error boundary
+  (group)/               route group
+  +page@.svelte          layout reset
+  [param]/               route param
+  [[optional]]/          optional segment
+  [...rest]/             catch-all
+src/params/<name>.go     param matchers       — needs //go:build sveltego
+src/lib/                 shared modules ($lib alias)
+hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+```
+
+`+` prefix rules:
+
+- `.svelte` files **keep** the `+`: `+page.svelte`, `+layout.svelte`, `+error.svelte`.
+- User `.go` files **drop** the `+`: `page.server.go`, `layout.server.go`, `server.go`. The scanner rejects `+page.server.go`.
+
+Every user `.go` file under `src/` (and `hooks.server.go` at the project root) **must** start with `//go:build sveltego` so the standard Go toolchain skips it. Codegen reads these files via `go/parser` directly.
+
+## Common patterns
+
+### Load
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+    return PageData{User: currentUser(ctx), Posts: fetchPosts(ctx)}, nil
+}
+
+type PageData struct {
+    User  User
+    Posts []Post
+}
+```
+
+`PageData` is inferred from the `Load` return type; reference fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+
+### Actions
+
+```go
+var Actions = kit.ActionMap{
+    "default": func(ev *kit.RequestEvent) kit.ActionResult {
+        var form CreatePostForm
+        if err := ev.BindForm(&form); err != nil {
+            return kit.ActionFail(400, map[string]string{"error": err.Error()})
+        }
+        return kit.ActionRedirect(303, "/posts")
+    },
+}
+```
+
+The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
+
+### Redirect / Fail from Load
+
+`kit.Redirect(code, location)` and `kit.Fail(code, data)` return `error` values. Return them from `Load` to short-circuit. The pipeline detects them via `errors.As`.
+
+```go
+if user == nil {
+    return PageData{}, kit.Redirect(303, "/login")
+}
+```
+
+### Cookies
+
+```go
+ev.Cookies.Set("session", token, kit.CookieOpts{HTTPOnly: true, Secure: true})
+v, ok := ev.Cookies.Get("session")
+ev.Cookies.Delete("session")
+```
+
+### Layout parent data
+
+```go
+parent, _ := ctx.Parent().(LayoutData)
+```
+
+`LoadCtx.Parent()` returns `any`. Type-assert to the immediate parent's data type.
+
+### REST endpoints (`server.go`)
+
+```go
+//go:build sveltego
+
+package api
+
+func GET(ev *kit.RequestEvent) (*kit.Response, error) { ... }
+func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
+```
+
+One verb per Go function; the dispatcher routes by HTTP method.
+
+### Hooks (`hooks.server.go`)
+
+```go
+//go:build sveltego
+
+package hooks
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+```
+
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `+error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+
+## Don't
+
+- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
+- `null` — write `nil`.
+- camelCase field access in templates.
+- A JS server runtime. No Node / Bun / Deno on the server.
+- Editing `.gen/*.go` directly.
+- Universal `Load` (`+page.ts`). sveltego is server-only.
+- `+` prefix on user `.go` files.
+- Omitting `//go:build sveltego` on user `.go` files.
+
+## Where to find more
+
+- Docs: <https://sveltego.dev> (see `llms.txt` for an LLM-optimized index).
+- Source and issue tracker: <https://github.com/binsarjr/sveltego>.
+- MCP server (when available): `sveltego mcp` exposes `search_docs`, `lookup_api`, `validate_template`.
+- See `AGENTS.md` for the master ruleset and `CLAUDE.md` for the Claude Code-specific entry point.

--- a/packages/init/internal/aitemplates/files/AGENTS.md
+++ b/packages/init/internal/aitemplates/files/AGENTS.md
@@ -1,0 +1,223 @@
+# AGENTS.md
+
+Conventions for AI agents working in a sveltego project. Read before generating code.
+
+This file is the master ruleset for generic agents (Aider, Codex, Continue, etc.). Tool-specific entry points are siblings of this file:
+
+- Claude Code → [`CLAUDE.md`](./CLAUDE.md)
+- Cursor → [`.cursorrules`](./.cursorrules)
+- GitHub Copilot → [`.github/copilot-instructions.md`](./.github/copilot-instructions.md)
+
+All four files carry the same canonical rules; the per-tool variants add tool-specific framing only.
+
+---
+
+## 1. Stack
+
+- This is a **sveltego** project. SSR is generated at build time from `.svelte` to Go via `sveltego compile`.
+- The server runtime is **pure Go**. There is no JS/Node runtime on the server.
+- The client uses **Svelte 5 runes** (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) bundled by Vite for hydration only.
+- Generated code lives under `.gen/` (gitignored). Never edit `.gen/*.go` by hand — edit the `.svelte` source.
+
+---
+
+## 2. Template expressions are Go, not JavaScript
+
+Inside `{...}` mustaches, write **Go** expressions. Field access is **PascalCase** (Go exported fields).
+
+| Wrong (JS) | Right (Go) |
+|---|---|
+| `{user.name}` | `{Data.User.Name}` |
+| `{posts.length}` | `{len(Data.Posts)}` |
+| `{count + 1}` | `{Count + 1}` |
+| `{"Hello, " + name}` | `{"Hello, " + Name}` |
+| `{n.toString()}` | `{strconv.Itoa(N)}` |
+| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
+| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
+| `null` | `nil` |
+
+Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error, not a runtime error.
+
+Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+
+---
+
+## 3. File conventions
+
+```
+src/routes/
+  +page.svelte           SSR template, Go expressions inside {...}
+  page.server.go         Load(), Actions      — needs //go:build sveltego
+  +layout.svelte         layout chain
+  layout.server.go       layout-level Load    — needs //go:build sveltego
+  server.go              REST endpoints       — needs //go:build sveltego
+  +error.svelte          error boundary
+  (group)/               route group, no URL segment
+  +page@.svelte          layout reset
+  [param]/               route param
+  [[optional]]/          optional segment
+  [...rest]/             catch-all
+src/params/<name>.go     param matchers       — needs //go:build sveltego
+src/lib/                 shared modules ($lib alias)
+hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+```
+
+**`+` prefix rules (do not invert):**
+
+- `.svelte` files keep the `+` prefix: `+page.svelte`, `+layout.svelte`, `+error.svelte`, `+page@.svelte`.
+- User `.go` files **drop** the `+` prefix: `page.server.go`, `layout.server.go`, `server.go`, `hooks.server.go`. SvelteKit-style `+page.server.go` is rejected by the scanner.
+
+**Build constraint:** every user `.go` file under `src/` (and `hooks.server.go` at project root) **must** start with:
+
+```go
+//go:build sveltego
+
+package myroute
+```
+
+Without that line, `go build` / `go vet` / `golangci-lint` would try to compile the file in a default Go module that lacks sveltego's generated context. The constraint makes the standard toolchain skip these files; codegen reads them through `go/parser` directly.
+
+---
+
+## 4. Common patterns
+
+### `Load`
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+    return PageData{
+        User:  currentUser(ctx),
+        Posts: fetchPosts(ctx),
+    }, nil
+}
+
+type PageData struct {
+    User  User
+    Posts []Post
+}
+```
+
+`PageData` is inferred from the `Load` return type. The template references its fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+
+### Actions (form POST)
+
+```go
+var Actions = kit.ActionMap{
+    "default": func(ev *kit.RequestEvent) kit.ActionResult {
+        var form CreatePostForm
+        if err := ev.BindForm(&form); err != nil {
+            return kit.ActionFail(400, map[string]string{"error": err.Error()})
+        }
+        if err := createPost(ev.Context(), form); err != nil {
+            return kit.ActionFail(500, nil)
+        }
+        return kit.ActionRedirect(303, "/posts")
+    },
+}
+```
+
+`kit.ActionRedirect`, `kit.ActionFail`, `kit.ActionDataResult` are the three sealed `ActionResult` constructors — do not invent new variants.
+
+### Redirect / Fail from Load
+
+`kit.Redirect(303, "/login")` and `kit.Fail(400, "bad input")` return `error` values. Return them from `Load` to short-circuit the request:
+
+```go
+if user == nil {
+    return PageData{}, kit.Redirect(303, "/login")
+}
+```
+
+The pipeline detects them via `errors.As` and writes the appropriate response.
+
+### Cookies
+
+```go
+ev.Cookies.Set("session", token, kit.CookieOpts{HTTPOnly: true, Secure: true})
+v, ok := ev.Cookies.Get("session")
+ev.Cookies.Delete("session")
+```
+
+### Layout parent data
+
+```go
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+    parent, _ := ctx.Parent().(LayoutData)
+    return PageData{Theme: parent.Theme}, nil
+}
+```
+
+`LoadCtx.Parent()` returns `any`. Type-assert to the immediate parent's data type.
+
+### REST endpoints (`server.go`)
+
+```go
+//go:build sveltego
+
+package api
+
+func GET(ev *kit.RequestEvent) (*kit.Response, error) { ... }
+func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
+```
+
+One verb per Go function; the dispatcher routes by HTTP method.
+
+### Hooks (`hooks.server.go`)
+
+```go
+//go:build sveltego
+
+package hooks
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+```
+
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). The `+error.svelte` template binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+
+---
+
+## 5. Anti-patterns
+
+Reject these at code review. They will fail at codegen or produce wrong runtime behavior.
+
+- **JS expressions in mustaches.** No `?.`, no `??`, no template literals, no `.map`/`.filter`/`.length`. Compute in `Load()` and expose via `Data`.
+- **Svelte 4 reactivity.** No `export let`, no `$:` blocks, no store autoload. Use `$props()`, `$state()`, `$derived()`, `$effect()`.
+- **`null` instead of `nil`.** Templates evaluate as Go.
+- **camelCase field access in templates.** `{data.user.name}` will not compile against a `PageData` whose field is `User`.
+- **Adding a JS server runtime.** No Node, no Bun, no Deno on the server. The point of sveltego is Go-only SSR.
+- **Editing `.gen/*.go`.** Generated files are overwritten on every `sveltego compile`.
+- **Universal `Load` (`+page.ts`).** sveltego is server-only by design (ADR 0005). All `Load` runs on the server in Go.
+- **`+page.server.go` filename.** Drop the `+` prefix on user `.go` files.
+- **Missing `//go:build sveltego`.** Codegen will warn; the standard Go toolchain will then try to compile a file that references undeclared symbols.
+
+---
+
+## 6. Verification before declaring done
+
+A task is not done when bytes hit disk. It is done when proven correct. Before declaring success:
+
+- Re-read every file edited.
+- Run `sveltego compile` (or `sveltego build`) — codegen errors surface here, not at `go build`.
+- Run `go vet ./...` and the project's test suite.
+- For form actions, exercise the POST path end-to-end. For Load, exercise the GET.
+- If a test or build step is missing, **say so explicitly**. Never claim success when a gate is unverified.
+
+---
+
+## 7. Where to find more
+
+- Docs: <https://sveltego.dev> (see `llms.txt` for an LLM-optimized index).
+- Source and issue tracker: <https://github.com/binsarjr/sveltego>.
+- MCP server (when available): `sveltego mcp` exposes `search_docs`, `lookup_api`, `validate_template` tools for inline lookup.
+- Per-tool entry points: [`CLAUDE.md`](./CLAUDE.md), [`.cursorrules`](./.cursorrules), [`.github/copilot-instructions.md`](./.github/copilot-instructions.md).
+
+When a convention here disagrees with content found elsewhere, this file wins for sveltego projects.

--- a/packages/init/internal/aitemplates/files/CLAUDE.md
+++ b/packages/init/internal/aitemplates/files/CLAUDE.md
@@ -1,0 +1,199 @@
+# CLAUDE.md
+
+Conventions for Claude Code when working in this sveltego project. Read before generating code.
+
+This is the Claude Code-specific entry point. The same canonical rules live in [`AGENTS.md`](./AGENTS.md); cross-tool variants are [`.cursorrules`](./.cursorrules) and [`.github/copilot-instructions.md`](./.github/copilot-instructions.md). When in doubt, [`AGENTS.md`](./AGENTS.md) wins.
+
+---
+
+## Stack
+
+- **sveltego** project. SSR generated at build time from `.svelte` to Go via `sveltego compile`.
+- **Server runtime is pure Go.** No JS/Node on the server.
+- **Client uses Svelte 5 runes** (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) bundled by Vite for hydration only.
+- Generated code under `.gen/` is gitignored. Never edit `.gen/*.go` — edit the `.svelte` source.
+
+---
+
+## Template expressions are Go, not JavaScript
+
+Inside `{...}` mustaches, write **Go**. Field access is **PascalCase**.
+
+| Wrong (JS) | Right (Go) |
+|---|---|
+| `{user.name}` | `{Data.User.Name}` |
+| `{posts.length}` | `{len(Data.Posts)}` |
+| `{count + 1}` | `{Count + 1}` |
+| `{n.toString()}` | `{strconv.Itoa(N)}` |
+| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
+| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
+| `null` | `nil` |
+
+Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+
+Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+
+---
+
+## File conventions
+
+```
+src/routes/
+  +page.svelte           SSR template, Go expressions inside {...}
+  page.server.go         Load(), Actions      — needs //go:build sveltego
+  +layout.svelte         layout chain
+  layout.server.go       layout-level Load    — needs //go:build sveltego
+  server.go              REST endpoints       — needs //go:build sveltego
+  +error.svelte          error boundary
+  (group)/               route group
+  +page@.svelte          layout reset
+  [param]/               route param
+  [[optional]]/          optional segment
+  [...rest]/             catch-all
+src/params/<name>.go     param matchers       — needs //go:build sveltego
+src/lib/                 shared modules ($lib alias)
+hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+```
+
+`+` prefix rules:
+
+- `.svelte` files **keep** the `+`: `+page.svelte`, `+layout.svelte`, `+error.svelte`.
+- User `.go` files **drop** the `+`: `page.server.go`, `layout.server.go`, `server.go`. The scanner rejects `+page.server.go`.
+
+Every user `.go` file under `src/` (and `hooks.server.go` at the project root) **must** start with `//go:build sveltego` so the standard Go toolchain skips it. Codegen reads the file via `go/parser` directly.
+
+---
+
+## Patterns
+
+### Load
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+    return PageData{
+        User:  currentUser(ctx),
+        Posts: fetchPosts(ctx),
+    }, nil
+}
+
+type PageData struct {
+    User  User
+    Posts []Post
+}
+```
+
+`PageData` is inferred from the `Load` return type; reference fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+
+### Actions
+
+```go
+var Actions = kit.ActionMap{
+    "default": func(ev *kit.RequestEvent) kit.ActionResult {
+        var form CreatePostForm
+        if err := ev.BindForm(&form); err != nil {
+            return kit.ActionFail(400, map[string]string{"error": err.Error()})
+        }
+        return kit.ActionRedirect(303, "/posts")
+    },
+}
+```
+
+The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
+
+### Redirect / Fail from Load
+
+`kit.Redirect(code, location)` and `kit.Fail(code, data)` return `error` values. Return them from `Load` to short-circuit:
+
+```go
+if user == nil {
+    return PageData{}, kit.Redirect(303, "/login")
+}
+```
+
+The pipeline detects them via `errors.As`.
+
+### Cookies
+
+```go
+ev.Cookies.Set("session", token, kit.CookieOpts{HTTPOnly: true, Secure: true})
+v, ok := ev.Cookies.Get("session")
+ev.Cookies.Delete("session")
+```
+
+### Layout parent data
+
+```go
+parent, _ := ctx.Parent().(LayoutData)
+```
+
+`LoadCtx.Parent()` returns `any`. Type-assert to the immediate parent's data type.
+
+### REST endpoints (`server.go`)
+
+```go
+//go:build sveltego
+
+package api
+
+func GET(ev *kit.RequestEvent) (*kit.Response, error) { ... }
+func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
+```
+
+One verb per Go function; the dispatcher routes by HTTP method.
+
+### Hooks (`hooks.server.go`)
+
+```go
+//go:build sveltego
+
+package hooks
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+```
+
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `+error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+
+---
+
+## Don't
+
+- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
+- `null` — write `nil`.
+- camelCase field access in templates.
+- A JS server runtime. No Node / Bun / Deno on the server.
+- Editing `.gen/*.go` directly.
+- Universal `Load` (`+page.ts`). sveltego is server-only.
+- `+` prefix on user `.go` files.
+- Omitting `//go:build sveltego` on user `.go` files.
+
+---
+
+## Working rules
+
+These match the project-level Claude Code working rules. Adhere to them when generating code.
+
+1. **Plan before build.** For any task with 3+ steps or architectural impact, write the plan first, get approval, then execute. "Plan" and "build" are separate steps.
+2. **Verification before done.** A task is not done when bytes hit disk. Re-read every file edited. Run `sveltego compile`, `go vet ./...`, and the test suite. If a gate is missing tooling, **say so explicitly**. Never claim success when a gate is unverified.
+3. **Edit safety.** Re-read files before editing after long conversations — context decay corrupts memory. Re-read after every edit to confirm the change applied. The Edit tool reports success on byte-write, not correctness.
+4. **No over-engineering.** No imaginary scenarios. No fallbacks for cases that cannot happen. Validate at boundaries only (HTTP input, external APIs, file I/O). Three similar lines beats a premature abstraction.
+5. **Comments.** Default: write none. Code with named identifiers explains itself. Add a comment only when the WHY is non-obvious. Godoc on exported symbols: one sentence starting with the symbol name.
+6. **Destructive action safety.** Never `git reset --hard`, `git push --force`, `rm -rf` without explicit user authorization in the same conversation.
+
+---
+
+## Where to find more
+
+- Docs: <https://sveltego.dev> (see `llms.txt` for the LLM-optimized index).
+- Source and issue tracker: <https://github.com/binsarjr/sveltego>.
+- MCP server (when available): `sveltego mcp` exposes `search_docs`, `lookup_api`, `validate_template`.
+- See [`AGENTS.md`](./AGENTS.md) for the master ruleset; this file is the Claude-specific entry point with extra working-rule guidance.

--- a/packages/init/internal/aitemplates/fs.go
+++ b/packages/init/internal/aitemplates/fs.go
@@ -1,0 +1,26 @@
+package aitemplates
+
+import (
+	"io/fs"
+	"path"
+)
+
+// stripPrefixFS exposes inner under the empty root by transparently
+// prepending "files/" to every requested name. It implements fs.FS so
+// fs.ReadFile(FS, "AGENTS.md") resolves to inner.ReadFile("files/AGENTS.md").
+type stripPrefixFS struct {
+	inner fs.FS
+}
+
+func (s stripPrefixFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		return s.inner.Open("files")
+	}
+	return s.inner.Open(path.Join("files", name))
+}
+
+// ReadFile lets callers use fs.ReadFile(FS, name) without going through
+// the fs.File round trip. fs.ReadFile prefers an interface match here.
+func (s stripPrefixFS) ReadFile(name string) ([]byte, error) {
+	return fs.ReadFile(s.inner, path.Join("files", name))
+}

--- a/packages/init/internal/scaffold/scaffold.go
+++ b/packages/init/internal/scaffold/scaffold.go
@@ -1,7 +1,7 @@
 // Package scaffold writes a fresh sveltego project tree into a target
 // directory. It owns both the baseline project files (src/routes, src/lib,
 // hooks, config, go.mod, README) and the optional AI-assistant templates
-// sourced from github.com/binsarjr/sveltego/templates/ai.
+// embedded under packages/init/internal/aitemplates.
 package scaffold
 
 import (
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	aitemplates "github.com/binsarjr/sveltego/templates/ai"
+	"github.com/binsarjr/sveltego/packages/init/internal/aitemplates"
 )
 
 const fileMode = 0o600
@@ -25,7 +25,7 @@ type Options struct {
 	// Module is the Go module path written into the generated go.mod.
 	// Empty falls back to the directory base name.
 	Module string
-	// AI copies the templates/ai/embed.FS contents into Dir.
+	// AI copies the embedded AI-template FS contents into Dir.
 	AI bool
 	// Force overwrites existing files. Default skips them and reports
 	// the list via the returned Result.

--- a/packages/init/internal/scaffold/scaffold_test.go
+++ b/packages/init/internal/scaffold/scaffold_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	aitemplates "github.com/binsarjr/sveltego/templates/ai"
+	"github.com/binsarjr/sveltego/packages/init/internal/aitemplates"
 )
 
 func TestRun_BaseScaffold(t *testing.T) {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,6 +27,7 @@
     "packages/adapter-static":     { "component": "adapter-static",     "package-name": "adapter-static" },
     "packages/enhanced-img":       { "component": "enhanced-img",       "package-name": "enhanced-img" },
     "packages/create-sveltego":    { "component": "create-sveltego",    "package-name": "create-sveltego" },
+    "packages/init":               { "component": "packages/init",      "package-name": "init" },
     "packages/mcp":                { "component": "mcp",                "package-name": "mcp" },
     "packages/lsp":                { "component": "lsp",                "package-name": "lsp" }
   }


### PR DESCRIPTION
## Summary

Closes #374.

- Real npm package at `packages/create-sveltego` that exec's the canonical `sveltego-init` Go binary; `npm create sveltego@latest <dir>` works from any terminal with Node >= 20.
- `packages/init` module path moves to `github.com/binsarjr/sveltego/packages/init` so the Go module proxy can resolve `@latest` (the path now matches the directory). The local `replace` on `templates/ai` is dropped — it blocked `go run @latest` from a fresh GOPATH. AI templates ship via a new `internal/aitemplates` package; a mirror test guards against drift from canonical `templates/ai/`.
- README, `docs/guide/quickstart.md`, and `docs/reference/cli.md` lead with the npm path; the from-source clone-and-go-install flow is demoted to a footnote.

## Fallback chain

The wrapper tries, in order:
1. Cached binary under `~/.cache/sveltego/` (or `$XDG_CACHE_HOME/sveltego/`).
2. Platform-matched GitHub release asset (placeholder until #368 lands; currently always falls through with a one-line stderr note).
3. `go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest` when `go` is on `PATH`.

If none apply the wrapper exits non-zero with a friendly message pointing the user at either `go.dev/dl/` or #368.

CI escape hatch: `SVELTEGO_INIT_LOCAL_PATH=<file>` runs the named binary directly. The new `create-sveltego-smoke` job uses it to verify the wrapper end-to-end before any release tag exists.

## Test plan

- [x] `npm test` (15 wrapper unit tests covering argv passthrough, fallback chain, env var seams, exit-code propagation).
- [x] `go test -race ./packages/init/... ./packages/create-sveltego/...` — 28 tests pass.
- [x] `go vet`, `gofumpt -l`, `goimports -l` clean on both packages.
- [x] `golangci-lint run` clean.
- [x] End-to-end identity: `node bin/create-sveltego.js --module example.com/x /tmp/a` and `sveltego-init --module example.com/x /tmp/b` produce byte-identical trees (verified locally with and without `--ai --tailwind=v4`).
- [x] CI smoke job (`create-sveltego-smoke`) builds `sveltego-init`, runs the wrapper through `SVELTEGO_INIT_LOCAL_PATH`, and `diff -r`s against the direct binary output.