### PR TITLE
docs(rfc-379): ADR 0008 pure-Svelte pivot + doc realignment

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -19,13 +19,16 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 `sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
-Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
+As of 2026-05-01, [ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) supersedes [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md): templates are **100% pure Svelte/JS/TS**, server-side Go files own data, and codegen emits TypeScript declaration files (Go AST → `.d.ts`) for IDE autocompletion. Runtime is hybrid: build-time SSG (Node only at build time) for prerendered routes, runtime SPA (Go-only) for everything else. Phases 2–6 land via [#381](https://github.com/binsarjr/sveltego/issues/381)–[#385](https://github.com/binsarjr/sveltego/issues/385); see [RFC #379](https://github.com/binsarjr/sveltego/issues/379) for the full plan.
 
-- **No JS runtime on the server.** `.svelte` compiles to Go source via codegen (`.gen/*.go`) for SSR. Vite produces the client bundle for hydration only.
-- **Mustache expressions are Go, not JS.** `{Data.User.Name}`, `{len(Data.Posts)}`, `nil` not `null`. PascalCase fields. Validated at codegen via `go/parser.ParseExpr`.
+Hard invariants (post-ADR 0008; do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
+
+- **No JS runtime on the server at runtime.** Node may run during `sveltego build` to prerender SSG routes via `svelte/server`. The deployed Go binary plus `static/` is the entire deployable; no JS engine on the request path.
+- **Templates are pure Svelte.** `.svelte` files contain only Svelte/JS/TS — runes, JS expressions, lowercase props (`{data.user.name}`). Zero Go syntax in mustaches, blocks, or `<script>`. Svelte LSP and the npm Svelte ecosystem work without a fork.
+- **Go owns the server.** Server-side Go files return a typed data shape from `Load(ctx kit.LoadCtx)`; that shape becomes `data` in client `$props()`. JSON tags drive the Go ↔ TypeScript boundary.
+- **Codegen, not interpretation.** Static decisions at build time. Codegen emits `.svelte.d.ts` declarations (Go AST → TypeScript) plus prerendered HTML for SSG routes, instead of the old `.gen/*.go` template artifacts.
 - **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Skip Svelte 4 legacy reactivity.
-- **Codegen, not interpretation.** Static decisions at build time, no per-request template walking.
-- **Performance target:** 20–40k rps mid-complexity SSR. If a proposal cannot reach that, surface the gap before writing code.
+- **Performance target:** 20–40k rps for SSG (zero per-request work) and JSON-payload responses for SPA-mode dynamic routes. If a proposal cannot reach that, surface the gap before writing code.
 
 For high-level project context, read [`README.md`](./README.md) first, then [`CLAUDE.md`](./CLAUDE.md).
 
@@ -245,7 +248,7 @@ Concurrency: PR runs cancel-in-progress; main and merge_group runs always comple
 
 ## 7. Out of scope (do not propose)
 
-See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) revisits expression semantics — consult it before proposing a JS-runtime or full-Svelte alternative.
+See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) is the live decision on template semantics (pure Svelte/JS/TS, no Go in mustaches); [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) is superseded — consult ADR 0008 before proposing a JS-runtime-on-server, Go-mustache, or Go-VDOM alternative.
 
 Quick reference:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,13 +19,16 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 `sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
-Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
+As of 2026-05-01, [ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) supersedes [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md): templates are **100% pure Svelte/JS/TS**, server-side Go files own data, and codegen emits TypeScript declaration files (Go AST → `.d.ts`) for IDE autocompletion. Runtime is hybrid: build-time SSG (Node only at build time) for prerendered routes, runtime SPA (Go-only) for everything else. Phases 2–6 land via [#381](https://github.com/binsarjr/sveltego/issues/381)–[#385](https://github.com/binsarjr/sveltego/issues/385); see [RFC #379](https://github.com/binsarjr/sveltego/issues/379) for the full plan.
 
-- **No JS runtime on the server.** `.svelte` compiles to Go source via codegen (`.gen/*.go`) for SSR. Vite produces the client bundle for hydration only.
-- **Mustache expressions are Go, not JS.** `{Data.User.Name}`, `{len(Data.Posts)}`, `nil` not `null`. PascalCase fields. Validated at codegen via `go/parser.ParseExpr`.
+Hard invariants (post-ADR 0008; do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
+
+- **No JS runtime on the server at runtime.** Node may run during `sveltego build` to prerender SSG routes via `svelte/server`. The deployed Go binary plus `static/` is the entire deployable; no JS engine on the request path.
+- **Templates are pure Svelte.** `.svelte` files contain only Svelte/JS/TS — runes, JS expressions, lowercase props (`{data.user.name}`). Zero Go syntax in mustaches, blocks, or `<script>`. Svelte LSP and the npm Svelte ecosystem work without a fork.
+- **Go owns the server.** Server-side Go files return a typed data shape from `Load(ctx kit.LoadCtx)`; that shape becomes `data` in client `$props()`. JSON tags drive the Go ↔ TypeScript boundary.
+- **Codegen, not interpretation.** Static decisions at build time. Codegen emits `.svelte.d.ts` declarations (Go AST → TypeScript) plus prerendered HTML for SSG routes, instead of the old `.gen/*.go` template artifacts.
 - **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Skip Svelte 4 legacy reactivity.
-- **Codegen, not interpretation.** Static decisions at build time, no per-request template walking.
-- **Performance target:** 20–40k rps mid-complexity SSR. If a proposal cannot reach that, surface the gap before writing code.
+- **Performance target:** 20–40k rps for SSG (zero per-request work) and JSON-payload responses for SPA-mode dynamic routes. If a proposal cannot reach that, surface the gap before writing code.
 
 For high-level project context, read [`README.md`](./README.md) first, then [`CLAUDE.md`](./CLAUDE.md).
 
@@ -245,7 +248,7 @@ Concurrency: PR runs cancel-in-progress; main and merge_group runs always comple
 
 ## 7. Out of scope (do not propose)
 
-See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) revisits expression semantics — consult it before proposing a JS-runtime or full-Svelte alternative.
+See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) is the live decision on template semantics (pure Svelte/JS/TS, no Go in mustaches); [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) is superseded — consult ADR 0008 before proposing a JS-runtime-on-server, Go-mustache, or Go-VDOM alternative.
 
 Quick reference:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,16 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 `sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
-Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
+As of 2026-05-01, [ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) supersedes [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md): templates are **100% pure Svelte/JS/TS**, server-side Go files own data, and codegen emits TypeScript declaration files (Go AST → `.d.ts`) for IDE autocompletion. Runtime is hybrid: build-time SSG (Node only at build time) for prerendered routes, runtime SPA (Go-only) for everything else. Phases 2–6 land via [#381](https://github.com/binsarjr/sveltego/issues/381)–[#385](https://github.com/binsarjr/sveltego/issues/385); see [RFC #379](https://github.com/binsarjr/sveltego/issues/379) for the full plan.
 
-- **No JS runtime on the server.** `.svelte` compiles to Go source via codegen (`.gen/*.go`) for SSR. Vite produces the client bundle for hydration only.
-- **Mustache expressions are Go, not JS.** `{Data.User.Name}`, `{len(Data.Posts)}`, `nil` not `null`. PascalCase fields. Validated at codegen via `go/parser.ParseExpr`.
+Hard invariants (post-ADR 0008; do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
+
+- **No JS runtime on the server at runtime.** Node may run during `sveltego build` to prerender SSG routes via `svelte/server`. The deployed Go binary plus `static/` is the entire deployable; no JS engine on the request path.
+- **Templates are pure Svelte.** `.svelte` files contain only Svelte/JS/TS — runes, JS expressions, lowercase props (`{data.user.name}`). Zero Go syntax in mustaches, blocks, or `<script>`. Svelte LSP and the npm Svelte ecosystem work without a fork.
+- **Go owns the server.** Server-side Go files return a typed data shape from `Load(ctx kit.LoadCtx)`; that shape becomes `data` in client `$props()`. JSON tags drive the Go ↔ TypeScript boundary.
+- **Codegen, not interpretation.** Static decisions at build time. Codegen emits `.svelte.d.ts` declarations (Go AST → TypeScript) plus prerendered HTML for SSG routes, instead of the old `.gen/*.go` template artifacts.
 - **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Skip Svelte 4 legacy reactivity.
-- **Codegen, not interpretation.** Static decisions at build time, no per-request template walking.
-- **Performance target:** 20–40k rps mid-complexity SSR. If a proposal cannot reach that, surface the gap before writing code.
+- **Performance target:** 20–40k rps for SSG (zero per-request work) and JSON-payload responses for SPA-mode dynamic routes. If a proposal cannot reach that, surface the gap before writing code.
 
 For high-level project context, read [`README.md`](./README.md) first, then [`CLAUDE.md`](./CLAUDE.md).
 
@@ -243,7 +246,7 @@ Concurrency: PR runs cancel-in-progress; main and merge_group runs always comple
 
 ## 7. Out of scope (do not propose)
 
-See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) revisits expression semantics — consult it before proposing a JS-runtime or full-Svelte alternative.
+See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) is the live decision on template semantics (pure Svelte/JS/TS, no Go in mustaches); [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) is superseded — consult ADR 0008 before proposing a JS-runtime-on-server, Go-mustache, or Go-VDOM alternative.
 
 Quick reference:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,16 @@ Always read both `tasks/` files at session start before proposing changes.
 
 This is a **rewrite of SvelteKit's shape in pure Go**, not an embed of SvelteKit-the-JS-server. The earlier "embed JS runtime via goja/v8go/Bun" direction was rejected — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md) for the chain of reasoning. Do not reopen that decision without new evidence.
 
-Key invariants:
+As of 2026-05-01, [ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) supersedes [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md): templates pivot to **100% pure Svelte/JS/TS**. Go expressions in mustaches are out. Server-side Go files own data; codegen reads their Go AST and emits TypeScript declaration files for IDE autocompletion. Runtime is hybrid: build-time SSG (Node only at build time) for prerendered routes, runtime SPA (Go-only) for everything else. Phases 2–6 land via [#381](https://github.com/binsarjr/sveltego/issues/381)–[#385](https://github.com/binsarjr/sveltego/issues/385); see [RFC #379](https://github.com/binsarjr/sveltego/issues/379) for the full plan.
 
-- **No JS runtime on the server.** `.svelte` compiles to Go source via codegen (`.gen/*.go`) for SSR. Vite produces the client bundle for hydration only.
-- **Mustache expressions are Go, not JS.** `{Data.User.Name}`, `{len(Data.Posts)}`, `nil` not `null`. PascalCase fields. Validated at codegen via `go/parser.ParseExpr`.
+Key invariants (post-ADR 0008):
+
+- **No JS runtime on the server at runtime.** Node may run during `sveltego build` to prerender SSG routes via `svelte/server`. The deployed Go binary plus `static/` is the entire deployable; no JS engine on the request path.
+- **Templates are pure Svelte.** `.svelte` files contain only Svelte/JS/TS — runes, JS expressions, lowercase props (`{data.user.name}`). Zero Go syntax in mustaches, blocks, or `<script>`. Svelte LSP and the npm Svelte ecosystem work without a fork.
+- **Go owns the server.** Server-side Go files return a typed data shape from `Load(ctx kit.LoadCtx)`; that shape becomes `data` in client `$props()`. JSON tags drive the Go ↔ TypeScript boundary.
+- **Codegen, not interpretation.** Static decisions at build time. Codegen now emits `.svelte.d.ts` declarations (Go AST → TypeScript) plus prerendered HTML for SSG routes, instead of the old `.gen/*.go` template artifacts. No per-request template walking.
 - **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Skip Svelte 4 legacy reactivity.
-- **Codegen, not interpretation.** Static decisions at build time, no per-request template walking.
-- **Performance target:** 20–40k rps mid-complexity SSR. If a proposal can't reach that, surface it before writing code.
+- **Performance target:** 20–40k rps for SSG (zero per-request work) and JSON-payload responses for SPA-mode dynamic routes. If a proposal can't reach that, surface it before writing code.
 
 ## Working rules (do not skip)
 
@@ -263,7 +266,7 @@ through `go/parser` directly. See ADR 0003 amendment (Phase 0i-fix).
 
 ## Out of scope (do not propose)
 
-See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) revisits expression semantics (Proposed — consult before proposing a JS-runtime or full-Svelte alternative).
+See [ADR 0005](tasks/decisions/0005-non-goals.md) for the canonical list and reasoning. [ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) is the live decision on template semantics (pure Svelte/JS/TS, no Go in mustaches); [ADR 0007](tasks/decisions/0007-svelte-semantics-revisit.md) is superseded — consult ADR 0008 before proposing a JS-runtime-on-server, Go-mustache, or Go-VDOM alternative.
 
 - Universal (shared client+server) `Load` (`+page.ts` / `+layout.ts`). Server-only by design.
 - `<script context="module">` (deprecated upstream).

--- a/README.md
+++ b/README.md
@@ -1,45 +1,51 @@
 # sveltego
 
-> SvelteKit-shape framework for Go. Native runtime, zero JS server.
+> SvelteKit-shape framework for Go. Pure-Svelte templates, Go-only server, zero JS at runtime.
 
-Rewritten from scratch in Go. File layout and DX mirror SvelteKit (file-based routing, `page.server.go`, layouts, hooks, form actions). Svelte components are compiled to Go source via codegen — no JS runtime on the server. The CPU bonds to Go, not V8.
+Rewritten from scratch in Go. File layout and DX mirror SvelteKit (file-based routing, server-side Go data loaders, layouts, hooks, form actions). Templates are 100% pure Svelte/JS/TS; Go owns the server and emits TypeScript declarations for IDE autocompletion. The runtime is hybrid: build-time static prerender (SSG) for marketing-style routes, client-side render (SPA) for everything else. The deployed Go binary has no JS engine.
 
 ## Status
 
 🚧 Pre-alpha. MVP closed; v0.2 (form actions, hooks), v0.4 (Svelte 5 runes), and v1.1 (LLM tooling) shipped. v0.3 (client SPA + hydration), v0.5 (SvelteKit-parity catch-up), v0.6 (auth), and v1.0 (production hardening) in flight. See [GitHub issues](https://github.com/binsarjr/sveltego/issues) for the live roadmap.
 
+[ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md) (2026-05-01) pivots templates from Go-decorated mustaches to **100% pure Svelte/JS/TS**. Migration phases land via [RFC #379](https://github.com/binsarjr/sveltego/issues/379) → [#380](https://github.com/binsarjr/sveltego/issues/380)–[#385](https://github.com/binsarjr/sveltego/issues/385).
+
 ## Goals
 
-- Go-level performance — target **20–40k rps** for mid-complexity SSR
+- Go-level performance — target **20–40k rps** for SSG output (zero per-request work) and JSON-payload responses on SPA-mode dynamic routes
 - Goroutine-native concurrency, no JS worker pool
-- DX nearly identical to SvelteKit (file structure and conventions)
-- Single Go binary deploy, no Node or Bun runtime
-- Svelte 5 (runes) as the UI source of truth, dual-target codegen (server Go + client JS)
+- DX identical to SvelteKit at the template layer — copy `.svelte` files between projects unchanged
+- Single Go binary deploy, no Node or Bun runtime at request time (Node runs only during `sveltego build` for SSG)
+- Svelte 5 (runes) as the UI source of truth; Go AST → TypeScript declaration codegen for type-safe `data` props in templates
 
 ## Non-Goals
 
-- 100% compatibility with SvelteKit JS plugins or libraries
+- A server-side JS runtime at request time
 - Svelte 4 legacy syntax
-- Dynamic JS execution on the server
+- Backward compatibility with the previous Mustache-Go template dialect (pre-alpha; users rewrite)
 
-Full enumerated list with reasoning: [ADR 0005 — Non-goals](tasks/decisions/0005-non-goals.md) (mirrors [issue #94](https://github.com/binsarjr/sveltego/issues/94)).
+Full enumerated list with reasoning: [ADR 0005 — Non-goals](tasks/decisions/0005-non-goals.md) (mirrors [issue #94](https://github.com/binsarjr/sveltego/issues/94)). Template semantics: [ADR 0008 — Pure-Svelte pivot](tasks/decisions/0008-pure-svelte-pivot.md).
 
 ## Architecture
 
+Pure-Svelte templates on the client, Go-only on the server, hybrid runtime.
+
 ```
-.svelte (UI)            ──┬─→ codegen → .gen/*.go    (server SSR)
-                          └─→ Vite build → JS bundle (client hydration)
-page.server.go          ──→  Load(), Actions()           (//go:build sveltego)
-layout.server.go        ──→  Load() with parent data flow (//go:build sveltego)
-hooks.server.go         ──→  Handle, HandleError, HandleFetch
-server.go               ──→  REST endpoints              (//go:build sveltego)
-                          ↓
-                  sveltego CLI (pure Go)
-                          ↓
-                       go:embed
-                          ↓
-                   single binary deploy
+.svelte (UI, 100% Svelte/JS/TS)  ──→ Vite build → JS bundle   (client hydration)
+                                  └─→ svelte/server (build time only) → static HTML (SSG)
+server-side Go (route data)      ──→ Load(), Actions()        (//go:build sveltego)
+                                  └─→ codegen → .svelte.d.ts  (Go AST → TypeScript types)
+hooks.server.go                  ──→ Handle, HandleError, HandleFetch
+                                          ↓
+                                  sveltego CLI (pure Go)
+                                          ↓
+                                       go:embed
+                                          ↓
+                                  single binary deploy
+                                  + static/ (SSG output, optional)
 ```
+
+Routes opting into `kit.PageOptions{Prerender: true}` ship as static HTML rendered at build time via `svelte/server`. Everything else ships as a SPA shell + JSON payload at runtime; the client mounts and renders. **Node is required at build time only.** The deployed Go binary plus `static/` is the entire deployable.
 
 ## Quickstart
 
@@ -68,24 +74,41 @@ sveltego-init ./hello
 
 </details>
 
-## Expression philosophy
+## Template philosophy
 
-Inside `.svelte`, `{...}` mustaches are **Go expressions**, not JS:
+Templates are **100% pure Svelte/JS/TS** ([ADR 0008](tasks/decisions/0008-pure-svelte-pivot.md)). No Go syntax inside `.svelte` files; everything reads like SvelteKit:
 
 ```svelte
-<script lang="go">
-  import "strconv"
+<script lang="ts">
+  let { data } = $props();
 </script>
 
-<h1>{Data.User.Name}</h1>
-{#if len(Data.Posts) > 0}
-  {#each Data.Posts as p}
-    <li>{p.Title}</li>
-  {/each}
+<h1>Hello {data.user.name}</h1>
+{#if data.posts.length > 0}
+  <ul>
+    {#each data.posts as post}
+      <li>{post.title}</li>
+    {/each}
+  </ul>
 {/if}
 ```
 
-Field names are PascalCase (Go exported). `nil` not `null`, `len(x)` not `x.length`, `strconv.Itoa(n)` for explicit number formatting.
+Server-side, a Go file returns the `data` shape:
+
+```go
+//go:build sveltego
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
+
+func Load(ctx kit.LoadCtx) (PageData, error) {
+    return PageData{User: fetchUser(ctx), Posts: fetchPosts(ctx)}, nil
+}
+```
+
+Codegen reads the Go AST and emits a sibling `.svelte.d.ts` declaration so Svelte LSP / vscode-svelte autocomplete `data.user.name` end to end. JSON tags drive field names at the Go ↔ TypeScript boundary; `kit.Streamed[T]` maps to `Promise<T[]>` for native `{#await}` blocks.
 
 ## Roadmap
 
@@ -111,7 +134,7 @@ packages/
   sveltego/             # Core: parser, codegen, runtime, kit, router, server, CLI
   auth/                 # First-party auth library (ADR 0006; #216–#255)
   init/                 # `sveltego-init` scaffolder (standalone binary)
-  lsp/                  # Language server for `.svelte` with Go expressions
+  lsp/                  # Language server for sveltego routes (Go-side `Load` + emitted `.svelte.d.ts`)
   mcp/                  # Model Context Protocol server (search_docs, lookup_api, …)
   enhanced-img/         # Image optimization helpers
   adapter-server/       # Bare HTTP binary deploy

--- a/tasks/decisions/0007-svelte-semantics-revisit.md
+++ b/tasks/decisions/0007-svelte-semantics-revisit.md
@@ -1,10 +1,10 @@
 # ADR 0007 — Svelte Semantics Revisit (Go-mustache vs Full-Svelte)
 
-- **Status:** Proposed
+- **Status:** Superseded by [ADR 0008](0008-pure-svelte-pivot.md) (2026-05-01)
 - **Date:** 2026-04-30
 - **Authors:** binsarjr, orchestrator
 - **Issue:** [binsarjr/sveltego#309](https://github.com/binsarjr/sveltego/issues/309)
-- **Supersedes (if Accepted):** sections of [ADR 0001](0001-parser-strategy.md) and [ADR 0002](0002-expression-syntax.md) covering expression syntax and template semantics. Status remains **Proposed** until the team converges.
+- **Superseded by:** [ADR 0008 — Pivot to Pure-Svelte Templates](0008-pure-svelte-pivot.md). The team rejected all five options enumerated below (A status quo, B JS runtime SSR, C CSR-only, D Go VDOM, E sugar) and chose a sixth path captured in RFC [#379](https://github.com/binsarjr/sveltego/issues/379): pure-Svelte templates with Go-AST → TypeScript declaration codegen, plus hybrid SSG (Node at build time only) + SPA runtime. The no-JS-runtime-on-server invariant is preserved. See ADR 0008 for the resolution.
 - **Related:** [ADR 0003](0003-file-convention.md), [ADR 0004](0004-codegen-shape.md), [ADR 0005](0005-non-goals.md), Issue #174 (file-naming RFC).
 
 > Working document. Not a dictation. The recommendation below is the

--- a/tasks/decisions/0008-pure-svelte-pivot.md
+++ b/tasks/decisions/0008-pure-svelte-pivot.md
@@ -1,0 +1,86 @@
+# ADR 0008 — Pivot to Pure-Svelte Templates
+
+- **Status:** Accepted
+- **Date:** 2026-05-01
+- **Authors:** binsarjr, orchestrator
+- **Issue:** [binsarjr/sveltego#379](https://github.com/binsarjr/sveltego/issues/379)
+- **Supersedes:** [ADR 0007](0007-svelte-semantics-revisit.md) (Proposed); the "Mustache expressions are Go" half of [ADR 0001](0001-parser-strategy.md) and [ADR 0002](0002-expression-syntax.md). Codegen-shape and file-convention ADRs (0003, 0004) remain in force, with template-emit lowered to typegen + Vite passthrough.
+- **Related:** [ADR 0005](0005-non-goals.md) (no JS runtime on the server — preserved), RFC #309 (Svelte semantics revisit), Spike #311 (JS runtime survey), Spike #313 (runes evaluation surface).
+
+## Context
+
+ADR 0001/0002 made `.svelte` files **Go-decorated templates**: mustaches held Go expressions (`{Data.User.Name}`, `{len(Data.Posts)}`), validated at codegen via `go/parser.ParseExpr`. ADR 0005 locked "no JS runtime on the server" to keep the Go binary the entire deployable.
+
+Three pressure points surfaced in the 2026-05-01 user conversation that ADR 0007 had only proposed (not resolved):
+
+1. **Two-language friction inside one file.** Devs read `.svelte`, expected Svelte/JS expressions, and wrote `{user.name}` then debugged `{Data.User.Name}` errors. The cognitive switch happened mid-template, every template.
+2. **Svelte ecosystem incompatibility.** Off-the-shelf `.svelte` components from npm assume JS expressions. Sveltego forked the dialect; reuse meant rewriting every component.
+3. **SvelteKit migration friction.** `docs/why-sveltego.md` named "zero-curve migration from SvelteKit" as a goal. Mustache-Go templates contradict that goal — every page needs a rewrite, not a port.
+
+Five reinterpretations were on the table in ADR 0007 (status quo, JS-runtime SSR, CSR-only, Go VDOM, sugar layer). None preserved the SvelteKit migration goal **and** the no-JS-runtime invariant **and** the Svelte ecosystem reuse goal simultaneously. The user picked a sixth path that does: keep templates 100% Svelte/JS/TS at authoring time, push all Go server-side, and split runtime into hybrid SSG (Node only at build time) + SPA (Go-only at runtime).
+
+## Decision
+
+Pivot `.svelte` files from Go-decorated templates to **100% pure Svelte/JS/TS**. The Go binary still has zero JS engine at runtime. Single static binary deploy stays the invariant.
+
+Concretely:
+
+1. **Templates are pure Svelte.** `.svelte` files contain only Svelte/JS/TS — runes, JS expressions, lowercase props (`{data.user.name}`). **Zero Go syntax** in mustaches, blocks, or `<script>`. Svelte LSP and the wider Svelte ecosystem work without a fork.
+2. **Go owns the server.** A Go-only file (the project's `*.server.go` route file under `src/routes/...`) is the only place Go touches a route. It returns a typed data shape from `Load(ctx kit.LoadCtx)`; that shape becomes `data` in client `$props()`.
+3. **Codegen emits TypeScript declarations.** A new Go-AST → TypeScript walker (`internal/codegen/typegen/`) reads each route's Go `Load` return type and emits a sibling `.svelte.d.ts` file per route. JSON tags drive field names; the type table maps `kit.Streamed[T]` → `Promise<T[]>`, `*T` → `T | null`, `time.Time` → `string`, etc. IDE autocomplete via Svelte LSP / vscode-svelte; drift caught by typegen golden tests.
+4. **Hybrid SSG + SPA runtime.** Routes opting into `kit.PageOptions{Prerender: true}` are rendered to static HTML at `sveltego build` via a one-shot Node process invoking `svelte/server`. Routes without `Prerender` ship the SPA shell (`app.html` + JSON payload) and hydrate client-side. **Node is required at build time only.** The deployable is the Go binary plus `static/`.
+5. **Streaming uses existing primitives.** `kit.Streamed[T]` flows through the existing `__sveltego__resolve` patch protocol (PR #366). The client-side wrapper exposes a `Promise<T[]>` to `$props()`; `.svelte` templates use Svelte's native `{#await}` block.
+6. **Mustache-Go codegen is removed.** Roughly 80% of the current template parser, element handlers, block emitters, and scoped-CSS Go-side codegen are deleted. Vite + svelte-preprocess take over those responsibilities for the client bundle. Pre-alpha; no compatibility shim.
+
+Migration runs across six phases tracked in `binsarjr/sveltego#380–#385`. Phase 1 (this ADR + doc realignment) is the approval gate; Phases 2–6 implement typegen, parallel pure-Svelte pipeline, playground/AI-template rewrite, deletion of Mustache-Go, and an optional perf re-bench.
+
+## Consequences
+
+### Enables
+
+- **Direct Svelte ecosystem reuse.** `.svelte` components from npm work without a dialect rewrite.
+- **SvelteKit-shaped migration.** Porting a SvelteKit app means swapping `+page.ts` loaders for `*.server.go` and accepting the type-mapping table; templates copy over verbatim.
+- **Lower mental load.** One language inside a template. JS expressions for client, Go for server, JSON-tag boundary between them.
+- **SSG-grade marketing routes.** `Prerender: true` produces static HTML at build time — no per-request work, optimal LCP for content pages.
+
+### Drops
+
+- **Build-time validation of template expressions.** Today, `{Data.User.NamE}` is a Go compile error. Post-pivot, `{data.user.namE}` typos surface only via Svelte LSP + TypeScript checking against the generated `.d.ts`. JS-only authors get less safety than Go-typed authors.
+- **The current SSR throughput proposition.** SPA-mode first paint is slower than the Mustache-Go SSR path because the client must boot before render. The 20–40k rps target now applies to JSON-payload responses (server side) and to SSG output (zero per-request cost), not to per-request HTML rendering. Marketing-style routes use `Prerender: true`; dynamic routes accept the SPA tradeoff.
+- **~80% of the existing Mustache-Go codegen.** Mustache parser, element handlers, block emitters, scoped-CSS Go-side codegen, expression validation, and the `.gen/*.go` template artifacts are deleted in Phase 5.
+- **Backward compatibility.** Pre-alpha; users rewrite their templates. No deprecation window for Mustache-Go.
+
+### Preserves
+
+- **No JS runtime on the server at runtime.** ADR 0005 invariant intact. Node runs only during `sveltego build` for SSG; the deployed Go binary has no JS engine.
+- **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Svelte 4 legacy reactivity remains out of scope.
+- **Codegen, not interpretation.** The codegen pipeline narrows but does not disappear: route scan, manifest, server-side `Load` AST extraction, `.d.ts` emission, prerender orchestration, hydration payload all remain compile-time work.
+- **File convention.** Route file names, `//go:build sveltego` tags on user Go files, `.gen/` provenance, `$lib`/`hooks.server.go`/`+error.svelte` semantics unchanged. ADR 0003 stands.
+- **Single static binary deploy.** Go binary plus `static/` is still the entire deployable.
+
+### Defers (subsequent issues)
+
+- **Phase 2 — typegen scaffold** (`#381`): Go AST → TypeScript walker, type-mapping table, golden tests, `.d.ts` emission alongside the legacy pipeline.
+- **Phase 3 — parallel pure-Svelte pipeline** (`#382`): per-route opt-in via `kit.PageOptions{Templates: "svelte"}`; SPA runtime; SSG via `svelte/server` at build time; smoke test on `playgrounds/basic`.
+- **Phase 4 — playground + AI template rewrite** (`#383`): rewrite all three playgrounds and `templates/ai/*` to pure Svelte; refresh quickstart + reference docs.
+- **Phase 5 — drop Mustache-Go path** (`#384`): delete the legacy parser, handlers, golden files, and the `Templates: "go-mustache"` option; `STABILITY.md` per package logs the breaking change.
+- **Phase 6 — bench + perf gate** (`#385`, optional): re-run bench harness; update `docs/perf.md`; surface regressions > 20% for discussion.
+
+## Supersedes
+
+- [ADR 0007 — Svelte Semantics Revisit](0007-svelte-semantics-revisit.md) — moves from `Proposed` → `Superseded by 0008` on this date. Option A (status quo Mustache-Go) and Options B/C/D/E (JS runtime, CSR-only, Go VDOM, sugar) are all rejected; the chosen path is pure-Svelte templates with Go-AST → `.d.ts` codegen plus hybrid SSG+SPA runtime.
+- The "expressions are Go" half of [ADR 0001](0001-parser-strategy.md) and [ADR 0002](0002-expression-syntax.md). The hand-rolled Svelte parser and Go expression validator give way to Vite + svelte-preprocess for templates and `go/ast` walking for the server-side `Load` type. Codegen-shape ([ADR 0004](0004-codegen-shape.md)) and file-convention ([ADR 0003](0003-file-convention.md)) ADRs survive intact.
+
+## References
+
+- [RFC #379 — pivot to pure-Svelte client templates + Go-only server](https://github.com/binsarjr/sveltego/issues/379) — full design, decision tree, migration phases, AskUserQuestion answers from 2026-05-01.
+- [Phase 1 issue #380](https://github.com/binsarjr/sveltego/issues/380) — this ADR's tracking issue.
+- [ADR 0007 — Svelte Semantics Revisit](0007-svelte-semantics-revisit.md) — superseded by this ADR.
+- [ADR 0005 — Non-Goals](0005-non-goals.md) — no-JS-runtime invariant preserved.
+- [RFC #309 — revisit Svelte semantics](https://github.com/binsarjr/sveltego/issues/309) — Option A vs B/C/D/E discussion that this ADR resolves.
+- Lesson: [pivot to Go-native rewrite (2026-04-29)](../lessons/2026-04-29-pivot-to-go-native-rewrite.md) — original "no JS runtime on server" rationale, still load-bearing.
+- PR #352 — hydration payload runtime; reused for SPA-mode JSON payload.
+- PR #360 — SPA router runtime; reused for client-side navigation post-pivot.
+- PR #366 — streaming hydration payload; `kit.Streamed[T]` → `Promise<T[]>` flows through this protocol.
+- PR #372 — prerender bundle; becomes the SSG mode in Phase 3.
+- Parent project direction: `CLAUDE.md` "Project direction" section, `AGENTS.md` "Project shape" section.


### PR DESCRIPTION
Closes #380. Phase 1 of RFC #379.

ADR 0008 documents the pivot from Mustache-Go to pure-Svelte templates. Realigns CLAUDE.md, AGENTS.md, .cursorrules, copilot-instructions, README.md to the new direction. Flips ADR 0007 to Superseded.

**Targets integration branch** `feat/pure-svelte-pivot-379`. Final PR to main lands after all RFC #379 phases merge into the integration branch.

**Scope boundary respected:** no file-name references touched (owned by #397). No scaffold or codegen edits.