### PR TITLE
fix(scaffold,codegen): unblock fresh-project build chain

### DIFF
--- a/packages/init/internal/scaffold/scaffold.go
+++ b/packages/init/internal/scaffold/scaffold.go
@@ -185,7 +185,7 @@ func renderGoMod(module string) string {
 	var b strings.Builder
 	b.WriteString("module ")
 	b.WriteString(module)
-	b.WriteString("\n\ngo 1.23\n\nrequire github.com/binsarjr/sveltego/packages/sveltego v0.0.0\n")
+	b.WriteString("\n\ngo 1.23\n")
 	return b.String()
 }
 

--- a/packages/init/internal/scaffold/scaffold_test.go
+++ b/packages/init/internal/scaffold/scaffold_test.go
@@ -56,6 +56,34 @@ func TestRun_BaseScaffold(t *testing.T) {
 	}
 }
 
+// TestRun_GoModNoLiteralV000 pins the contract that the scaffold never
+// emits a `require ... v0.0.0` line for the framework module. The
+// release-please bootstrap pseudo-version churns on every commit to
+// main, and the proxy cannot resolve the literal v0.0.0 — pinning it
+// silently breaks every fresh project on first `go build`. See #110.
+//
+// The fix from the standalone-scaffold repro (#110): drop the require
+// line entirely. `sveltego build` shells out to `go get @latest` on
+// first invocation to seed it.
+func TestRun_GoModNoLiteralV000(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Run(Options{Dir: dir, Module: "example.com/hello"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	gomod, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	if bytes.Contains(gomod, []byte("v0.0.0")) {
+		t.Errorf("go.mod contains literal v0.0.0; the proxy cannot resolve it. body:\n%s", gomod)
+	}
+	// And no require line for the framework module at all — sveltego
+	// build will add the resolved pseudo-version on first run.
+	if bytes.Contains(gomod, []byte("github.com/binsarjr/sveltego")) {
+		t.Errorf("go.mod references sveltego before first build; expected bare module clause. body:\n%s", gomod)
+	}
+}
+
 // TestRun_MainGoCompiles parses cmd/app/main.go to confirm the scaffold
 // emits syntactically valid Go and that the import path for the generated
 // package picks up the user's module path. Full type-check would require

--- a/packages/sveltego/cmd/sveltego/build.go
+++ b/packages/sveltego/cmd/sveltego/build.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -26,6 +27,9 @@ func newBuildCmd() *cobra.Command {
 			verbose := isVerbose(cmd)
 			root, err := resolveProjectRoot()
 			if err != nil {
+				return err
+			}
+			if err := ensureSveltegoRequire(cmd, root, verbose); err != nil {
 				return err
 			}
 			result, err := codegen.Build(codegen.BuildOptions{
@@ -153,6 +157,64 @@ func runViteBuild(cmd *cobra.Command, root, viteConfig string, verbose bool) err
 		return fmt.Errorf("vite build: %w — ensure Node >=18 and @sveltejs/vite-plugin-svelte are installed", err)
 	}
 	return nil
+}
+
+// sveltegoModulePath is the canonical Go module path of the framework
+// runtime. The fresh-scaffold go.mod (init #110) intentionally omits the
+// require line so the proxy can resolve whatever pseudo-version is
+// current. ensureSveltegoRequire bridges that gap on first build.
+const sveltegoModulePath = "github.com/binsarjr/sveltego/packages/sveltego"
+
+// ensureSveltegoRequire seeds the project's go.mod with a require line for
+// the framework runtime when one is missing. The fresh-scaffold (#110)
+// emits a bare `module ... / go 1.23` clause so we do not pin a literal
+// `v0.0.0` that the proxy cannot resolve. On the first `sveltego build`,
+// shell out to `go get <module>@latest` to let the proxy fill in the
+// current pseudo-version and seed go.sum at the same time.
+//
+// A go.mod that already requires the framework module is left untouched
+// so subsequent builds do not chase a moving target.
+func ensureSveltegoRequire(cmd *cobra.Command, root string, verbose bool) error {
+	goModPath := filepath.Join(root, "go.mod")
+	body, err := os.ReadFile(goModPath) //nolint:gosec // root is resolved from cwd
+	if err != nil {
+		return fmt.Errorf("read go.mod: %w", err)
+	}
+	if hasRequire(body, sveltegoModulePath) {
+		return nil
+	}
+	if verbose {
+		fmt.Fprintf(cmd.OutOrStdout(), "go.mod: adding require %s@latest\n", sveltegoModulePath)
+	}
+	getCmd := exec.Command("go", "get", sveltegoModulePath+"@latest") //nolint:gosec // module path is a fixed constant
+	getCmd.Dir = root
+	getCmd.Stdout = cmd.OutOrStdout()
+	getCmd.Stderr = cmd.ErrOrStderr()
+	if err := getCmd.Run(); err != nil {
+		return fmt.Errorf("go get %s@latest: %w", sveltegoModulePath, err)
+	}
+	return nil
+}
+
+// hasRequire reports whether goModBody declares a require directive for
+// the given module path. The check is line-based and tolerates both the
+// single-line `require <path> v1` and the parenthesized block form.
+func hasRequire(goModBody []byte, modulePath string) bool {
+	for _, line := range strings.Split(string(goModBody), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		// `require github.com/foo/bar v1.2.3`
+		if strings.HasPrefix(trimmed, "require "+modulePath) || strings.HasPrefix(trimmed, "require\t"+modulePath) {
+			return true
+		}
+		// Inside a `require ( ... )` block: bare `<module> v1.2.3` lines.
+		if strings.HasPrefix(trimmed, modulePath+" ") || strings.HasPrefix(trimmed, modulePath+"\t") {
+			return true
+		}
+	}
+	return false
 }
 
 // detectPackageManager returns "pnpm", "bun", or "npm" based on lockfile

--- a/packages/sveltego/cmd/sveltego/build_test.go
+++ b/packages/sveltego/cmd/sveltego/build_test.go
@@ -119,3 +119,53 @@ func TestBuildCmd_NoGoMod(t *testing.T) {
 		t.Fatal("expected error when no go.mod exists in cwd ancestry")
 	}
 }
+
+// TestHasRequire pins the go.mod parsing used by ensureSveltegoRequire
+// to decide whether `go get @latest` needs to run on first build. The
+// rule matters because the fresh-scaffold (#110) deliberately omits the
+// require line and we must not run `go get` on already-tidy projects.
+func TestHasRequire(t *testing.T) {
+	t.Parallel()
+	const target = "github.com/binsarjr/sveltego/packages/sveltego"
+
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "bare module clause (fresh scaffold)",
+			body: "module example.com/hello\n\ngo 1.23\n",
+			want: false,
+		},
+		{
+			name: "single-line require",
+			body: "module example.com/hello\n\ngo 1.23\n\nrequire " + target + " v0.0.0-bootstrap.0.20260501100517-d57b1b5d2445\n",
+			want: true,
+		},
+		{
+			name: "block-form require",
+			body: "module example.com/hello\n\ngo 1.23\n\nrequire (\n\t" + target + " v0.0.0-bootstrap.0.20260501100517-d57b1b5d2445\n)\n",
+			want: true,
+		},
+		{
+			name: "different module required",
+			body: "module example.com/hello\n\ngo 1.23\n\nrequire github.com/spf13/cobra v1.0.0\n",
+			want: false,
+		},
+		{
+			name: "comment line referencing module",
+			body: "module example.com/hello\n\ngo 1.23\n\n// " + target + " is the framework\n",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := hasRequire([]byte(tc.body), target)
+			if got != tc.want {
+				t.Errorf("hasRequire(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -234,7 +234,7 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 			if i < len(route.LayoutServerFiles) {
 				serverFile = route.LayoutServerFiles[i]
 			}
-			hasHead, err := emitLayout(opts.ProjectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile, opts.Release, opts.EnvLookup, opts.Provenance, start, imageVariants)
+			hasHead, err := emitLayout(opts.ProjectRoot, outDir, modulePath, layoutDir, pkgPath, pkgName, serverFile, opts.Release, opts.EnvLookup, opts.Provenance, start, imageVariants)
 			if err != nil {
 				return nil, err
 			}
@@ -427,6 +427,8 @@ func emitPage(projectRoot, outDir, modulePath string, route routescan.ScannedRou
 			return 0, false, false, err
 		}
 		opts.HasActions = actionInfo.HasActions
+		encodedSub := strings.TrimPrefix(route.PackagePath, ".gen/")
+		opts.MirrorImportPath = modulePath + "/" + outDir + "/usersrc/" + encodedSub
 	}
 	out, err := Generate(frag, opts)
 	if err != nil {
@@ -725,7 +727,7 @@ func emitErrorPage(projectRoot, outDir, errorDir, pkgPath, pkgName string, prove
 // struct return is used to infer LayoutData fields. When release is true,
 // any $lib/dev/** import is a fatal error. lookup resolves env.Static*
 // calls to literal string values at build time.
-func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile string, release bool, lookup EnvLookup, provenance bool, generatedAt time.Time, imageVariants map[string]images.Result) (bool, error) {
+func emitLayout(projectRoot, outDir, modulePath, layoutDir, pkgPath, pkgName, serverFile string, release bool, lookup EnvLookup, provenance bool, generatedAt time.Time, imageVariants map[string]images.Result) (bool, error) {
 	layoutPath, err := resolveLayoutSource(layoutDir)
 	if err != nil {
 		return false, err
@@ -747,14 +749,20 @@ func emitLayout(projectRoot, outDir, layoutDir, pkgPath, pkgName, serverFile str
 	if len(perrs) > 0 {
 		return false, fmt.Errorf("codegen: parse %s: %w", layoutPath, perrs)
 	}
+	mirrorImportPath := ""
+	if serverFile != "" {
+		encodedSub := strings.TrimPrefix(pkgPath, ".gen/")
+		mirrorImportPath = modulePath + "/" + outDir + "/layoutsrc/" + encodedSub
+	}
 	out, err := GenerateLayout(frag, LayoutOptions{
-		PackageName:    pkgName,
-		ServerFilePath: serverFile,
-		Filename:       layoutPath,
-		Provenance:     provenance,
-		SourceContent:  src,
-		GeneratedAt:    generatedAt,
-		ImageVariants:  imageVariants,
+		PackageName:      pkgName,
+		ServerFilePath:   serverFile,
+		Filename:         layoutPath,
+		Provenance:       provenance,
+		SourceContent:    src,
+		GeneratedAt:      generatedAt,
+		ImageVariants:    imageVariants,
+		MirrorImportPath: mirrorImportPath,
 	})
 	if err != nil {
 		return false, fmt.Errorf("codegen: generate %s: %w", layoutPath, err)

--- a/packages/sveltego/internal/codegen/build_test.go
+++ b/packages/sveltego/internal/codegen/build_test.go
@@ -764,3 +764,119 @@ func TestRewriteLibImports(t *testing.T) {
 		})
 	}
 }
+
+// TestBuild_PageDataNamedType reproduces the standalone-scaffold variant
+// of #143: when the user's page.server.go declares a top-level
+// `type PageData struct{...}`, the generated page.gen.go must alias to
+// the mirrored type — `type PageData = usersrc.PageData` — instead of
+// synthesizing an empty `type PageData = struct{}`. Without this, the
+// gen file references `data.<UserField>` against the empty alias and
+// fails to compile.
+//
+// The scaffold flow is the canonical repro: a fresh project's
+// page.server.go uses the named-type form by default to keep Load()
+// readable. See feedback_minimal_setup.md (2026-05-01).
+func TestBuild_PageDataNamedType(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/named\n\ngo 1.23\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "+page.svelte"),
+		"<h1>{data.Greeting}</h1>\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "page.server.go"),
+		`//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+type PageData struct {
+	Greeting string
+}
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
+	_ = ctx
+	return PageData{Greeting: "hello"}, nil
+}
+`)
+
+	if _, err := Build(BuildOptions{ProjectRoot: root}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	pageGen := filepath.Join(root, ".gen", "routes", "page.gen.go")
+	body, err := os.ReadFile(pageGen)
+	if err != nil {
+		t.Fatalf("read page.gen.go: %v", err)
+	}
+	got := string(body)
+
+	const wantAlias = "type PageData = usersrc.PageData"
+	if !strings.Contains(got, wantAlias) {
+		t.Errorf("expected %q in page.gen.go, got:\n%s", wantAlias, got)
+	}
+	if strings.Contains(got, "type PageData = struct{}") {
+		t.Errorf("empty alias `type PageData = struct{}` leaked into named-type branch:\n%s", got)
+	}
+	const wantImport = `usersrc "example.com/named/.gen/usersrc/routes"`
+	if !strings.Contains(got, wantImport) {
+		t.Errorf("expected import %q, got:\n%s", wantImport, got)
+	}
+	// page.gen.go must parse as Go and reference data.Greeting (the
+	// alias gives the gen file access to the user's named field).
+	assertParsesAsGo(t, pageGen)
+	if !strings.Contains(got, "data.Greeting") {
+		t.Errorf("expected data.Greeting reference in render body:\n%s", got)
+	}
+}
+
+// TestBuild_LayoutDataNamedType mirrors TestBuild_PageDataNamedType for
+// layouts. A layout.server.go declaring `type LayoutData struct{...}`
+// produces `type LayoutData = usersrc.LayoutData` in layout.gen.go.
+func TestBuild_LayoutDataNamedType(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/lyt\n\ngo 1.23\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "+layout.svelte"),
+		"<header>{data.Title}</header><slot />\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "layout.server.go"),
+		`//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/exports/kit"
+
+type LayoutData struct {
+	Title string
+}
+
+func Load(ctx *kit.LoadCtx) (LayoutData, error) {
+	_ = ctx
+	return LayoutData{Title: "x"}, nil
+}
+`)
+	writeFile(t, filepath.Join(root, "src", "routes", "+page.svelte"),
+		"<h1>page</h1>\n")
+
+	if _, err := Build(BuildOptions{ProjectRoot: root}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	layoutGen := filepath.Join(root, ".gen", "routes", "layout.gen.go")
+	body, err := os.ReadFile(layoutGen)
+	if err != nil {
+		t.Fatalf("read layout.gen.go: %v", err)
+	}
+	got := string(body)
+	const wantAlias = "type LayoutData = usersrc.LayoutData"
+	if !strings.Contains(got, wantAlias) {
+		t.Errorf("expected %q in layout.gen.go, got:\n%s", wantAlias, got)
+	}
+	if strings.Contains(got, "type LayoutData = struct{}") {
+		t.Errorf("empty alias leaked into named-type branch:\n%s", got)
+	}
+	const wantImport = `usersrc "example.com/lyt/.gen/layoutsrc/routes"`
+	if !strings.Contains(got, wantImport) {
+		t.Errorf("expected import %q, got:\n%s", wantImport, got)
+	}
+	assertParsesAsGo(t, layoutGen)
+}

--- a/packages/sveltego/internal/codegen/codegen.go
+++ b/packages/sveltego/internal/codegen/codegen.go
@@ -44,6 +44,14 @@ type Options struct {
 	// resolved to its generated variant set. The codegen-time lookup
 	// rejects unknown sources with a clear diagnostic.
 	ImageVariants map[string]images.Result
+	// MirrorImportPath is the Go import path of the user-source mirror
+	// (`<module>/.gen/usersrc/<encoded>`) for this route. Set by the
+	// build driver when a sibling page.server.go exists. Generate emits
+	// `type PageData = <usersrc-alias>.PageData` whenever the server file
+	// declares a named PageData type, preserving type identity between
+	// the user-authored type and the manifest's adapter assertion. Empty
+	// preserves the inline-struct alias behavior.
+	MirrorImportPath string
 }
 
 // LayoutOptions configures GenerateLayout.
@@ -64,6 +72,12 @@ type LayoutOptions struct {
 	GeneratedAt time.Time
 	// ImageVariants mirrors Options.ImageVariants for layout files.
 	ImageVariants map[string]images.Result
+	// MirrorImportPath mirrors Options.MirrorImportPath for layouts. When
+	// the layout server file declares a named LayoutData type, the
+	// emitter aliases to `<usersrc>.LayoutData` instead of synthesizing
+	// an inline struct, so the manifest's runtime type assertion sees
+	// the user-authored type.
+	MirrorImportPath string
 }
 
 // ErrorPageOptions configures GenerateErrorPage.
@@ -111,15 +125,24 @@ func Generate(frag *ast.Fragment, opts Options) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if opts.HasActions {
+	mirrorAlias := ""
+	if pageData.HasNamedType && opts.MirrorImportPath != "" {
+		mirrorAlias = "usersrc"
+	}
+	if opts.HasActions && !pageData.HasNamedType {
 		// Remove any user-declared Form field before injecting the contract field.
 		// This allows page.server.go to declare `Form any` in its Load return
-		// without causing a duplicate-field compile error. See #143.
+		// without causing a duplicate-field compile error. See #143. The
+		// named-type branch leaves Form to the user's authored declaration.
 		pageData.Fields = dropField(pageData.Fields, "Form")
 		pageData.Fields = append(pageData.Fields, pageDataField{Name: "Form", Type: "any"})
 	}
 
-	imports := mergeImports(scripts.Imports, pageData.Imports)
+	pageDataImports := pageData.Imports
+	if mirrorAlias != "" {
+		pageDataImports = append(pageDataImports, fmt.Sprintf("%s %q", mirrorAlias, opts.MirrorImportPath))
+	}
+	imports := mergeImports(scripts.Imports, pageDataImports)
 	headChildren, bodyChildren := extractHeadChildren(frag.Children)
 
 	var b Builder
@@ -153,7 +176,7 @@ func Generate(frag *ast.Fragment, opts Options) ([]byte, error) {
 
 	b.Line("type Page struct{}")
 	b.Line("")
-	emitPageDataStruct(&b, pageData.Fields)
+	emitPageDataStruct(&b, pageData.Fields, mirrorAlias)
 	b.Line("")
 	if scripts.HasProps {
 		emitPropsStruct(&b, scripts.Props)
@@ -222,12 +245,20 @@ func GenerateLayout(frag *ast.Fragment, opts LayoutOptions) ([]byte, error) {
 		return nil, err
 	}
 	applyScopeClass(frag.Children, style.ScopeClass)
-	layoutData, err := inferPageData(opts.ServerFilePath)
+	layoutData, err := inferLayoutData(opts.ServerFilePath)
 	if err != nil {
 		return nil, err
 	}
+	mirrorAlias := ""
+	if layoutData.HasNamedType && opts.MirrorImportPath != "" {
+		mirrorAlias = "usersrc"
+	}
 
-	imports := mergeImports(scripts.Imports, layoutData.Imports)
+	layoutDataImports := layoutData.Imports
+	if mirrorAlias != "" {
+		layoutDataImports = append(layoutDataImports, fmt.Sprintf("%s %q", mirrorAlias, opts.MirrorImportPath))
+	}
+	imports := mergeImports(scripts.Imports, layoutDataImports)
 	headChildren, bodyChildren := extractHeadChildren(frag.Children)
 
 	var b Builder
@@ -262,7 +293,7 @@ func GenerateLayout(frag *ast.Fragment, opts LayoutOptions) ([]byte, error) {
 
 	b.Line("type Layout struct{}")
 	b.Line("")
-	emitLayoutDataAlias(&b, layoutData.Fields)
+	emitLayoutDataAlias(&b, layoutData.Fields, mirrorAlias)
 	b.Line("")
 	if scripts.HasProps {
 		emitPropsStruct(&b, scripts.Props)
@@ -395,11 +426,16 @@ func GenerateErrorPage(frag *ast.Fragment, opts ErrorPageOptions) ([]byte, error
 	return restoreRunesBytes(out), nil
 }
 
-// emitLayoutDataAlias writes `type LayoutData = struct{...}` mirroring
-// the alias-form rationale on emitPageDataStruct: type identity between
-// the user's inline struct literal and the LayoutData symbol asserted
-// by the manifest adapter must be preserved.
-func emitLayoutDataAlias(b *Builder, fields []pageDataField) {
+// emitLayoutDataAlias writes the layout's LayoutData type alias.
+// Mirrors emitPageDataStruct's three-shape contract: when mirrorAlias is
+// non-empty, emits `type LayoutData = <alias>.LayoutData` so the
+// manifest's runtime assertion against the user-authored type
+// succeeds; otherwise emits the inline-struct alias form.
+func emitLayoutDataAlias(b *Builder, fields []pageDataField, mirrorAlias string) {
+	if mirrorAlias != "" {
+		b.Linef("type LayoutData = %s.LayoutData", mirrorAlias)
+		return
+	}
 	if len(fields) == 0 {
 		b.Line("type LayoutData = struct{}")
 		return

--- a/packages/sveltego/internal/codegen/pagedata.go
+++ b/packages/sveltego/internal/codegen/pagedata.go
@@ -18,6 +18,13 @@ type pageDataField struct {
 type pageDataResult struct {
 	Fields  []pageDataField
 	Imports []string
+	// HasNamedType is true when the user's server file declares
+	// `type PageData struct{...}` at package scope (instead of returning
+	// an inline anonymous struct). The codegen emits a `type PageData =
+	// <mirror>.PageData` alias in that case so the runtime type assertion
+	// in the manifest adapter sees the same Go type the user authored.
+	// See #109, the standalone-scaffold variant of #143.
+	HasNamedType bool
 }
 
 type importBinding struct {
@@ -25,11 +32,35 @@ type importBinding struct {
 	Alias string
 }
 
-// inferPageData parses serverFilePath, locates Load(), and reads its first
-// return composite literal. Only inline struct literals (struct{...}{...})
-// produce field inference. Named-type returns and missing files yield a
-// zero result, leaving the caller to emit `type PageData struct{}`.
+// inferPageData parses serverFilePath, locates Load(), and reads the
+// page's data shape. See inferDataShape for the two supported forms.
 func inferPageData(serverFilePath string) (pageDataResult, error) {
+	return inferDataShape(serverFilePath, "PageData")
+}
+
+// inferLayoutData parses serverFilePath, locates Load(), and reads the
+// layout's data shape. Mirrors inferPageData but keys on a `LayoutData`
+// named-type declaration instead.
+func inferLayoutData(serverFilePath string) (pageDataResult, error) {
+	return inferDataShape(serverFilePath, "LayoutData")
+}
+
+// inferDataShape parses serverFilePath, locates Load(), and reads its
+// data shape. Two source forms are supported:
+//
+//  1. Inline anonymous struct return — `return struct{...}{...}, nil`.
+//     The struct fields are extracted and the caller emits a `type
+//     <Data> = struct{...}` alias whose fields mirror them.
+//  2. Named-type declaration — a top-level `type <Data> struct{...}`
+//     accompanies a `func Load(...) (<Data>, error)`. The caller emits
+//     a `type <Data> = <mirror>.<Data>` alias instead, preserving type
+//     identity with the user-authored type so the manifest's adapter
+//     assertion succeeds.
+//
+// Missing files and unrecognized return shapes produce a zero result;
+// the caller falls back to the empty `type <Data> = struct{}` form.
+// dataTypeName selects between page (PageData) and layout (LayoutData).
+func inferDataShape(serverFilePath, dataTypeName string) (pageDataResult, error) {
 	if serverFilePath == "" {
 		return pageDataResult{}, nil
 	}
@@ -50,6 +81,16 @@ func inferPageData(serverFilePath string) (pageDataResult, error) {
 	if loadFn == nil {
 		return pageDataResult{}, nil
 	}
+
+	// Case 2: user declared `type <Data> ...` at package scope. The gen
+	// file aliases to the mirrored type rather than synthesizing a fresh
+	// inline struct. Detected first because a named-type Load return
+	// collides with the inline-struct branch (lit.Type is an Ident, not
+	// StructType).
+	if hasTypeDecl(f, dataTypeName) {
+		return pageDataResult{HasNamedType: true}, nil
+	}
+
 	lit := findFirstReturnComposite(loadFn)
 	if lit == nil {
 		return pageDataResult{}, nil
@@ -91,6 +132,31 @@ func inferPageData(serverFilePath string) (pageDataResult, error) {
 	sort.Strings(imps)
 
 	return pageDataResult{Fields: fields, Imports: imps}, nil
+}
+
+// hasTypeDecl reports whether the file declares a top-level type with
+// the given name (struct, alias, or any other type spec). Codegen uses
+// this to switch between the inline-struct alias form and the
+// mirror-import alias form. The check is purely structural — the type
+// body is not validated; the user-authored declaration is the source of
+// truth and the mirror compiles independently.
+func hasTypeDecl(f *goast.File, name string) bool {
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*goast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*goast.TypeSpec)
+			if !ok || ts.Name == nil {
+				continue
+			}
+			if ts.Name.Name == name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func findLoadFunc(f *goast.File) *goast.FuncDecl {
@@ -182,13 +248,28 @@ func dropField(fields []pageDataField, name string) []pageDataField {
 	return out
 }
 
-// emitPageDataStruct writes `type PageData = struct{...}` as a type alias
-// (note the `=`). The alias preserves type identity between the user's
-// inline anonymous struct literal returned by Load() and PageData, so the
-// manifest adapter's `data.(PageData)` assertion succeeds. A new named
-// type would require an explicit value conversion at the wire boundary.
-// See #109. Empty fields produce the zero-field alias form.
-func emitPageDataStruct(b *Builder, fields []pageDataField) {
+// emitPageDataStruct writes the page's PageData type alias. Three shapes:
+//
+//  1. mirrorAlias != "" — the user's server file declares a named
+//     `type PageData ...`, mirrored into the usersrc tree. Emits
+//     `type PageData = <mirrorAlias>.PageData`. Type identity flows
+//     through the alias so the manifest adapter's runtime assertion
+//     against the user's authored type succeeds.
+//  2. mirrorAlias == "" and len(fields) > 0 — the user's Load() returns
+//     an inline anonymous struct literal whose fields were inferred.
+//     Emits `type PageData = struct{...}` mirroring those fields.
+//  3. Both empty — Load() returns nothing inferable. Emits the
+//     zero-field alias `type PageData = struct{}`.
+//
+// The alias `=` is load-bearing in cases 2 and 3 too: it preserves type
+// identity between the user's anonymous struct value and PageData. A
+// named type (no `=`) would force a value conversion at the wire
+// boundary. See #109.
+func emitPageDataStruct(b *Builder, fields []pageDataField, mirrorAlias string) {
+	if mirrorAlias != "" {
+		b.Linef("type PageData = %s.PageData", mirrorAlias)
+		return
+	}
 	if len(fields) == 0 {
 		b.Line("type PageData = struct{}")
 		return

--- a/packages/sveltego/internal/codegen/pagedata_test.go
+++ b/packages/sveltego/internal/codegen/pagedata_test.go
@@ -19,7 +19,7 @@ func TestEmitPageDataStruct_AliasForm(t *testing.T) {
 		emitPageDataStruct(&b, []pageDataField{
 			{Name: "Greeting", Type: "string"},
 			{Name: "Count", Type: "int"},
-		})
+		}, "")
 		got := string(b.Bytes())
 		if !strings.Contains(got, "type PageData = struct {") {
 			t.Errorf("expected alias form `type PageData = struct {`, got:\n%s", got)
@@ -38,10 +38,30 @@ func TestEmitPageDataStruct_AliasForm(t *testing.T) {
 	t.Run("empty fields emit alias to zero-field struct", func(t *testing.T) {
 		t.Parallel()
 		var b Builder
-		emitPageDataStruct(&b, nil)
+		emitPageDataStruct(&b, nil, "")
 		got := string(b.Bytes())
 		if !strings.Contains(got, "type PageData = struct{}") {
 			t.Errorf("expected `type PageData = struct{}`, got:\n%s", got)
+		}
+	})
+
+	// Mirror-alias form covers the named-type branch: when the user's
+	// page.server.go declares `type PageData struct{...}` at package
+	// scope, the gen file aliases to <usersrc>.PageData rather than
+	// synthesizing a fresh inline struct so the manifest's runtime type
+	// assertion sees the user-authored type. Closes the standalone-
+	// scaffold variant of #143.
+	t.Run("mirror alias for named-type PageData", func(t *testing.T) {
+		t.Parallel()
+		var b Builder
+		emitPageDataStruct(&b, nil, "usersrc")
+		got := string(b.Bytes())
+		want := "type PageData = usersrc.PageData"
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+		if strings.Contains(got, "type PageData = struct{") {
+			t.Errorf("inline-struct form leaked into mirror branch:\n%s", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fresh-scaffold projects could not run `go build` because the generated `go.mod` pinned `github.com/binsarjr/sveltego/packages/sveltego v0.0.0` — a literal the proxy cannot resolve. The codegen also emitted an empty `type PageData = struct{}` alias even when the user's `page.server.go` declared a named `PageData` type, so the generated render referenced non-existent fields and failed to compile.

Closes #110. Closes the standalone-scaffold variant of #143.

## Root cause

**Bug 1** — `packages/init/internal/scaffold/scaffold.go::renderGoMod` hardcoded `require github.com/binsarjr/sveltego/packages/sveltego v0.0.0`. The release-please bootstrap pseudo-version churns on every commit; the literal `v0.0.0` tag does not exist in the proxy.

**Bug 2** — `inferPageData` only inferred fields from inline anonymous-struct returns (`return struct{...}{...}, nil`). When a user declared `type PageData struct{...}` at package scope and returned `PageData{...}`, `findFirstReturnComposite` produced an `*ast.Ident` (`PageData`), not a `*ast.StructType`, so the function fell through to the empty result. Codegen then emitted `type PageData = struct{}` while `wire.gen.go` returned a real `usersrc.PageData{Greeting:"..."}` value, forcing a type-assertion mismatch and a `data.Greeting` reference against the empty struct.

## Fix

**Bug 1** — drop the `require` line from the scaffold's `go.mod` entirely. The fresh-scaffold output is now `module <user>; go 1.23` only. `sveltego build` runs `go get github.com/binsarjr/sveltego/packages/sveltego@latest` on first invocation when the require line is missing, letting the proxy resolve the current pseudo-version and seed `go.sum`.

**Bug 2** — extend `inferDataShape` (renamed from `inferPageData`) to detect a top-level `type PageData struct{...}` (or `type LayoutData`) declaration in the user's server file. When present, return `pageDataResult{HasNamedType: true}`. `Generate` / `GenerateLayout` add a `usersrc <module>/.gen/usersrc/<encoded>` import to `page.gen.go` / `layout.gen.go` and emit `type PageData = usersrc.PageData`. Type identity flows through the alias so the manifest's `data.(<alias>.PageData)` assertion against the user-authored type succeeds.

## Files

- `packages/init/internal/scaffold/scaffold.go` — drop `v0.0.0` from the go.mod template.
- `packages/sveltego/cmd/sveltego/build.go` — auto-`go get @latest` when go.mod is missing the framework require.
- `packages/sveltego/internal/codegen/pagedata.go` — `inferDataShape` + `hasTypeDecl` for named-type detection.
- `packages/sveltego/internal/codegen/codegen.go` — thread `MirrorImportPath` through `Options` / `LayoutOptions`; add `usersrc` import; emit alias to mirror.
- `packages/sveltego/internal/codegen/build.go` — set `MirrorImportPath` on `emitPage` / `emitLayout`.

## Tests

- `TestRun_GoModNoLiteralV000` — pins the no-`v0.0.0` contract on scaffold output.
- `TestHasRequire` — table-driven coverage for go.mod parsing (single-line, block-form, comment, missing).
- `TestEmitPageDataStruct_AliasForm/mirror_alias_for_named-type_PageData` — unit test for the new branch.
- `TestBuild_PageDataNamedType` / `TestBuild_LayoutDataNamedType` — end-to-end Build runs that assert the generated `page.gen.go` / `layout.gen.go` use `type PageData = usersrc.PageData` and parse as Go.

## Test plan

- [x] `go test -count=1 ./...` green across `packages/init` (29 tests) and `packages/sveltego` (1317 tests).
- [x] `go vet ./...` clean across both modules.
- [x] `go test -race -count=1 ./internal/codegen/ ./cmd/sveltego/` green (507 tests).
- [x] `gofumpt -l` and `goimports -l` clean.
- [x] End-to-end repro of `/tmp/hello-fresh`:
  - `go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@main /tmp/smoke-fresh` → go.mod has no `v0.0.0`.
  - `go get @<post-378-commit>` (transient until `@latest` resolves to a post-#378 commit on the proxy) → tidy.
  - `sveltego build --no-client` → produces `build/app` binary that compiles cleanly.

## Notes

- The `go get @latest` step in `ensureSveltegoRequire` resolves cleanly once a post-#378 commit becomes the latest tagged or pseudo-versioned ref on the proxy. Until proxy state catches up, users can pin a known-good commit; the codegen + scaffold halves of the chain are independent and unblock the rest of the flow.
- Integration tests under `-tags=integration` (`TestIntegrationSmoke`, `TestIntegrationManifestComposes`) already exercised the inline-struct path; they remain pre-existing failures from the #378 module rename interacting with the smoke fixtures' `replace` directives, not regressions from this change.