### PR TITLE
chore(infra): bump CI matrix and go.work to Go 1.25

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Install benchstat and bench-compare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # CI budget split (Phase 0p + merge queue):
 #
-# - PR runs (lite): 1 OS × 1 Go (ubuntu-latest, 1.23.x) + changes +
+# - PR runs (lite): 1 OS × 1 Go (ubuntu-latest, 1.25.x) + changes +
 #   commit-lint + agents-sync. Roughly 4 jobs per push.
-# - merge_group runs: same lite matrix + isolated-modules (no playground-smoke).
+# - merge_group runs: full matrix [1.23.x, 1.25.x] + isolated-modules (no playground-smoke).
 #   CI runs once on the merged candidate; cancel-in-progress is disabled so
 #   the queue run always completes.
 # - Push to main: DISABLED. Flaky post-merge runs on main added noise without
@@ -71,16 +71,16 @@ jobs:
               - '.golangci.yml'
               - '.github/workflows/**'
 
-  # Lite matrix on PRs and merge_group: ubuntu-latest, go1.23.x. ~1 job.
+  # Lite matrix on PRs: ubuntu-latest, go1.25.x. ~1 job. Validates new floor.
   lint-and-test-pr:
     name: lint-and-test (${{ matrix.os }}, go${{ matrix.go }})
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request'
     needs: changes
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        go: ['1.23.x']
+        go: ['1.25.x']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -320,23 +320,24 @@ jobs:
           done
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.23.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.25.x'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: coverage
           fail_ci_if_error: false
 
-  # Full matrix on push to main: 3 OS × 2 Go. ~6 jobs.
-  lint-and-test-main:
+  # Full matrix on merge_group: 1 OS × 2 Go. ~2 jobs. Validates both toolchains
+  # before landing. Phase 4 of #387 drops 1.23.x once all modules declare 1.25.
+  lint-and-test-merge:
     name: lint-and-test (${{ matrix.os }}, go${{ matrix.go }})
-    if: github.event_name == 'push'
+    if: github.event_name == 'merge_group'
     needs: changes
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.22.x', '1.23.x']
+        os: [ubuntu-latest]
+        go: ['1.23.x', '1.25.x']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -576,18 +577,18 @@ jobs:
           done
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.23.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.25.x'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: coverage
           fail_ci_if_error: false
 
-  # Push-to-main and merge_group: catches per-module isolation breakage that the
-  # workspace path can mask. Skipped on PRs to keep PR runs lean.
+  # merge_group: catches per-module isolation breakage that the workspace path
+  # can mask. Skipped on PRs to keep PR runs lean.
   isolated-modules:
     name: isolated-modules (GOWORK=off)
-    if: github.event_name == 'push' || github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       GOWORK: off
@@ -596,7 +597,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Cache Go module and build artifacts
@@ -605,9 +606,9 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-1.22.x-isolated-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.25.x-isolated-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.22.x-isolated-
+            ${{ runner.os }}-go-1.25.x-isolated-
 
       - name: Build and test each module in isolation
         shell: bash
@@ -681,7 +682,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Assert no replace in packages/init/go.mod
@@ -760,7 +761,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Assert no replace in packages/sveltego/go.mod
@@ -829,7 +830,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Compile + Build

--- a/go.work
+++ b/go.work
@@ -1,4 +1,6 @@
-go 1.23
+go 1.25
+
+toolchain go1.25.0
 
 use (
 	./bench


### PR DESCRIPTION
## Summary

Phase 1 of #387 — Go 1.23 → 1.25 cap migration. Foundation for Phases 2-4.

- **`go.work`**: `go 1.23` → `go 1.25`; adds `toolchain go1.25.0`
- **`.github/workflows/ci.yml`**:
  - Lite-PR matrix bumped from `[1.23.x]` to `[1.25.x]` so PRs validate the new floor
  - Renamed `lint-and-test-main` → `lint-and-test-merge` (push-to-main was disabled), runs `[1.23.x, 1.25.x]` on `merge_group` to validate both toolchains during transition
  - `isolated-modules` bumped from 1.22.x → 1.25.x; trigger trimmed to `merge_group` only (push disabled)
  - `init-smoke`, `sveltego-build-smoke`, `playground-smoke` pinned `go-version` bumped to `1.25.x`
  - Codecov upload condition updated to match new lite/main version
- **`.github/workflows/bench.yml`**: `setup-go` pin bumped to `1.25.x`
- Module-level `go.mod` files untouched per Phase 1 scope; modules still declare `go 1.23` and Go 1.25 toolchain accepts that. Phase 2 (#389) handles active module bumps; Phase 3 (#390) handles held auth/cookiesession; Phase 4 (#391) drops 1.23 + dep refresh.

## Test plan

- [x] `go build ./...` clean across workspace
- [x] `go vet ./...` clean
- [x] `go test -race -short` clean per module (playground modules need `sveltego compile` → covered by `playground-smoke` CI job)
- [x] `gofumpt -l .` clean
- [x] `goimports -l -local github.com/binsarjr/sveltego .` clean
- [ ] CI matrix runs on `merge_group` against BOTH `go1.23.x` AND `go1.25.x`. Both must pass before merge.

Closes #388
Refs #387