### PR TITLE
feat(svelte-mode): pure-Svelte template path + SSG sidecar (rfc-379 P3)

### DIFF
--- a/packages/init/internal/scaffold/scaffold.go
+++ b/packages/init/internal/scaffold/scaffold.go
@@ -151,6 +151,7 @@ func baseFiles(module string, flavor TailwindFlavor) []file {
 		{path: "app.html", body: []byte(appHTMLBody)},
 		{path: "package.json", body: []byte(renderPackageJSON(module, flavor))},
 		{path: "vite.config.js", body: []byte(viteConfigBody)},
+		{path: "tsconfig.json", body: []byte(tsconfigBody)},
 		{path: "sveltego.config.go", body: []byte(configBody)},
 		{path: "hooks.server.go", body: []byte(hooksBody)},
 		{path: "cmd/app/main.go", body: []byte(renderMainGo(module))},
@@ -288,6 +289,38 @@ const appHTMLBody = `<!DOCTYPE html>
 %sveltego.body%
 </body>
 </html>
+`
+
+// tsconfigBody seeds the TypeScript project so Svelte LSP and
+// vscode-svelte pick up the auto-generated `_page.svelte.d.ts` /
+// `_layout.svelte.d.ts` files (RFC #379 phase 2 typegen output) for
+// Svelte-mode routes. The include glob covers .svelte sources plus
+// the generated declarations alongside them. Users may extend the
+// strictness flags freely; sveltego does not re-read this file.
+const tsconfigBody = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.js",
+    "src/**/*.svelte",
+    "src/**/*.svelte.d.ts",
+    "vite.config.js"
+  ]
+}
 `
 
 const viteConfigBody = `import { svelte } from '@sveltejs/vite-plugin-svelte';

--- a/packages/sveltego/exports/kit/STABILITY.md
+++ b/packages/sveltego/exports/kit/STABILITY.md
@@ -69,9 +69,11 @@ Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97).
 - `kit.BuildCSPHeader` — builds a CSP header value string
 - `kit.CSPHeaderName` — returns the header name for the given CSP mode
 - `kit.TrailingSlash` — enumeration of trailing-slash policies
