### PR TITLE
chore(infra): bump held modules to Go 1.25

### DIFF
--- a/packages/auth/go.mod
+++ b/packages/auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/binsarjr/sveltego/auth
 
-go 1.22
+go 1.25
 
 require (
 	github.com/jackc/pgx/v5 v5.7.4

--- a/packages/cookiesession/go.mod
+++ b/packages/cookiesession/go.mod
@@ -1,3 +1,3 @@
 module github.com/binsarjr/sveltego/cookiesession
 
-go 1.23
+go 1.25


### PR DESCRIPTION
Closes #390. Phase 3 of #387.

Bumps `packages/auth/go.mod` and `packages/cookiesession/go.mod` to `go 1.25`. Config-only — no `.go` source touched. Held-package policy per `feedback_focus_core.md` respected.

Note: pre-existing `packages/auth/go.mod` declared `go 1.22` (not `go 1.23` as the issue text assumed); bumped directly to `1.25` regardless.

Verification:
- [x] `go build ./...` clean per module + workspace
- [x] `go vet ./...` clean per module
- [x] `go test -race ./... -count=1` clean per module (auth: 102 tests / 9 pkgs; cookiesession: 33 tests / 2 pkgs)
- [x] Zero `.go` files modified
- [x] No `go.sum` drift (no tidy needed)

Note: PR #336 (held cookiesession `Handle[T]`) will need rebase post-merge.