### PR TITLE
docs: doc-drift audit after Go 1.25 chain

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -17,7 +17,7 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), six deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), six deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ If a per-package `CLAUDE.md` exists (e.g. `packages/sveltego/internal/codegen/CL
 
 ## 1. Project shape
 
-`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
+`sveltego` is a **rewrite of SvelteKit's shape in pure Go**, not an embedding of SvelteKit-the-JS-server. Pre-alpha. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), six deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates, and end-to-end playgrounds. MVP, v0.2, v0.4, and v1.1 milestones have shipped; v0.3, v0.5, v0.6, and v1.0 are in flight on `binsarjr/sveltego`.
 
 Hard invariants (do not reopen without new evidence — see [`tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md`](tasks/lessons/2026-04-29-pivot-to-go-native-rewrite.md)):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ When in doubt about a convention: open the relevant issue with `gh issue view <N
 
 ## Repository state
 
-Pre-alpha. MVP closed; v0.2, v0.4, and v1.1 shipped; v0.3, v0.5, v0.6, and v1.0 in flight. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), five deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates (`templates/ai/`), and end-to-end playgrounds. New work continues to flow through:
+Pre-alpha. MVP closed; v0.2, v0.4, and v1.1 shipped; v0.3, v0.5, v0.6, and v1.0 in flight. The Go workspace already hosts the core (`packages/sveltego`), auth (`packages/auth`), tooling (`packages/lsp`, `packages/mcp`, `packages/init`, `packages/enhanced-img`), six deploy adapters plus `adapter-auto`, the bench harness (`bench/`, `benchmarks/`), AI templates (`templates/ai/`), and end-to-end playgrounds. New work continues to flow through:
 
 - `tasks/todo.md` — current execution plan, milestone scope, phase tracking
 - `tasks/lessons.md` — design decisions and self-rules captured per session (append-only journal)
@@ -211,7 +211,7 @@ If counts, file lists, or roadmap stages disagree across these, the doc set is b
 | v0.4 | 19 (#43–59, #86, #90) | Svelte 5 full coverage, a11y, `<svelte:options>` |
 | v0.5 | 23 (SvelteKit-parity catch-up + cookie-session core) | Upstream-tracked enhancements (`kit.After`, `HandleAction`, `RawParam`, `RouteID`, …) and the cookie-session auth core |
 | v0.6 | 40 (auth track) | `sveltego-auth` master plan (#155), storage adapters, sessions, password / magic-link / OTP / OAuth |
-| v1.0 | 25 (#60–69, #89, #91–93, plus post-merge code-quality follow-ups) | Bench, docs, streaming, SSG, CSP, sitemap, image opt, deploy adapters, post-Wave-1 hardening |
+| v1.0 | 28 (#60–69, #89, #91–93, plus post-merge code-quality follow-ups) | Bench, docs, streaming, SSG, CSP, sitemap, image opt, deploy adapters, post-Wave-1 hardening |
 | v1.1 | 6 (#70–75) | LLM tooling: `llms.txt`, MCP server, AI templates, provenance |
 
 Closed standalone issues (e.g. #94 non-goals RFC) live unmilestoned — search `gh issue list --search "no:milestone state:closed"` if needed.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Field names are PascalCase (Go exported). `nil` not `null`, `len(x)` not `x.leng
 | **v0.4** | 19 | Svelte 5 runes, slots, snippets, special elements, `<svelte:options>`, scoped CSS, a11y warnings |
 | **v0.5** | 23 | SvelteKit-parity catch-up: upstream-tracked enhancements (`kit.After`, `HandleAction`, `RawParam`, `RouteID`, etc.) and the cookie-session auth core |
 | **v0.6** | 40 | Authentication: `sveltego-auth` master plan (#155), storage adapters, sessions, password / magic-link / OTP / OAuth flows |
-| **v1.0** | 25 | Benchmarks, docs, examples, streaming/SSG/CSP, sitemap, image opt, deploy adapters, CI/release/LSP, service worker, post-merge code-quality follow-ups |
+| **v1.0** | 28 | Benchmarks, docs, examples, streaming/SSG/CSP, sitemap, image opt, deploy adapters, CI/release/LSP, service worker, post-merge code-quality follow-ups |
 | **v1.1** | 6 | LLM tooling: `llms.txt`, MCP server, copy-for-LLM, AI templates, provenance |
 
 ## Repository layout
@@ -119,6 +119,7 @@ packages/
   adapter-lambda/       # AWS Lambda via aws-lambda-go-api-proxy
   adapter-static/       # SSG output (stub; tracks #65)
   adapter-cloudflare/   # Cloudflare Workers (stub; tracks Workers Go runtime)
+  adapter-fastly/       # Fastly Compute@Edge (Wasm; #298)
   adapter-auto/         # Dispatch by env / target name + standalone CLI
 bench/                  # Benchmark harness vs adapter-bun (RFC #105)
 benchmarks/             # Per-package microbenchmarks

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -47,7 +47,7 @@ Vite integration for the Svelte client bundle, `window.__sveltego__` hydration p
 
 Runes: `$props`, `$state`, `$derived`, `$effect`, `$bindable`. Snippets and `{@render}`. Legacy slots (default + named, with slot props). Special elements: `<svelte:head>`, `<svelte:body>` / `<svelte:window>` / `<svelte:document>`, `<svelte:component>`, `<svelte:options>`. CSS scope hash matching upstream. `{@html}`, `{@const}`, `{#await}`, `{#key}`. Nested component import and rendering. Compile-time a11y warnings.
 
-### v1.0 (25 issues) — Production Ready
+### v1.0 (28 issues) — Production Ready
 
 Benchmark suite vs adapter-bun with nightly regression gate. Docs site (Vitepress). Blog and dashboard examples. Streaming responses. Prerender / SSG mode. CSP nonce injection. CI (GitHub Actions). Release pipeline (release-please + GoReleaser). LSP for `.svelte` with Go expressions. Sitemap/robots helpers, image optimization (`<Image>`), service worker convention, deploy adapters (server, docker, static, lambda, cloudflare).
 
@@ -82,7 +82,7 @@ Full `sveltego-auth` package modeled on the better-auth feature set: master plan
 - [x] Direction confirmed (Go-native rewrite, not JS embed)
 - [x] Repo created at `binsarjr/sveltego`
 - [x] Issue templates (feature, RFC, bug)
-- [x] 20 labels, 6 milestones, 105 issues created (initial roadmap snapshot; live counts now 8 milestones / 221 issues — see milestone table above)
+- [x] 20 labels, 6 milestones, 105 issues created (initial roadmap snapshot; live counts now 8 milestones / 194 issues — see milestone table above)
 - [x] All 69 original issues rewritten in English with industry-standard detail
 - [x] v1.1 milestone added — LLM & AI tooling (#70–75)
 - [x] SvelteKit-parity gap audit + 19 issues filed with priorities (#76–94)
@@ -109,7 +109,7 @@ Full `sveltego-auth` package modeled on the better-auth feature set: master plan
 - [x] v1.1 milestone — Vitepress docs site + `llms.txt` + copy-for-LLM + AI guide (#70, #71, #72, #73, #74, #75). `sveltego mcp` scaffold (#71), AI templates `templates/ai/` (#73), `llms.txt` + `llms-full.txt`, markdown guide. 6 issues total. **CLOSED.**
 - [x] v0.5 wave (partial, ongoing) — SvelteKit-parity catch-up: `kit.After()`, `HandleAction`, `Init()` error fallback, `HandleError` short-circuit, `LoadCtx.Speculative()`, `kit.HTTPError`, headers/cookies on error responses, `kit.RedirectReload`, `LoadCtx.RawParam()`, codegen `RouteID` constants, dev-only code stripping, `kit.Header` Set vs Add, MIME type registration, `kit.Error` default message, `static asset precompression`. Auth core (`packages/auth`) scaffold + storage + mailer + SMS adapters (#216, #217, #226, #227). ADR 0006 (auth master plan), ADR 0007 (Svelte semantics revisit). STABILITY.md per package. 23 issues tracked; in flight.
 - [ ] v0.5 remaining — `kit.After`, `HandleAction` wire-up, `iter.Seq` streamed, kit.Cron, child-component pkg gen, cookiesession (#160, #161, #166, #167, #173, etc.) — 4 open issues.
-- [ ] v0.6 in-flight — auth: session strategy (#220), password hashing (#222), email verification (#224), magic-link (#229), OTP (#230), TOTP (#231), OAuth core (#236), RBAC (#245), and many more. 37 open issues.
+- [ ] v0.6 in-flight — auth: session strategy (#220), password hashing (#222), email verification (#224), magic-link (#229), OTP (#230), TOTP (#231), OAuth core (#236), RBAC (#245), and many more. 30 open issues.
 
 ## Open questions
 


### PR DESCRIPTION
Runs `feedback_doc_drift.md` audit after RFC #387 Phases 1-4 merged. Fixes safe drift; no ambiguous items needed follow-up issues.

## Categories audited
- Issue counts per milestone
- Go version floor (now 1.25)
- Module path consistency
- Pinned dep versions
- Package list completeness
- Adapter list

## Findings

**Issue counts (5 fixes):**
- v1.0 milestone: 25 → 28 (verified live: open=4 closed=24 total=28). Updated in `README.md`, `CLAUDE.md` Roadmap structure table, `tasks/todo.md` v1.0 heading.
- Total milestoned issue count: `tasks/todo.md` historical-checkpoint line "8 milestones / 221 issues" → 194 (live verified).
- v0.6 open count: `tasks/todo.md` "37 open issues" → 30 open issues (live verified).

**Package + adapter list (3 fixes):**
- `README.md` "Repository layout" added `adapter-fastly` (#298 landed; was missing).
- `CLAUDE.md` Repository state: "five deploy adapters plus `adapter-auto`" → "six deploy adapters plus `adapter-auto`" (auto + cloudflare + docker + fastly + lambda + server + static).
- `AGENTS.md` Project shape: same fix; `.cursorrules` + `.github/copilot-instructions.md` re-synced via `scripts/sync-ai-docs.sh`.

**Clean (no drift):**
- Go 1.25 floor: `go.work` declares `go 1.25 / toolchain go1.25.0`. Only "1.23" hit is in `tasks/todo.md` Phase 0p historical log — preserved as historical context.
- Module paths: all `github.com/binsarjr/sveltego/packages/<pkg>` references correct.
- Pinned dep versions: not surfaced in root docs (lives per-package).

## Skipped per rules
- Root `CLAUDE.md` "Project direction" + "Out of scope" sections — owned by #380.
- All `+page.*` filename references (CLAUDE.md L235-240, AGENTS.md L202-207, tasks/todo.md L40, L124) — owned by #397.
- `packages/auth/`, `packages/cookiesession/` — held packages.

## Follow-ups filed
None — all drift was safe-to-fix.

## Test plan
- [x] `go build ./...` passes locally
- [x] `scripts/validate-commits.sh HEAD~1..HEAD` passes
- [x] `scripts/sync-ai-docs.sh` re-ran cleanly, `.cursorrules` + `copilot-instructions.md` regenerated