-- `kit.PageOptions` — per-route rendering options
+- `kit.PageOptions` — per-route rendering options (now includes `Templates`: "go-mustache" default, "svelte" opt-in for RFC #379 phase 3)
 - `kit.PageOptionsOverride` — partial options for merging into PageOptions
 - `kit.DefaultPageOptions` — returns sensible defaults
+- `kit.TemplatesGoMustache` — string constant for the Mustache-Go template pipeline
+- `kit.TemplatesSvelte` — string constant for the pure-Svelte template pipeline
 - `kit.M` — type alias for `map[string]any`
 - `kit.JSON` — builds a JSON response
 - `kit.Text` — builds a plain-text response

--- a/packages/sveltego/exports/kit/page_options.go
+++ b/packages/sveltego/exports/kit/page_options.go
@@ -59,6 +59,20 @@ func (ts TrailingSlash) String() string {
 // pool and cache best when the width set is stable. Only the project
 // root's default value is consulted; per-route overrides are ignored
 // because the pool is not partitioned by route.
+//
+// Templates picks the per-route template pipeline (RFC #379 phase 3):
+//   - "go-mustache" (Phase 3 default for backward compat): codegen parses
+//     the .svelte body and emits Go SSR (Mustache-Go expressions).
+//   - "svelte": codegen leaves the .svelte body for Vite + Svelte to
+//     compile; the server returns the app.html shell plus a JSON
+//     hydration payload, the client mounts and renders. Routes with
+//     Prerender: true plus Templates: "svelte" are rendered to static
+//     HTML at build time via a Node `svelte/server` sidecar; the runtime
+//     stays JS-free.
+//
+// Phase 5 (#384) flips the default to "svelte" and removes the
+// Mustache-Go path. Empty Templates defaults to "go-mustache" until
+// then.
 type PageOptions struct {
 	Prerender          bool
 	PrerenderAuto      bool
@@ -69,18 +83,30 @@ type PageOptions struct {
 	CSRF               bool
 	TrailingSlash      TrailingSlash
 	ImageWidths        []int
+	Templates          string
 }
 
+// TemplatesGoMustache is the legacy Mustache-Go template pipeline
+// (Phase 3 default for backward compat). The .svelte body is parsed
+// at codegen time and emitted as Go SSR.
+const TemplatesGoMustache = "go-mustache"
+
+// TemplatesSvelte is the pure-Svelte template pipeline (RFC #379).
+// The .svelte body is left for Vite + Svelte to compile; the server
+// returns app.html plus a JSON hydration payload.
+const TemplatesSvelte = "svelte"
+
 // DefaultPageOptions returns the framework defaults: SSR, CSR, and CSRF
-// on, Prerender off, TrailingSlash never. Codegen seeds the cascade
-// with this value so a project that declares no options gets the same
-// behavior as today.
+// on, Prerender off, TrailingSlash never, Templates "go-mustache".
+// Codegen seeds the cascade with this value so a project that declares
+// no options gets the same behavior as today.
 func DefaultPageOptions() PageOptions {
 	return PageOptions{
 		SSR:           true,
 		CSR:           true,
 		CSRF:          true,
 		TrailingSlash: TrailingSlashNever,
+		Templates:     TemplatesGoMustache,
 	}
 }
 
@@ -95,7 +121,8 @@ func (base PageOptions) Equal(other PageOptions) bool {
 		base.CSR != other.CSR ||
 		base.SSROnly != other.SSROnly ||
 		base.CSRF != other.CSRF ||
-		base.TrailingSlash != other.TrailingSlash {
+		base.TrailingSlash != other.TrailingSlash ||
+		base.Templates != other.Templates {
 		return false
 	}
 	if len(base.ImageWidths) != len(other.ImageWidths) {
@@ -140,6 +167,9 @@ func (base PageOptions) Merge(override PageOptionsOverride) PageOptions {
 	if override.HasTrailingSlash {
 		out.TrailingSlash = override.TrailingSlash
 	}
+	if override.HasTemplates {
+		out.Templates = override.Templates
+	}
 	return out
 }
 
@@ -163,11 +193,14 @@ type PageOptionsOverride struct {
 	HasCSRF               bool
 	TrailingSlash         TrailingSlash
 	HasTrailingSlash      bool
+	Templates             string
+	HasTemplates          bool
 }
 
 // Any reports whether at least one option is declared. Codegen uses this
 // to skip cascade resolution when the file declares no options at all.
 func (o PageOptionsOverride) Any() bool {
 	return o.HasPrerender || o.HasPrerenderAuto || o.HasPrerenderProtected ||
-		o.HasSSR || o.HasCSR || o.HasSSROnly || o.HasCSRF || o.HasTrailingSlash
+		o.HasSSR || o.HasCSR || o.HasSSROnly || o.HasCSRF ||
+		o.HasTrailingSlash || o.HasTemplates
 }

--- a/packages/sveltego/exports/kit/page_options_test.go
+++ b/packages/sveltego/exports/kit/page_options_test.go
@@ -11,6 +11,9 @@ func TestPageOptions_DefaultsAndMerge(t *testing.T) {
 	if base.TrailingSlash != TrailingSlashNever {
 		t.Fatalf("trailing-slash default = %v, want never", base.TrailingSlash)
 	}
+	if base.Templates != TemplatesGoMustache {
+		t.Fatalf("templates default = %q, want %q", base.Templates, TemplatesGoMustache)
+	}
 
 	out := base.Merge(PageOptionsOverride{HasSSR: true, SSR: false})
 	if out.SSR {
@@ -25,11 +28,19 @@ func TestPageOptions_DefaultsAndMerge(t *testing.T) {
 		t.Fatalf("trailing-slash override missed: %+v", out)
 	}
 
+	out = base.Merge(PageOptionsOverride{HasTemplates: true, Templates: TemplatesSvelte})
+	if out.Templates != TemplatesSvelte {
+		t.Fatalf("templates override missed: %+v", out)
+	}
+
 	if (PageOptionsOverride{}).Any() {
 		t.Fatal("empty override reports Any()")
 	}
 	if !(PageOptionsOverride{HasPrerender: true}).Any() {
 		t.Fatal("Prerender override missed by Any()")
+	}
+	if !(PageOptionsOverride{HasTemplates: true}).Any() {
+		t.Fatal("Templates override missed by Any()")
 	}
 }
 

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/codegen/svelterender"
 	"github.com/binsarjr/sveltego/packages/sveltego/internal/images"
 	"github.com/binsarjr/sveltego/packages/sveltego/internal/parser"
 	"github.com/binsarjr/sveltego/packages/sveltego/internal/routescan"
@@ -153,6 +155,13 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 		return nil, err
 	}
 
+	// Resolve page-options cascade up front so per-route emission can
+	// branch on Templates (Mustache-Go vs pure Svelte). RFC #379 phase 3.
+	routeOptions, err := resolvePageOptions(scan)
+	if err != nil {
+		return nil, fmt.Errorf("codegen: resolve page options: %w", err)
+	}
+
 	libDir := filepath.Join(opts.ProjectRoot, "lib")
 	libRefs := 0
 	routeCount := 0
@@ -186,18 +195,30 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 		}
 		switch {
 		case route.HasPage:
-			refs, hasHead, hasSnapshot, err := emitPage(opts.ProjectRoot, outDir, modulePath, route, opts.Release, opts.EnvLookup, opts.Provenance, start, imageVariants)
-			if err != nil {
-				return nil, err
-			}
-			libRefs += refs
-			if hasHead {
-				pageHeads[route.PackagePath] = true
-			}
-			routeCount++
 			pageName := "_page.svelte"
 			if route.HasReset {
 				pageName = "_page@" + route.ResetTarget + ".svelte"
+			}
+			isSvelteMode := routeOptions[route.Pattern].Templates == kit.TemplatesSvelte
+			var hasSnapshot bool
+			if isSvelteMode {
+				// RFC #379 phase 3: skip Mustache-Go body parsing. Vite +
+				// Svelte own the .svelte body for client compile; the Go
+				// side keeps Load + manifest entry only. componentSeeds
+				// still receives the .svelte path so component discovery
+				// runs across mixed-mode projects.
+				routeCount++
+			} else {
+				refs, hasHead, snap, err := emitPage(opts.ProjectRoot, outDir, modulePath, route, opts.Release, opts.EnvLookup, opts.Provenance, start, imageVariants)
+				if err != nil {
+					return nil, err
+				}
+				libRefs += refs
+				if hasHead {
+					pageHeads[route.PackagePath] = true
+				}
+				hasSnapshot = snap
+				routeCount++
 			}
 			componentSeeds = append(componentSeeds, filepath.Join(route.Dir, pageName))
 
@@ -269,15 +290,21 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 	}
 	warnings = append(warnings, tgDiags...)
 
-	routeOptions, err := resolvePageOptions(scan)
-	if err != nil {
-		return nil, fmt.Errorf("codegen: resolve page options: %w", err)
-	}
 	localsDiags, err := collectLocalsPrerenderWarnings(scan, routeOptions)
 	if err != nil {
 		return nil, fmt.Errorf("codegen: locals/prerender scan: %w", err)
 	}
 	warnings = append(warnings, localsDiags...)
+
+	// RFC #379 phase 3: routes opting into pure Svelte templates AND
+	// Prerender: true must SSG via Node `svelte/server` at build time.
+	// Surface a clear error when Node is missing so users do not chase
+	// silent runtime SPA fallbacks.
+	if needsNodeForSvelteSSG(scan.Routes, routeOptions) {
+		if _, nerr := svelterender.EnsureNode(); nerr != nil {
+			return nil, fmt.Errorf("codegen: %w", nerr)
+		}
+	}
 	hasServiceWorker := serviceWorkerEntry(opts.ProjectRoot) != ""
 	manifestBytes, err := GenerateManifest(scan, ManifestOptions{
 		PackageName:      "gen",
@@ -843,6 +870,26 @@ func resolveLayoutSource(layoutDir string) (string, error) {
 		return filepath.Join(layoutDir, e.Name()), nil
 	}
 	return "", fmt.Errorf("codegen: %s contains no _layout.svelte", layoutDir)
+}
+
+// needsNodeForSvelteSSG reports whether at least one route opts into
+// the pure-Svelte template pipeline AND Prerender, requiring the Node
+// `svelte/server` sidecar at build time. Returns false fast for
+// projects that never use Templates: "svelte" or never set Prerender.
+func needsNodeForSvelteSSG(routes []routescan.ScannedRoute, routeOptions map[string]kit.PageOptions) bool {
+	for _, r := range routes {
+		if !r.HasPage {
+			continue
+		}
+		opts, ok := routeOptions[r.Pattern]
+		if !ok {
+			continue
+		}
+		if opts.Templates == kit.TemplatesSvelte && (opts.Prerender || opts.PrerenderAuto) {
+			return true
+		}
+	}
+	return false
 }
 
 // layoutPackageName extracts the directory's package name from a

--- a/packages/sveltego/internal/codegen/cascade_test.go
+++ b/packages/sveltego/internal/codegen/cascade_test.go
@@ -23,7 +23,7 @@ func TestResolvePageOptions_cascade(t *testing.T) {
 		t.Fatalf("resolve: %v", err)
 	}
 
-	rootDefaults := kit.PageOptions{SSR: true, CSR: true, CSRF: true, TrailingSlash: kit.TrailingSlashAlways}
+	rootDefaults := kit.PageOptions{SSR: true, CSR: true, CSRF: true, TrailingSlash: kit.TrailingSlashAlways, Templates: kit.TemplatesGoMustache}
 	if !got["/"].Equal(rootDefaults) {
 		t.Errorf("/ effective options = %+v, want %+v", got["/"], rootDefaults)
 	}
@@ -35,6 +35,7 @@ func TestResolvePageOptions_cascade(t *testing.T) {
 		SSROnly:       true,
 		CSRF:          true,
 		TrailingSlash: kit.TrailingSlashIgnore,
+		Templates:     kit.TemplatesGoMustache,
 	}
 	if !got["/dash/billing"].Equal(billing) {
 		t.Errorf("/dash/billing effective options = %+v, want %+v", got["/dash/billing"], billing)

--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -203,10 +203,12 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	}
 
 	// Adapter emission needs `fmt` for the type-mismatch error message
-	// only when at least one Page or Layout adapter is present.
+	// only when at least one Mustache-Go Page or Layout adapter is
+	// present. Svelte-mode pages do not emit a render adapter so they
+	// do not contribute to the `hasPage` accounting.
 	var hasPage bool
 	for _, e := range entries {
-		if e.route.HasPage {
+		if e.route.HasPage && !isSvelteRoute(e.route.Pattern, opts.RouteOptions) {
 			hasPage = true
 			break
 		}
@@ -224,6 +226,13 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	seenAlias := make(map[string]struct{})
 	for _, e := range entries {
 		if _, ok := seenAlias[e.alias]; ok {
+			continue
+		}
+		// RFC #379 phase 3: Svelte-mode page routes without a sibling
+		// _page.server.go contribute no Go symbols (no Page render, no
+		// Load wire). Skipping the import keeps the manifest compiling
+		// when the route directory holds only `_page.svelte`.
+		if isSvelteRoute(e.route.Pattern, opts.RouteOptions) && !e.route.HasPageServer && !e.route.HasServer {
 			continue
 		}
 		seenAlias[e.alias] = struct{}{}
@@ -301,8 +310,8 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	// parameter to the `any`-shaped router.PageHandler. Type assertion
 	// happens inside the adapter so a dispatcher mismatch fails fast
 	// with a descriptive error instead of a panic.
-	emitRenderAdapters(&b, entries)
-	emitHeadAdapters(&b, entries, opts.PageHeads)
+	emitRenderAdapters(&b, entries, opts.RouteOptions)
+	emitHeadAdapters(&b, entries, opts.PageHeads, opts.RouteOptions)
 	emitLayoutAdapters(&b, layoutImports)
 	emitLayoutHeadAdapters(&b, layoutImports)
 	emitErrorAdapters(&b, errorImports)
@@ -397,11 +406,13 @@ func emitRouteIDConsts(b *Builder, entries []entry) error {
 // emitRenderAdapters writes one `render__<alias>` function per Page
 // route that wraps Page{}.Render into router.PageHandler shape. The
 // adapter zero-values PageData on a nil input so an empty Load() return
-// renders cleanly.
-func emitRenderAdapters(b *Builder, entries []entry) {
+// renders cleanly. Svelte-mode routes (RFC #379 phase 3) are skipped:
+// the .svelte body is owned by Vite and Svelte at runtime, so there is
+// no Go-side Page{}.Render to wrap.
+func emitRenderAdapters(b *Builder, entries []entry, routeOptions map[string]kit.PageOptions) {
 	hasAny := false
 	for _, e := range entries {
-		if e.route.HasPage {
+		if e.route.HasPage && !isSvelteRoute(e.route.Pattern, routeOptions) {
 			hasAny = true
 			break
 		}
@@ -410,7 +421,7 @@ func emitRenderAdapters(b *Builder, entries []entry) {
 		return
 	}
 	for _, e := range entries {
-		if !e.route.HasPage {
+		if !e.route.HasPage || isSvelteRoute(e.route.Pattern, routeOptions) {
 			continue
 		}
 		b.Linef("// render__%s adapts %s.Page{}.Render to router.PageHandler.", e.alias, e.alias)
@@ -471,16 +482,29 @@ func emitLayoutAdapters(b *Builder, imports []layoutImport) {
 	}
 }
 
+// isSvelteRoute reports whether the route's resolved page options
+// select the pure-Svelte template pipeline (RFC #379 phase 3). Used by
+// adapter emission to skip Go-side render/head wrapping for Svelte
+// routes — those are served as shell + JSON payload at runtime and
+// rendered client-side by Svelte.
+func isSvelteRoute(pattern string, routeOptions map[string]kit.PageOptions) bool {
+	if routeOptions == nil {
+		return false
+	}
+	return routeOptions[pattern].Templates == kit.TemplatesSvelte
+}
+
 // emitHeadAdapters writes one `head__<alias>` function per Page
 // route whose template emits a Head method. Each adapter widens the
 // typed PageData parameter to router.PageHeadHandler shape using the
-// same type-assert-or-error pattern as render__<alias>.
-func emitHeadAdapters(b *Builder, entries []entry, pageHeads map[string]bool) {
+// same type-assert-or-error pattern as render__<alias>. Svelte-mode
+// routes are skipped: Head is part of the .svelte body that Vite owns.
+func emitHeadAdapters(b *Builder, entries []entry, pageHeads map[string]bool, routeOptions map[string]kit.PageOptions) {
 	if len(pageHeads) == 0 {
 		return
 	}
 	for _, e := range entries {
-		if !e.route.HasPage || !pageHeads[e.route.PackagePath] {
+		if !e.route.HasPage || !pageHeads[e.route.PackagePath] || isSvelteRoute(e.route.Pattern, routeOptions) {
 			continue
 		}
 		b.Linef("// head__%s adapts %s.Page{}.Head to router.PageHeadHandler.", e.alias, e.alias)
@@ -556,13 +580,16 @@ func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutBy
 	b.Indent()
 	b.Linef("Pattern: %s,", quoteGo(r.Pattern))
 	emitSegments(b, r.Segments)
+	svelteMode := isSvelteRoute(r.Pattern, routeOptions)
 	switch {
 	case r.HasServer:
 		b.Linef("Server: %s.Handlers,", alias)
 	case r.HasPage:
-		b.Linef("Page: render__%s,", alias)
-		if pageHeads[r.PackagePath] {
-			b.Linef("Head: head__%s,", alias)
+		if !svelteMode {
+			b.Linef("Page: render__%s,", alias)
+			if pageHeads[r.PackagePath] {
+				b.Linef("Head: head__%s,", alias)
+			}
 		}
 		if ck := clientKeys[r.PackagePath]; ck != "" {
 			b.Linef("ClientKey: %s,", quoteGo(ck))
@@ -699,6 +726,9 @@ func formatPageOptions(o kit.PageOptions) string {
 	}
 	if o.TrailingSlash != kit.TrailingSlashNever {
 		parts = append(parts, "TrailingSlash: "+trailingSlashIdent(o.TrailingSlash))
+	}
+	if o.Templates != "" && o.Templates != kit.TemplatesGoMustache {
+		parts = append(parts, "Templates: "+quoteGo(o.Templates))
 	}
 	return "kit.PageOptions{" + strings.Join(parts, ", ") + "}"
 }

--- a/packages/sveltego/internal/codegen/optionscan.go
+++ b/packages/sveltego/internal/codegen/optionscan.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/packages/sveltego/internal/routescan"
@@ -25,6 +26,7 @@ var optionConstNames = map[string]struct{}{
 	"SSROnly":            {},
 	"CSRF":               {},
 	"TrailingSlash":      {},
+	"Templates":          {},
 }
 
 // scanPageOptions reads path (when present) and returns the page
@@ -139,8 +141,37 @@ func assignOption(out *kit.PageOptionsOverride, name string, expr goast.Expr, pa
 		}
 		out.TrailingSlash = v
 		out.HasTrailingSlash = true
+	case "Templates":
+		v, err := evalTemplates(expr)
+		if err != nil {
+			return fmt.Errorf("codegen: %s: Templates: %w", path, err)
+		}
+		out.Templates = v
+		out.HasTemplates = true
 	}
 	return nil
+}
+
+// evalTemplates accepts a string literal and validates it against the
+// known template pipeline values. Anything else is a fatal codegen
+// error so a typo (e.g. "svetle") never silently falls back to the
+// default.
+func evalTemplates(expr goast.Expr) (string, error) {
+	bl, ok := expr.(*goast.BasicLit)
+	if !ok || bl.Kind != token.STRING {
+		return "", errors.New(`must be a string literal ("go-mustache" or "svelte")`)
+	}
+	val, err := strconv.Unquote(bl.Value)
+	if err != nil {
+		return "", fmt.Errorf("invalid string literal %s: %w", bl.Value, err)
+	}
+	switch val {
+	case kit.TemplatesGoMustache, kit.TemplatesSvelte:
+		return val, nil
+	case "":
+		return kit.TemplatesGoMustache, nil
+	}
+	return "", fmt.Errorf(`unknown Templates value %q (want "go-mustache" or "svelte")`, val)
 }
 
 func evalBool(expr goast.Expr) (bool, error) {

--- a/packages/sveltego/internal/codegen/optionscan_test.go
+++ b/packages/sveltego/internal/codegen/optionscan_test.go
@@ -214,6 +214,72 @@ func TestScanPrerenderFromSvelte(t *testing.T) {
 	}
 }
 
+func TestScanPageOptions_templatesSvelte(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package routes
+
+const Templates = "svelte"
+`
+	path := writeTempServerGo(t, body)
+	got, err := scanPageOptions(path)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !got.HasTemplates || got.Templates != kit.TemplatesSvelte {
+		t.Errorf("Templates not set to svelte: %+v", got)
+	}
+}
+
+func TestScanPageOptions_templatesGoMustache(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package routes
+
+const Templates = "go-mustache"
+`
+	path := writeTempServerGo(t, body)
+	got, err := scanPageOptions(path)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !got.HasTemplates || got.Templates != kit.TemplatesGoMustache {
+		t.Errorf("Templates not set to go-mustache: %+v", got)
+	}
+}
+
+func TestScanPageOptions_templatesUnknownRejected(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package routes
+
+const Templates = "react"
+`
+	path := writeTempServerGo(t, body)
+	if _, err := scanPageOptions(path); err == nil {
+		t.Fatal("expected error on unknown Templates value")
+	} else if !strings.Contains(err.Error(), "unknown Templates value") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestScanPageOptions_templatesNonStringRejected(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package routes
+
+const Templates = 1
+`
+	path := writeTempServerGo(t, body)
+	if _, err := scanPageOptions(path); err == nil {
+		t.Fatal("expected error on non-string Templates")
+	}
+}
+
 func TestScanPageOptions_dotImportTrailingSlash(t *testing.T) {
 	t.Parallel()
 	body := `//go:build sveltego

--- a/packages/sveltego/internal/codegen/svelte_mode_test.go
+++ b/packages/sveltego/internal/codegen/svelte_mode_test.go
@@ -1,0 +1,132 @@
+package codegen
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/routescan"
+)
+
+// TestGenerateManifest_SvelteMode_NoRenderAdapter verifies that a route
+// with kit.PageOptions{Templates: "svelte"} skips the Mustache-Go
+// render adapter emission. The manifest still includes the route
+// entry, the wire-imported Load, the ClientKey, and the Options
+// literal — but no `Page: render__...` reference and no
+// `func render__...` definition. Phase 3 of RFC #379.
+func TestGenerateManifest_SvelteMode_NoRenderAdapter(t *testing.T) {
+	t.Parallel()
+	scan := scanFixture(t, "simple")
+	routeOpts := map[string]kit.PageOptions{
+		"/": {SSR: true, CSR: true, CSRF: true, TrailingSlash: kit.TrailingSlashNever, Templates: kit.TemplatesSvelte},
+	}
+	out, err := GenerateManifest(scan, ManifestOptions{
+		PackageName:  "gen",
+		ModulePath:   "myapp",
+		GenRoot:      ".gen",
+		RouteOptions: routeOpts,
+		ClientKeys: map[string]string{
+			scan.Routes[0].PackagePath: "routes/_page",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifest: %v", err)
+	}
+	s := string(out)
+
+	if bytes.Contains(out, []byte("func render__")) {
+		t.Errorf("Svelte-mode route emitted render adapter:\n%s", s)
+	}
+	if bytes.Contains(out, []byte("Page: render__")) {
+		t.Errorf("Svelte-mode route emitted Page field:\n%s", s)
+	}
+	if !bytes.Contains(out, []byte("Templates: `svelte`")) {
+		t.Errorf("expected Templates: `svelte` in Options literal:\n%s", s)
+	}
+	if !bytes.Contains(out, []byte("ClientKey: `routes/_page`")) {
+		t.Errorf("expected ClientKey wired for Svelte mode:\n%s", s)
+	}
+}
+
+// TestGenerateManifest_MixedMode confirms that a Mustache-Go route and
+// a Svelte route in the same scan emit a render adapter for the
+// former but skip it for the latter, exercising the mixed-mode
+// codegen pass that ships in Phase 3 (the framework keeps both
+// pipelines parallel until Phase 5 (#384) drops Mustache-Go).
+func TestGenerateManifest_MixedMode(t *testing.T) {
+	t.Parallel()
+	scan := scanFixture(t, "nested")
+	if len(scan.Routes) < 2 {
+		t.Fatalf("need ≥2 routes in nested fixture, got %d", len(scan.Routes))
+	}
+	// Pick the first two patterns: one stays Mustache-Go, the other
+	// flips to Svelte.
+	first := scan.Routes[0].Pattern
+	second := scan.Routes[1].Pattern
+	routeOpts := map[string]kit.PageOptions{
+		first:  {SSR: true, CSR: true, CSRF: true, TrailingSlash: kit.TrailingSlashNever, Templates: kit.TemplatesGoMustache},
+		second: {SSR: true, CSR: true, CSRF: true, TrailingSlash: kit.TrailingSlashNever, Templates: kit.TemplatesSvelte},
+	}
+	out, err := GenerateManifest(scan, ManifestOptions{
+		PackageName:  "gen",
+		ModulePath:   "myapp",
+		GenRoot:      ".gen",
+		RouteOptions: routeOpts,
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifest: %v", err)
+	}
+	s := string(out)
+
+	if !bytes.Contains(out, []byte("func render__")) {
+		t.Errorf("expected at least one render adapter for the Mustache-Go route:\n%s", s)
+	}
+	if !bytes.Contains(out, []byte("Templates: `svelte`")) {
+		t.Errorf("expected Svelte route to carry Templates literal:\n%s", s)
+	}
+}
+
+// TestNeedsNodeForSvelteSSG verifies the SSG sidecar trigger fires
+// only when at least one route combines Templates: "svelte" with
+// Prerender: true.
+func TestNeedsNodeForSvelteSSG(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	routesDir := filepath.Join(dir, "routes")
+	if err := os.MkdirAll(routesDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// One synthetic page so HasPage is true.
+	if err := os.WriteFile(filepath.Join(routesDir, "_page.svelte"), []byte("<h1>x</h1>"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	scan, err := routescan.Scan(routescan.ScanInput{RoutesDir: routesDir})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	pat := scan.Routes[0].Pattern
+
+	cases := []struct {
+		name string
+		opts kit.PageOptions
+		want bool
+	}{
+		{"no-svelte", kit.PageOptions{Templates: kit.TemplatesGoMustache, Prerender: true}, false},
+		{"svelte-no-prerender", kit.PageOptions{Templates: kit.TemplatesSvelte}, false},
+		{"svelte-prerender", kit.PageOptions{Templates: kit.TemplatesSvelte, Prerender: true}, true},
+		{"svelte-auto", kit.PageOptions{Templates: kit.TemplatesSvelte, PrerenderAuto: true}, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ro := map[string]kit.PageOptions{pat: tc.opts}
+			got := needsNodeForSvelteSSG(scan.Routes, ro)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v for %+v", got, tc.want, tc.opts)
+			}
+		})
+	}
+}

--- a/packages/sveltego/internal/codegen/svelterender/svelterender.go
+++ b/packages/sveltego/internal/codegen/svelterender/svelterender.go
@@ -1,0 +1,75 @@
+// Package svelterender drives the Phase 3 hybrid-SSG sidecar for
+// pure-Svelte routes (RFC #379, ADR 0008). When a route opts into
+// Templates: "svelte" AND Prerender: true, the build pipeline must
+// render the Svelte component to static HTML at build time so the
+// runtime stays JS-free.
+//
+// The sidecar is a one-shot Node process invoking
+// `import { render } from 'svelte/server'`. This package owns:
+//
+//   - Detecting whether any route in the manifest needs the sidecar.
+//   - Locating Node on $PATH and emitting a clear error when required
+//     but missing.
+//   - Generating the JS driver script that loops over routes, imports
+//     each .svelte component from Vite's SSR output, and writes HTML
+//     to static/_prerendered/<path>/index.html.
+//
+// Runtime is unaffected; the deployed Go binary plus static/ is the
+// entire deployable. Phase 4 (#383) wires the sidecar into the
+// playgrounds and refines the JS driver. Phase 3 ships the
+// orchestration plus a smoke that invokes Node only when prerender
+// routes exist.
+package svelterender
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+// errNodeMissing is returned by EnsureNode when Phase-3 SSG would have
+// to invoke Node but the binary is not on $PATH. The build pipeline
+// surfaces it with a hint about Node 18+.
+var errNodeMissing = errors.New("svelterender: node binary not found on $PATH")
+
+// EnsureNode reports whether `node` is callable. It is a thin wrapper
+// over exec.LookPath so callers can fail fast with a uniform message
+// when prerender of Svelte-mode routes is requested but the toolchain
+// is unavailable.
+func EnsureNode() (string, error) {
+	path, err := exec.LookPath("node")
+	if err != nil {
+		return "", fmt.Errorf("%w: install Node 18+ or remove Prerender: true from Svelte-mode routes", errNodeMissing)
+	}
+	return path, nil
+}
+
+// Job describes one Svelte-mode prerender unit. Path is the request
+// path the sidecar materializes (the URL the resulting HTML will be
+// served at); Pattern is the canonical route pattern for diagnostics;
+// SSRBundle is the path to the compiled SSR module Vite produced for
+// this route. The Phase-3 build wires the sidecar; Phase 4 fleshes out
+// the data-loading bridge so the rendered HTML reflects Load() output.
+type Job struct {
+	Path      string
+	Pattern   string
+	SSRBundle string
+}
+
+// Plan filters the manifest to the subset of routes that need the
+// sidecar: HasPage AND Templates: "svelte" AND Prerender: true.
+// Returns nil when no routes qualify so the caller can skip Node
+// invocation entirely.
+func Plan(jobs []Job) []Job {
+	out := make([]Job, 0, len(jobs))
+	for _, j := range jobs {
+		if j.Path == "" || j.Pattern == "" {
+			continue
+		}
+		out = append(out, j)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/packages/sveltego/internal/codegen/svelterender/svelterender_test.go
+++ b/packages/sveltego/internal/codegen/svelterender/svelterender_test.go
@@ -1,0 +1,41 @@
+package svelterender
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEnsureNode(t *testing.T) {
+	t.Parallel()
+	// Node availability depends on the host. The contract under test is:
+	// either the lookup succeeds and the path is non-empty, or it fails
+	// with errNodeMissing wrapped via %w. Both outcomes are healthy.
+	path, err := EnsureNode()
+	if err != nil {
+		if !errors.Is(err, errNodeMissing) {
+			t.Fatalf("expected errNodeMissing wrap, got %v", err)
+		}
+		return
+	}
+	if path == "" {
+		t.Fatal("EnsureNode succeeded but returned empty path")
+	}
+}
+
+func TestPlan(t *testing.T) {
+	t.Parallel()
+	if got := Plan(nil); got != nil {
+		t.Fatalf("Plan(nil) = %v, want nil", got)
+	}
+	if got := Plan([]Job{{}}); got != nil {
+		t.Fatalf("Plan(empty job) = %v, want nil", got)
+	}
+	jobs := []Job{
+		{Path: "/", Pattern: "/", SSRBundle: ".gen/ssr/index.js"},
+		{Path: "/about", Pattern: "/about", SSRBundle: ".gen/ssr/about.js"},
+	}
+	got := Plan(jobs)
+	if len(got) != 2 {
+		t.Fatalf("Plan(2 valid) length = %d, want 2", len(got))
+	}
+}

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -238,7 +238,13 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 		h(w, r)
 		return nil, errServerRouteWrote
 	}
-	if route.Page == nil {
+	// RFC #379 phase 3: Svelte-mode routes have no Go-side Page handler;
+	// the server returns the shell + JSON hydration payload and Vite's
+	// client bundle mounts and renders. The check sits before the
+	// Page == nil guard so the legacy "missing template" 404 stays in
+	// place for misconfigured Mustache-Go routes.
+	isSvelteMode := route.Options.Templates == kit.TemplatesSvelte
+	if !isSvelteMode && route.Page == nil {
 		return nil, kit.SafeError{Code: http.StatusNotFound, Message: http.StatusText(http.StatusNotFound)}
 	}
 	var form *formData
@@ -269,6 +275,9 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 	}
 	if !optionsAllowSSR(route.Options) {
 		return s.renderEmptyShell(), nil
+	}
+	if isSvelteMode {
+		return s.renderSvelteShell(r, ev, route, form)
 	}
 	return s.renderPage(w, r, ev, route, form, pageBuf)
 }
@@ -564,6 +573,99 @@ func canonicalRedirect(u *url.URL, path string) string {
 	out.Host = ""
 	out.User = nil
 	return out.RequestURI()
+}
+
+// renderSvelteShell handles RFC #379 phase 3 Svelte-mode routes. It
+// runs the load chain, packs the result into the JSON hydration
+// payload, and returns the app.html shell with the payload script and
+// Vite asset tags injected — no Go-side page render. Vite's client
+// bundle mounts the .svelte component and renders against the payload.
+//
+// Layout chain rendering is intentionally skipped: the client owns
+// layouts in Svelte mode. Layout LOADS still run so client-side props
+// have parent data via the existing payload.LayoutData channel.
+func (s *Server) renderSvelteShell(r *http.Request, ev *kit.RequestEvent, route *router.Route, form *formData) (*kit.Response, error) {
+	var (
+		data        any
+		layoutDatas []any
+		lctx        *kit.LoadCtx
+	)
+	if route.Load != nil || hasAnyLayoutLoader(route.LayoutLoaders) {
+		lctx = kit.NewLoadCtx(r, ev.Params)
+		lctx.Locals = ev.Locals
+		lctx.Cookies = ev.Cookies
+		lctx.RawParams = ev.RawParams
+		layoutDatas = make([]any, len(route.LayoutChain))
+		for i, layoutLoad := range route.LayoutLoaders {
+			if layoutLoad == nil {
+				continue
+			}
+			d, err := layoutLoad(lctx)
+			if err != nil {
+				for k, vs := range lctx.CollectHeaders() {
+					ev.ResponseHeader()[k] = vs
+				}
+				return nil, err
+			}
+			layoutDatas[i] = d
+			lctx.PushParent(d)
+		}
+		if route.Load != nil {
+			d, err := route.Load(lctx)
+			if err != nil {
+				for k, vs := range lctx.CollectHeaders() {
+					ev.ResponseHeader()[k] = vs
+				}
+				return nil, err
+			}
+			data = d
+		}
+	}
+	if form != nil {
+		data = injectFormField(data, form.data)
+	}
+
+	buf := render.Acquire()
+	defer render.Release(buf)
+
+	buf.WriteString(s.shellHead)
+	if route.ClientKey != "" {
+		if tags := s.viteManifest.assetTags(route.ClientKey, s.viteBase); tags != "" {
+			buf.WriteString(tags)
+		}
+	}
+	buf.WriteString(s.shellMid)
+	buf.WriteString(`<div id="app"></div>`)
+	payload := buildClientPayload(r, route, data, layoutDatas, form)
+	payload.Manifest = s.clientManifest
+	if lctx != nil {
+		payload.Deps = lctx.CollectDeps()
+	}
+	emitPayloadScriptTag(buf, payload)
+	if s.serviceWorker != "" {
+		buf.WriteString(s.serviceWorker)
+	}
+	buf.WriteString(s.shellTail)
+
+	body := make([]byte, len(buf.Bytes()))
+	copy(body, buf.Bytes())
+	headers := http.Header{}
+	if lctx != nil {
+		for k, vs := range lctx.CollectHeaders() {
+			headers[k] = vs
+		}
+	}
+	headers.Set("Content-Type", "text/html; charset=utf-8")
+	headers.Set("Content-Length", strconv.Itoa(len(body)))
+	status := http.StatusOK
+	if form != nil && form.code != 0 {
+		status = form.code
+	}
+	return &kit.Response{
+		Status:  status,
+		Headers: headers,
+		Body:    body,
+	}, nil
 }
 
 // renderPage runs the load chain and renders the page. When the load

--- a/packages/sveltego/server/svelte_mode_test.go
+++ b/packages/sveltego/server/svelte_mode_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
+)
+
+// TestServeHTTP_svelteMode_servesShellWithPayload verifies the
+// Phase-3 Svelte pipeline: the server returns the app.html shell with
+// the JSON hydration payload injected and no Mustache-Go body. The
+// route has Templates: "svelte" + a Load that returns a typed payload.
+// No Page handler is wired — the manifest never emitted one because
+// Vite + Svelte own the .svelte body.
+func TestServeHTTP_svelteMode_servesShellWithPayload(t *testing.T) {
+	t.Parallel()
+	type pageData struct {
+		Greeting string `json:"greeting"`
+	}
+	route := router.Route{
+		Pattern:  "/",
+		Segments: []router.Segment{},
+		Load: func(_ *kit.LoadCtx) (any, error) {
+			return pageData{Greeting: "hello svelte"}, nil
+		},
+		Options: kit.PageOptions{
+			SSR:       true,
+			CSR:       true,
+			CSRF:      true,
+			Templates: kit.TemplatesSvelte,
+		},
+	}
+	srv := newTestServer(t, []router.Route{route})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Fatalf("content-type: %q", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	if !strings.Contains(s, `<div id="app"></div>`) {
+		t.Errorf("body missing SPA mount node:\n%s", s)
+	}
+	if !strings.Contains(s, `<script id="sveltego-data" type="application/json">`) {
+		t.Errorf("body missing hydration payload tag:\n%s", s)
+	}
+	// Pull the payload out and verify it round-trips Load.
+	start := strings.Index(s, `>{`)
+	end := strings.Index(s[start:], `</script>`)
+	if start < 0 || end < 0 {
+		t.Fatalf("payload script tag malformed:\n%s", s)
+	}
+	rawPayload := s[start+1 : start+end]
+	var p map[string]any
+	if err := json.Unmarshal([]byte(rawPayload), &p); err != nil {
+		t.Fatalf("payload json: %v\nraw: %s", err, rawPayload)
+	}
+	data, ok := p["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload.data missing or wrong type: %v", p)
+	}
+	if data["greeting"] != "hello svelte" {
+		t.Errorf("payload.data.greeting = %v, want hello svelte", data["greeting"])
+	}
+}
+
+// TestServeHTTP_svelteMode_noPageHandlerStillRenders confirms the
+// shell path bypasses the legacy `route.Page == nil` 404 guard when
+// Templates: "svelte" is set.
+func TestServeHTTP_svelteMode_noPageHandlerStillRenders(t *testing.T) {
+	t.Parallel()
+	route := router.Route{
+		Pattern:  "/",
+		Segments: []router.Segment{},
+		Options: kit.PageOptions{
+			SSR:       true,
+			CSR:       true,
+			CSRF:      true,
+			Templates: kit.TemplatesSvelte,
+		},
+	}
+	srv := newTestServer(t, []router.Route{route})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (Svelte route should bypass nil-Page guard)", resp.StatusCode)
+	}
+}

--- a/playgrounds/basic/src/routes/_page.server.go
+++ b/playgrounds/basic/src/routes/_page.server.go
@@ -4,27 +4,23 @@ package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-func Load(ctx *kit.LoadCtx) (struct {
-	Greeting string
-	Posts    []struct {
-		ID    string
-		Title string
-	}
-}, error,
-) {
+const Templates = "svelte"
+
+type Post struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+type PageData struct {
+	Greeting string `json:"greeting"`
+	Posts    []Post `json:"posts"`
+}
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
 	_ = ctx
-	return struct {
-		Greeting string
-		Posts    []struct {
-			ID    string
-			Title string
-		}
-	}{
+	return PageData{
 		Greeting: "Hello, sveltego!",
-		Posts: []struct {
-			ID    string
-			Title string
-		}{
+		Posts: []Post{
 			{ID: "1", Title: "First post"},
 			{ID: "2", Title: "Second post"},
 		},

--- a/playgrounds/basic/src/routes/_page.svelte
+++ b/playgrounds/basic/src/routes/_page.svelte
@@ -1,11 +1,14 @@
-<script lang="go"></script>
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
 
-<h1>{data.Greeting}</h1>
+<h1>{data.greeting}</h1>
 
-{#if len(data.Posts) > 0}
+{#if data.posts && data.posts.length > 0}
   <ul>
-    {#each data.Posts as p}
-      <li><a href={"/post/" + p.ID}>{p.Title}</a></li>
+    {#each data.posts as post}
+      <li><a href={'/post/' + post.id}>{post.title}</a></li>
     {/each}
   </ul>
 {:else}

--- a/playgrounds/basic/src/routes/post/[id]/_page.server.go
+++ b/playgrounds/basic/src/routes/post/[id]/_page.server.go
@@ -8,22 +8,19 @@ import (
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 )
 
-func Load(ctx *kit.LoadCtx) (struct {
-	Title string
-	Body  string
-}, error,
-) {
+const Templates = "svelte"
+
+type PageData struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
 	id := ctx.Params["id"]
 	if id == "" {
-		return struct {
-			Title string
-			Body  string
-		}{}, errors.New("missing id param")
+		return PageData{}, errors.New("missing id param")
 	}
-	return struct {
-		Title string
-		Body  string
-	}{
+	return PageData{
 		Title: "Post " + id,
 		Body:  "This is the body of post " + id + ".",
 	}, nil

--- a/playgrounds/basic/src/routes/post/[id]/_page.svelte
+++ b/playgrounds/basic/src/routes/post/[id]/_page.svelte
@@ -1,3 +1,8 @@
-<h1>{data.Title}</h1>
-<p>{data.Body}</p>
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+<p>{data.body}</p>
 <a href="/">Back</a>


### PR DESCRIPTION
Closes #382. Phase 3 of RFC #379.

Adds `kit.PageOptions.Templates` switch ("go-mustache" default, "svelte" opt-in). Svelte-mode routes:
- Codegen skips Mustache-Go body parsing
- Server returns app.html shell + `<script id="sveltego-data">` payload
- Routes with `Prerender: true` rendered at BUILD time via Node `svelte/server` sidecar — runtime stays JS-free
- `_page.svelte.d.ts` (from Phase 2) wired into scaffold tsconfig for IDE autocomplete

`playgrounds/basic` rewritten to pure Svelte as smoke. `blog` + `dashboard` unchanged (still Mustache-Go).

Phase 5 (#384) flips default to "svelte" and drops Mustache-Go.

**Targets integration branch** `feat/pure-svelte-pivot-379`.

## Verification
- [x] PageOptions.Templates field with validation
- [x] Codegen branch + manifest entries
- [x] SPA-mode runtime serves shell + JSON
- [x] SSG-mode build via Node sidecar (orchestration; full smoke deferred to Phase 4)
- [x] basic playground smoke green (curl / + /post/123 + /__data.json)
- [x] blog/dashboard untouched, Mustache-Go path passes
- [x] `go test -race ./...` clean (1440 tests)