### PR TITLE
feat(playgrounds): rewrite blog/dashboard to pure Svelte (rfc-379 P4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,7 +822,7 @@ jobs:
             port: 3000
             home_match: 'sveltego dashboard'
             extra_path: /login
-            extra_match: 'Sign in'
+            extra_match: '"routeId":"/login"'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/packages/init/internal/aitemplates/files/.cursorrules
+++ b/packages/init/internal/aitemplates/files/.cursorrules
@@ -1,32 +1,38 @@
 # Cursor rules for sveltego
 
-This is a sveltego project. SSR is generated from `.svelte` to Go via `sveltego compile`. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before generating code.
+This is a sveltego project. `.svelte` files are pure Svelte 5; `sveltego compile` reads sibling `_*.server.go` files and emits TypeScript declarations (`.svelte.d.ts`) so the Svelte LSP types `data` end-to-end. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before generating code.
 
 For the master ruleset, see `AGENTS.md` in the project root. This file is the Cursor-specific shim and stays in sync with `AGENTS.md` and `CLAUDE.md`.
 
-## Template expressions are Go, not JavaScript
+## Templates are pure Svelte / JS / TS
 
-Inside `{...}` mustaches, write **Go**. Field access is **PascalCase** (Go exported fields).
+Inside `.svelte` files, write **Svelte/JS/TS only**. Field access uses **camelCase** keys derived from JSON tags on the Go-side `PageData` struct.
 
-| Wrong (JS) | Right (Go) |
+| Wrong (Go in mustaches) | Right (pure Svelte) |
 |---|---|
-| `{user.name}` | `{Data.User.Name}` |
-| `{posts.length}` | `{len(Data.Posts)}` |
-| `{count + 1}` | `{Count + 1}` |
-| `{n.toString()}` | `{strconv.Itoa(N)}` |
-| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
-| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
-| `null` | `nil` |
+| `{Data.User.Name}` | `{data.user.name}` |
+| `{len(Data.Posts)}` | `{data.posts.length}` |
+| `{Count + 1}` | `{count + 1}` |
+| `{strconv.Itoa(N)}` | `{n.toString()}` |
+| `nil` | `null` |
+| `{#if Data.User != nil}` | `{#if data.user != null}` |
 
-Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+Server-side data shaping (filtering, formatting, computing derived fields) belongs in `Load()`. Templates only render.
 
-Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+```svelte
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+```
 
 ## File conventions
 
 ```
 src/routes/
-  _page.svelte           SSR template, Go expressions inside {...}
+  _page.svelte           SSR template, pure Svelte
   _page.server.go        Load(), Actions      (Go skips '_*' automatically)
   _layout.svelte         layout chain
   _layout.server.go      layout-level Load    (Go skips '_*' automatically)
@@ -47,28 +53,32 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-Every user `.go` file under `src/` (and `hooks.server.go` at the project root) **must** start with `//go:build sveltego` so the standard Go toolchain skips it. Codegen reads these files via `go/parser` directly.
+Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
 
 ## Common patterns
 
 ### Load
 
 ```go
+//go:build sveltego
+
 package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
+const Templates = "svelte"
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
+
 func Load(ctx *kit.LoadCtx) (PageData, error) {
     return PageData{User: currentUser(ctx), Posts: fetchPosts(ctx)}, nil
 }
-
-type PageData struct {
-    User  User
-    Posts []Post
-}
 ```
 
-`PageData` is inferred from the `Load` return type; the template references its fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+`PageData`'s JSON tags drive the Go ↔ TypeScript boundary; reference fields as `{data.user.name}`, `{data.posts.length}`.
 
 ### Actions
 
@@ -84,7 +94,7 @@ var Actions = kit.ActionMap{
 }
 ```
 
-The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
+The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants. When a route declares `Actions`, add `Form any \`json:"form"\`` to its `PageData`.
 
 ### Redirect / Fail from Load
 
@@ -95,6 +105,17 @@ if user == nil {
     return PageData{}, kit.Redirect(303, "/login")
 }
 ```
+
+### Prerender (SSG)
+
+```go
+const (
+    Templates = "svelte"
+    Prerender = true
+)
+```
+
+`sveltego build` runs Node once at build time and writes `static/_prerendered/<path>/index.html`.
 
 ### Cookies
 
@@ -136,16 +157,16 @@ var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*ki
 var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
 ```
 
-`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
 
 ## Don't
 
-- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Go expressions in mustaches (`{Data.User.Name}`, `{len(...)}`, `nil`). Pure Svelte/JS/TS only.
+- PascalCase field access in templates. Use camelCase JSON-tag keys.
+- Omit JSON tags on `PageData` fields — without them, the boundary breaks.
 - Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
-- `null` — write `nil`.
-- camelCase field access in templates.
-- A JS server runtime. No Node / Bun / Deno on the server.
-- Editing `.gen/*.go` directly.
+- A JS server runtime at request time. Node only at build time for SSG.
+- Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
 - Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).

--- a/packages/init/internal/aitemplates/files/.github/copilot-instructions.md
+++ b/packages/init/internal/aitemplates/files/.github/copilot-instructions.md
@@ -1,32 +1,38 @@
 # GitHub Copilot instructions for sveltego
 
-This is a sveltego project. SSR is generated from `.svelte` to Go via `sveltego compile`. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before suggesting code.
+This is a sveltego project. `.svelte` files are pure Svelte 5; `sveltego compile` reads sibling `_*.server.go` files and emits TypeScript declarations (`.svelte.d.ts`) so the Svelte LSP types `data` end-to-end. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before suggesting code.
 
 For the master ruleset, see `AGENTS.md` in the project root. This file is the GitHub Copilot-specific shim and stays in sync with `AGENTS.md` and `CLAUDE.md`.
 
-## Template expressions are Go, not JavaScript
+## Templates are pure Svelte / JS / TS
 
-Inside `{...}` mustaches, write **Go**. Field access is **PascalCase** (Go exported fields).
+Inside `.svelte` files, write **Svelte/JS/TS only**. Field access uses **camelCase** keys derived from JSON tags on the Go-side `PageData` struct.
 
-| Wrong (JS) | Right (Go) |
+| Wrong (Go in mustaches) | Right (pure Svelte) |
 |---|---|
-| `{user.name}` | `{Data.User.Name}` |
-| `{posts.length}` | `{len(Data.Posts)}` |
-| `{count + 1}` | `{Count + 1}` |
-| `{n.toString()}` | `{strconv.Itoa(N)}` |
-| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
-| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
-| `null` | `nil` |
+| `{Data.User.Name}` | `{data.user.name}` |
+| `{len(Data.Posts)}` | `{data.posts.length}` |
+| `{Count + 1}` | `{count + 1}` |
+| `{strconv.Itoa(N)}` | `{n.toString()}` |
+| `nil` | `null` |
+| `{#if Data.User != nil}` | `{#if data.user != null}` |
 
-Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+Server-side data shaping (filtering, formatting, computing derived fields) belongs in `Load()`. Templates only render.
 
-Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+```svelte
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+```
 
 ## File conventions
 
 ```
 src/routes/
-  _page.svelte           SSR template, Go expressions inside {...}
+  _page.svelte           SSR template, pure Svelte
   _page.server.go        Load(), Actions      (Go skips '_*' automatically)
   _layout.svelte         layout chain
   _layout.server.go      layout-level Load    (Go skips '_*' automatically)
@@ -47,28 +53,32 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-Every user `.go` file under `src/` (and `hooks.server.go` at the project root) **must** start with `//go:build sveltego` so the standard Go toolchain skips it. Codegen reads these files via `go/parser` directly.
+Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
 
 ## Common patterns
 
 ### Load
 
 ```go
+//go:build sveltego
+
 package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
+const Templates = "svelte"
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
+
 func Load(ctx *kit.LoadCtx) (PageData, error) {
     return PageData{User: currentUser(ctx), Posts: fetchPosts(ctx)}, nil
 }
-
-type PageData struct {
-    User  User
-    Posts []Post
-}
 ```
 
-`PageData` is inferred from the `Load` return type; reference fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+`PageData`'s JSON tags drive the Go ↔ TypeScript boundary; reference fields as `{data.user.name}`, `{data.posts.length}`.
 
 ### Actions
 
@@ -84,7 +94,7 @@ var Actions = kit.ActionMap{
 }
 ```
 
-The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
+The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants. When a route declares `Actions`, add `Form any \`json:"form"\`` to its `PageData`.
 
 ### Redirect / Fail from Load
 
@@ -95,6 +105,17 @@ if user == nil {
     return PageData{}, kit.Redirect(303, "/login")
 }
 ```
+
+### Prerender (SSG)
+
+```go
+const (
+    Templates = "svelte"
+    Prerender = true
+)
+```
+
+`sveltego build` runs Node once at build time and writes `static/_prerendered/<path>/index.html`.
 
 ### Cookies
 
@@ -136,16 +157,16 @@ var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*ki
 var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
 ```
 
-`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
 
 ## Don't
 
-- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Go expressions in mustaches (`{Data.User.Name}`, `{len(...)}`, `nil`). Pure Svelte/JS/TS only.
+- PascalCase field access in templates. Use camelCase JSON-tag keys.
+- Omit JSON tags on `PageData` fields — without them, the boundary breaks.
 - Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
-- `null` — write `nil`.
-- camelCase field access in templates.
-- A JS server runtime. No Node / Bun / Deno on the server.
-- Editing `.gen/*.go` directly.
+- A JS server runtime at request time. Node only at build time for SSG.
+- Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
 - Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).

--- a/packages/init/internal/aitemplates/files/AGENTS.md
+++ b/packages/init/internal/aitemplates/files/AGENTS.md
@@ -14,31 +14,38 @@ All four files carry the same canonical rules; the per-tool variants add tool-sp
 
 ## 1. Stack
 
-- This is a **sveltego** project. SSR is generated at build time from `.svelte` to Go via `sveltego compile`.
-- The server runtime is **pure Go**. There is no JS/Node runtime on the server.
+- This is a **sveltego** project. `.svelte` files are pure Svelte 5; `sveltego compile` reads sibling `_*.server.go` files and emits TypeScript declarations (`.svelte.d.ts`) so editors and the Svelte LSP get strong types for `data`, plus the Go runtime that hosts SSG output and SPA payloads.
+- The server runtime is **pure Go**. There is no JS/Node runtime on the server at request time. Node may run **at build time only** to prerender SSG routes through `svelte/server`.
 - The client uses **Svelte 5 runes** (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) bundled by Vite for hydration only.
-- Generated code lives under `.gen/` (gitignored). Never edit `.gen/*.go` by hand — edit the `.svelte` source.
+- Generated code lives under `.gen/` (gitignored). Never edit `.gen/*` by hand — edit the `.svelte` source or its `_*.server.go` sibling.
 
 ---
 
-## 2. Template expressions are Go, not JavaScript
+## 2. Templates are pure Svelte / JS / TS
 
-Inside `{...}` mustaches, write **Go** expressions. Field access is **PascalCase** (Go exported fields).
+Inside `.svelte` files, write **Svelte/JS/TS only**. Field access uses **camelCase** keys derived from JSON tags on the Go-side `PageData` struct.
 
-| Wrong (JS) | Right (Go) |
+| Wrong (Go in mustaches) | Right (pure Svelte) |
 |---|---|
-| `{user.name}` | `{Data.User.Name}` |
-| `{posts.length}` | `{len(Data.Posts)}` |
-| `{count + 1}` | `{Count + 1}` |
-| `{"Hello, " + name}` | `{"Hello, " + Name}` |
-| `{n.toString()}` | `{strconv.Itoa(N)}` |
-| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
-| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
-| `null` | `nil` |
+| `{Data.User.Name}` | `{data.user.name}` |
+| `{len(Data.Posts)}` | `{data.posts.length}` |
+| `{Count + 1}` | `{count + 1}` |
+| `{strconv.Itoa(N)}` | `{n.toString()}` |
+| `nil` | `null` |
+| `{#if Data.User != nil}` | `{#if data.user != null}` |
 
-Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error, not a runtime error.
+Server-side data shaping (filtering, formatting, computing derived fields) belongs in `Load()`. Templates only render.
 
-Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+Imports inside `<script lang="ts">` are normal TypeScript. Reach for `PageData` from the sibling `.svelte.d.ts` codegen emits:
+
+```svelte
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+```
 
 ---
 
@@ -46,7 +53,7 @@ Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<s
 
 ```
 src/routes/
-  _page.svelte           SSR template, Go expressions inside {...}
+  _page.svelte           SSR template, pure Svelte
   _page.server.go        Load(), Actions      (Go skips '_*' automatically)
   _layout.svelte         layout chain
   _layout.server.go      layout-level Load    (Go skips '_*' automatically)
@@ -67,15 +74,7 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files under `src/routes/` use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page@.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`. The `_` prefix on `.go` files makes Go's default toolchain skip them automatically.
 - `hooks.server.go` (project root) and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
 
-**Build constraint:** files under `src/routes/**` use the `_` prefix (`_page.server.go`, `_layout.server.go`, `_server.go`); Go's default toolchain skips files whose names start with `_`, so no constraint is required there. Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** still start with:
-
-```go
-//go:build sveltego
-
-package myroute
-```
-
-Without that line on those files, `go build` / `go vet` / `golangci-lint` would try to compile them in a default Go module that lacks sveltego's generated context. Codegen reads every user `.go` file through `go/parser` directly regardless of the constraint.
+Without that constraint on the non-`_` files, `go build` / `go vet` / `golangci-lint` would try to compile them in a default Go module that lacks sveltego's generated context. Codegen reads every user `.go` file through `go/parser` directly regardless of the constraint.
 
 ---
 
@@ -84,9 +83,28 @@ Without that line on those files, `go build` / `go vet` / `golangci-lint` would 
 ### `Load` (`_page.server.go`)
 
 ```go
+//go:build sveltego
+
 package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+
+const Templates = "svelte"
+
+type User struct {
+    ID   string `json:"id"`
+    Name string `json:"name"`
+}
+
+type Post struct {
+    ID    string `json:"id"`
+    Title string `json:"title"`
+}
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
 
 func Load(ctx *kit.LoadCtx) (PageData, error) {
     return PageData{
@@ -94,14 +112,9 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
         Posts: fetchPosts(ctx),
     }, nil
 }
-
-type PageData struct {
-    User  User
-    Posts []Post
-}
 ```
 
-`PageData` is inferred from the `Load` return type. The template references its fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+The struct's JSON tags drive the Go ↔ TypeScript boundary. The template references its fields as `{data.user.name}`, `{data.posts.length}`. Codegen generates a sibling `.svelte.d.ts` declaration so the Svelte LSP type-checks `data` end-to-end.
 
 ### Actions (form POST)
 
@@ -121,6 +134,8 @@ var Actions = kit.ActionMap{
 ```
 
 `kit.ActionRedirect`, `kit.ActionFail`, `kit.ActionDataResult` are the three sealed `ActionResult` constructors — do not invent new variants.
+
+When a route declares `Actions`, codegen widens the page payload with a `form` field. Add `Form any \`json:"form"\`` to your `PageData` struct so the template can render the action result via `{data.form?.error}` or similar.
 
 ### Redirect / Fail from Load
 
@@ -153,6 +168,19 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
 
 `LoadCtx.Parent()` returns `any`. Type-assert to the immediate parent's data type.
 
+### Prerender (SSG)
+
+For routes that are content-stable at build time, opt into static prerender:
+
+```go
+const (
+    Templates = "svelte"
+    Prerender = true
+)
+```
+
+`sveltego build` runs Node once at build time and writes `static/_prerendered/<path>/index.html`. The deployed binary serves it as a static file — no Node, no Go template work per request.
+
 ### REST endpoints (`_server.go`)
 
 ```go
@@ -177,7 +205,7 @@ var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*ki
 var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
 ```
 
-`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). The `_error.svelte` template binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). The `_error.svelte` template binds `data` to this type directly: `{data.code}`, `{data.message}`.
 
 ---
 
@@ -185,12 +213,12 @@ var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.Sa
 
 Reject these at code review. They will fail at codegen or produce wrong runtime behavior.
 
-- **JS expressions in mustaches.** No `?.`, no `??`, no template literals, no `.map`/`.filter`/`.length`. Compute in `Load()` and expose via `Data`.
+- **Go expressions in mustaches.** No `{Data.User.Name}`, no `{len(...)}`, no `nil`. Pure Svelte/JS/TS only — `{data.user.name}`, `{data.posts.length}`, `null`. The legacy `Templates: "go-mustache"` mode is removed.
+- **PascalCase field access in templates.** Templates read JSON-tagged fields, so use camelCase: `{data.user.name}`, not `{data.User.Name}`.
+- **Missing JSON tags on `PageData` fields.** Without explicit `\`json:"..."\`` tags, Go marshals fields with their PascalCase Go names and the template `{data.foo}` won't match.
 - **Svelte 4 reactivity.** No `export let`, no `$:` blocks, no store autoload. Use `$props()`, `$state()`, `$derived()`, `$effect()`.
-- **`null` instead of `nil`.** Templates evaluate as Go.
-- **camelCase field access in templates.** `{data.user.name}` will not compile against a `PageData` whose field is `User`.
-- **Adding a JS server runtime.** No Node, no Bun, no Deno on the server. The point of sveltego is Go-only SSR.
-- **Editing `.gen/*.go`.** Generated files are overwritten on every `sveltego compile`.
+- **Adding a JS server runtime at request time.** No Node, no Bun, no Deno on the request path. Node may run at build time for SSG only.
+- **Editing `.gen/*` files.** Generated files are overwritten on every `sveltego compile`.
 - **Universal `Load` (e.g. SvelteKit's `+page.ts`).** sveltego is server-only by design (ADR 0005). All `Load` runs on the server in Go.
 - **`+` prefix on route files** (SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead (`_page.svelte`, `_layout.svelte`, `_page.server.go`).
 - **Missing `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go`.** The standard Go toolchain will try to compile those files (they have no `_` prefix to auto-skip them). Route files under `src/routes/**` no longer need the constraint — the `_` prefix handles skipping.

--- a/packages/init/internal/aitemplates/files/CLAUDE.md
+++ b/packages/init/internal/aitemplates/files/CLAUDE.md
@@ -8,30 +8,36 @@ This is the Claude Code-specific entry point. The same canonical rules live in [
 
 ## Stack
 
-- **sveltego** project. SSR generated at build time from `.svelte` to Go via `sveltego compile`.
-- **Server runtime is pure Go.** No JS/Node on the server.
+- **sveltego** project. `.svelte` files are pure Svelte 5; `sveltego compile` reads sibling `_*.server.go` files and emits TypeScript declarations (`.svelte.d.ts`) so editors and the Svelte LSP get strong types for `data`.
+- **Server runtime is pure Go.** No JS/Node on the server at request time. Node runs **only at build time** to prerender SSG routes through `svelte/server`.
 - **Client uses Svelte 5 runes** (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) bundled by Vite for hydration only.
-- Generated code under `.gen/` is gitignored. Never edit `.gen/*.go` — edit the `.svelte` source.
+- Generated code under `.gen/` is gitignored. Never edit `.gen/*` — edit the `.svelte` source or its `_*.server.go` sibling.
 
 ---
 
-## Template expressions are Go, not JavaScript
+## Templates are pure Svelte / JS / TS
 
-Inside `{...}` mustaches, write **Go**. Field access is **PascalCase**.
+Inside `.svelte` files, write **Svelte/JS/TS only**. Field access uses **camelCase** keys derived from JSON tags on the Go-side `PageData` struct.
 
-| Wrong (JS) | Right (Go) |
+| Wrong (Go in mustaches) | Right (pure Svelte) |
 |---|---|
-| `{user.name}` | `{Data.User.Name}` |
-| `{posts.length}` | `{len(Data.Posts)}` |
-| `{count + 1}` | `{Count + 1}` |
-| `{n.toString()}` | `{strconv.Itoa(N)}` |
-| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
-| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
-| `null` | `nil` |
+| `{Data.User.Name}` | `{data.user.name}` |
+| `{len(Data.Posts)}` | `{data.posts.length}` |
+| `{Count + 1}` | `{count + 1}` |
+| `{strconv.Itoa(N)}` | `{n.toString()}` |
+| `nil` | `null` |
+| `{#if Data.User != nil}` | `{#if data.user != null}` |
 
-Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+Server-side data shaping (filtering, formatting, computing derived fields) belongs in `Load()`. Templates only render.
 
-Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+```svelte
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+```
 
 ---
 
@@ -39,7 +45,7 @@ Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<s
 
 ```
 src/routes/
-  _page.svelte           SSR template, Go expressions inside {...}
+  _page.svelte           SSR template, pure Svelte
   _page.server.go        Load(), Actions      (Go skips '_*' automatically)
   _layout.svelte         layout chain
   _layout.server.go      layout-level Load    (Go skips '_*' automatically)
@@ -69,9 +75,18 @@ User `.go` files under `src/routes/**` are auto-skipped by Go via the `_` prefix
 ### Load
 
 ```go
+//go:build sveltego
+
 package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+
+const Templates = "svelte"
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
 
 func Load(ctx *kit.LoadCtx) (PageData, error) {
     return PageData{
@@ -79,14 +94,9 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
         Posts: fetchPosts(ctx),
     }, nil
 }
-
-type PageData struct {
-    User  User
-    Posts []Post
-}
 ```
 
-`PageData` is inferred from the `Load` return type; reference fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+`PageData`'s JSON tags drive the Go ↔ TypeScript boundary; reference fields as `{data.user.name}`, `{data.posts.length}`.
 
 ### Actions
 
@@ -104,6 +114,8 @@ var Actions = kit.ActionMap{
 
 The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
 
+When a route declares `Actions`, add `Form any \`json:"form"\`` to its `PageData` so the action result is reachable in the template (e.g. `{#if data.form}` ...).
+
 ### Redirect / Fail from Load
 
 `kit.Redirect(code, location)` and `kit.Fail(code, data)` return `error` values. Return them from `Load` to short-circuit:
@@ -115,6 +127,19 @@ if user == nil {
 ```
 
 The pipeline detects them via `errors.As`.
+
+### Prerender (SSG)
+
+For build-time-static routes:
+
+```go
+const (
+    Templates = "svelte"
+    Prerender = true
+)
+```
+
+`sveltego build` invokes Node once to render the component to `static/_prerendered/<path>/index.html`. The deployed Go binary serves it as a static file.
 
 ### Cookies
 
@@ -156,18 +181,18 @@ var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*ki
 var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
 ```
 
-`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
 
 ---
 
 ## Don't
 
-- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Go expressions in mustaches (`{Data.User.Name}`, `{len(...)}`, `nil`). Pure Svelte/JS/TS only.
+- PascalCase field access in templates. Use camelCase JSON-tag keys.
+- Omit JSON tags on `PageData` fields — without them, the boundary breaks.
 - Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
-- `null` — write `nil`.
-- camelCase field access in templates.
-- A JS server runtime. No Node / Bun / Deno on the server.
-- Editing `.gen/*.go` directly.
+- A JS server runtime at request time. Node only at build time for SSG.
+- Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
 - Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it).

--- a/playgrounds/blog/src/routes/[slug]/_page.server.go
+++ b/playgrounds/blog/src/routes/[slug]/_page.server.go
@@ -24,94 +24,62 @@ import (
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 )
 
+const Templates = "svelte"
+
+type Comment struct {
+	Author string `json:"author"`
+	Body   string `json:"body"`
+	Posted string `json:"posted"`
+}
+
+type PageData struct {
+	Title    string    `json:"title"`
+	Date     string    `json:"date"`
+	HTML     string    `json:"html"`
+	Comments []Comment `json:"comments"`
+	Form     any       `json:"form"`
+}
+
 var (
 	commentsMu sync.RWMutex
-	// comments stores in-memory threads keyed by post slug. The shape
-	// matches the anonymous struct returned by Load so values pass
-	// straight through to the template without conversion.
-	comments = map[string][]struct {
-		Author string
-		Body   string
-		Posted string
-	}{}
+	comments   = map[string][]Comment{}
 )
 
-func Load(ctx *kit.LoadCtx) (struct {
-	Title    string
-	Date     string
-	HTML     string
-	Comments []struct {
-		Author string
-		Body   string
-		Posted string
-	}
-	Form any
-},
-	error,
-) {
-	// First return literal carries the struct shape codegen infers from.
-	// Subsequent returns reuse `zero` to avoid restating the type seven
-	// times.
+func Load(ctx *kit.LoadCtx) (PageData, error) {
 	if ctx == nil || ctx.Params["slug"] == "" {
-		return struct {
-			Title    string
-			Date     string
-			HTML     string
-			Comments []struct {
-				Author string
-				Body   string
-				Posted string
-			}
-			Form any
-		}{}, errors.New("missing slug param")
+		return PageData{}, errors.New("missing slug param")
 	}
 	slug := ctx.Params["slug"]
 
-	var zero struct {
-		Title    string
-		Date     string
-		HTML     string
-		Comments []struct {
-			Author string
-			Body   string
-			Posted string
-		}
-		Form any
-	}
-
 	if !isSafeSlug(slug) {
-		return zero, kit.Error(404, "post not found")
+		return PageData{}, kit.Error(404, "post not found")
 	}
 
 	path := filepath.Join("content", "posts", slug+".md")
 	body, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return zero, kit.Error(404, "post not found")
+			return PageData{}, kit.Error(404, "post not found")
 		}
-		return zero, kit.Error(500, "read post: "+err.Error())
+		return PageData{}, kit.Error(500, "read post: "+err.Error())
 	}
 
 	fm, content := splitFrontmatter(body)
 	html, err := renderMarkdown(content)
 	if err != nil {
-		return zero, kit.Error(500, "render markdown: "+err.Error())
+		return PageData{}, kit.Error(500, "render markdown: "+err.Error())
 	}
 
 	commentsMu.RLock()
-	existing := append([]struct {
-		Author string
-		Body   string
-		Posted string
-	}(nil), comments[slug]...)
+	existing := append([]Comment(nil), comments[slug]...)
 	commentsMu.RUnlock()
 
-	out := zero
-	out.Title = fm["title"]
-	out.Date = fm["date"]
-	out.HTML = html
-	out.Comments = existing
-	return out, nil
+	return PageData{
+		Title:    fm["title"],
+		Date:     fm["date"],
+		HTML:     html,
+		Comments: existing,
+	}, nil
 }
 
 // Actions exposes the comment submission entry. The default key fires
@@ -142,11 +110,7 @@ var Actions = kit.ActionMap{
 			return kit.ActionFail(404, map[string]string{"error": "post not found"})
 		}
 
-		c := struct {
-			Author string
-			Body   string
-			Posted string
-		}{
+		c := Comment{
 			Author: form.Author,
 			Body:   form.Body,
 			Posted: time.Now().UTC().Format(time.RFC3339),

--- a/playgrounds/blog/src/routes/[slug]/_page.svelte
+++ b/playgrounds/blog/src/routes/[slug]/_page.svelte
@@ -1,34 +1,37 @@
-<script lang="go"></script>
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
 
 <article class="prose dark:prose-invert max-w-none">
-  <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">{data.Title}</h1>
-  <p class="text-sm text-gray-500 dark:text-gray-400 mb-6"><small>{data.Date}</small></p>
+  <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">{data.title}</h1>
+  <p class="text-sm text-gray-500 dark:text-gray-400 mb-6"><small>{data.date}</small></p>
   <div class="text-gray-700 dark:text-gray-300 leading-relaxed">
-    {@html data.HTML}
+    {@html data.html}
   </div>
 </article>
 
 <section class="mt-12">
-  <h2 class="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-6">Comments ({len(data.Comments)})</h2>
+  <h2 class="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-6">Comments ({data.comments.length})</h2>
 
-  {#if len(data.Comments) == 0}
+  {#if data.comments.length === 0}
     <p class="text-gray-500 dark:text-gray-400 mb-6">No comments yet. Be the first.</p>
   {:else}
     <ul class="divide-y divide-gray-200 dark:divide-gray-700 mb-8">
-      {#each data.Comments as c}
+      {#each data.comments as c}
         <li class="py-4">
           <div class="flex items-baseline gap-2 mb-1">
-            <strong class="font-semibold text-gray-900 dark:text-gray-100">{c.Author}</strong>
-            <small class="text-xs text-gray-500 dark:text-gray-400"> — {c.Posted}</small>
+            <strong class="font-semibold text-gray-900 dark:text-gray-100">{c.author}</strong>
+            <small class="text-xs text-gray-500 dark:text-gray-400"> — {c.posted}</small>
           </div>
-          <p class="text-gray-700 dark:text-gray-300">{c.Body}</p>
+          <p class="text-gray-700 dark:text-gray-300">{c.body}</p>
         </li>
       {/each}
     </ul>
   {/if}
 
   <form method="post" class="mt-6 space-y-4">
-    {#if data.Form != nil}
+    {#if data.form != null}
       <p class="text-sm text-red-600 dark:text-red-400">comment was rejected — please fill in name and body.</p>
     {/if}
     <div>

--- a/playgrounds/blog/src/routes/_page.server.go
+++ b/playgrounds/blog/src/routes/_page.server.go
@@ -15,39 +15,31 @@ import (
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 )
 
+const Templates = "svelte"
+
 const pageSize = 3
 
-func Load(ctx *kit.LoadCtx) (struct {
-	Posts []struct {
-		Slug    string
-		Title   string
-		Summary string
-		Date    string
-	}
-	Page       int
-	TotalPages int
-	HasPrev    bool
-	HasNext    bool
-	PrevHref   string
-	NextHref   string
-}, error,
-) {
+type Post struct {
+	Slug    string `json:"slug"`
+	Title   string `json:"title"`
+	Summary string `json:"summary"`
+	Date    string `json:"date"`
+}
+
+type PageData struct {
+	Posts      []Post `json:"posts"`
+	Page       int    `json:"page"`
+	TotalPages int    `json:"totalPages"`
+	HasPrev    bool   `json:"hasPrev"`
+	HasNext    bool   `json:"hasNext"`
+	PrevHref   string `json:"prevHref"`
+	NextHref   string `json:"nextHref"`
+}
+
+func Load(ctx *kit.LoadCtx) (PageData, error) {
 	all, err := readAllPosts()
 	if err != nil {
-		return struct {
-			Posts []struct {
-				Slug    string
-				Title   string
-				Summary string
-				Date    string
-			}
-			Page       int
-			TotalPages int
-			HasPrev    bool
-			HasNext    bool
-			PrevHref   string
-			NextHref   string
-		}{}, kit.Error(500, "failed to load posts: "+err.Error())
+		return PageData{}, kit.Error(500, "failed to load posts: "+err.Error())
 	}
 
 	sort.Slice(all, func(i, j int) bool { return all[i].Date > all[j].Date })
@@ -84,20 +76,7 @@ func Load(ctx *kit.LoadCtx) (struct {
 		nextHref = "/?page=" + strconv.Itoa(pageNum+1)
 	}
 
-	return struct {
-		Posts []struct {
-			Slug    string
-			Title   string
-			Summary string
-			Date    string
-		}
-		Page       int
-		TotalPages int
-		HasPrev    bool
-		HasNext    bool
-		PrevHref   string
-		NextHref   string
-	}{
+	return PageData{
 		Posts:      all[start:end],
 		Page:       pageNum,
 		TotalPages: total,
@@ -109,27 +88,13 @@ func Load(ctx *kit.LoadCtx) (struct {
 }
 
 // readAllPosts walks content/posts for *.md files and parses the
-// frontmatter into the same anonymous struct shape Load returns. Using
-// the inline struct keeps PageData inference happy: codegen reads the
-// first return composite literal and copies its fields verbatim.
-func readAllPosts() ([]struct {
-	Slug    string
-	Title   string
-	Summary string
-	Date    string
-},
-	error,
-) {
+// frontmatter into Post values.
+func readAllPosts() ([]Post, error) {
 	entries, err := os.ReadDir("content/posts")
 	if err != nil {
 		return nil, err
 	}
-	out := make([]struct {
-		Slug    string
-		Title   string
-		Summary string
-		Date    string
-	}, 0, len(entries))
+	out := make([]Post, 0, len(entries))
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
 			continue
@@ -141,12 +106,7 @@ func readAllPosts() ([]struct {
 		}
 		fm, _ := splitFrontmatter(body)
 		slug := strings.TrimSuffix(e.Name(), ".md")
-		out = append(out, struct {
-			Slug    string
-			Title   string
-			Summary string
-			Date    string
-		}{
+		out = append(out, Post{
 			Slug:    slug,
 			Title:   fm["title"],
 			Summary: fm["summary"],

--- a/playgrounds/blog/src/routes/_page.svelte
+++ b/playgrounds/blog/src/routes/_page.svelte
@@ -1,26 +1,29 @@
-<script lang="go"></script>
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
 
 <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">Posts</h1>
 
-{#if len(data.Posts) == 0}
+{#if data.posts.length === 0}
   <p class="text-gray-500 dark:text-gray-400">No posts on this page.</p>
 {:else}
   <ul class="divide-y divide-gray-200 dark:divide-gray-700">
-    {#each data.Posts as p}
+    {#each data.posts as p}
       <li class="py-4">
-        <a href={"/" + p.Slug} class="text-lg font-medium text-indigo-600 dark:text-indigo-400 hover:underline">{p.Title}</a>
-        <small class="ml-2 text-sm text-gray-500 dark:text-gray-400"> — {p.Summary}</small>
+        <a href={'/' + p.slug} class="text-lg font-medium text-indigo-600 dark:text-indigo-400 hover:underline">{p.title}</a>
+        <small class="ml-2 text-sm text-gray-500 dark:text-gray-400"> — {p.summary}</small>
       </li>
     {/each}
   </ul>
 {/if}
 
 <nav class="mt-8 flex items-center gap-4">
-  {#if data.HasPrev}
-    <a href={data.PrevHref} class="px-4 py-2 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 text-sm font-medium">prev</a>
+  {#if data.hasPrev}
+    <a href={data.prevHref} class="px-4 py-2 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 text-sm font-medium">prev</a>
   {/if}
-  <span class="text-sm text-gray-500 dark:text-gray-400"> page {data.Page} of {data.TotalPages} </span>
-  {#if data.HasNext}
-    <a href={data.NextHref} class="px-4 py-2 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 text-sm font-medium">next</a>
+  <span class="text-sm text-gray-500 dark:text-gray-400"> page {data.page} of {data.totalPages} </span>
+  {#if data.hasNext}
+    <a href={data.nextHref} class="px-4 py-2 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 text-sm font-medium">next</a>
   {/if}
 </nav>

--- a/playgrounds/dashboard/src/routes/_page.server.go
+++ b/playgrounds/dashboard/src/routes/_page.server.go
@@ -7,31 +7,25 @@ import (
 	"github.com/binsarjr/sveltego/playgrounds/dashboard/src/lib/store"
 )
 
+const Templates = "svelte"
+
+type PageData struct {
+	LoggedIn bool   `json:"loggedIn"`
+	Username string `json:"username"`
+	Form     any    `json:"form"`
+}
+
 // Load returns the auth state so the index template can render a
 // personalized welcome or a sign-in CTA. Locals["user"] is populated by
 // the Handle hook in src/hooks.server.go.
-// The Form field is required by codegen on every page that declares
-// `var Actions = kit.ActionMap{...}` — codegen widens PageData with
-// `Form any` so action results can re-render. The user Load returns
-// the same struct type so the manifest adapter's type assertion
-// matches; runtime injects the action's payload after Load runs.
-func Load(ctx *kit.LoadCtx) (struct {
-	LoggedIn bool
-	Username string
-	Form     any
-}, error,
-) {
+func Load(ctx *kit.LoadCtx) (PageData, error) {
 	loggedIn := false
 	username := ""
 	if u, ok := ctx.Locals["user"].(*store.User); ok && u != nil {
 		loggedIn = true
 		username = u.Username
 	}
-	return struct {
-		LoggedIn bool
-		Username string
-		Form     any
-	}{
+	return PageData{
 		LoggedIn: loggedIn,
 		Username: username,
 	}, nil

--- a/playgrounds/dashboard/src/routes/_page.svelte
+++ b/playgrounds/dashboard/src/routes/_page.svelte
@@ -1,13 +1,16 @@
-<script lang="go"></script>
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
 
 <div class="max-w-3xl mx-auto px-4 py-8">
   <nav class="flex items-center gap-4 pb-3 mb-6 border-b border-gray-200">
     <a href="/" class="text-blue-600 hover:underline text-sm font-medium">Home</a>
-    {#if data.LoggedIn}
+    {#if data.loggedIn}
       <a href="/dashboard" class="text-blue-600 hover:underline text-sm font-medium">Dashboard</a>
       <form method="post" action="/?/logout" class="inline m-0">
         <button type="submit" class="bg-white text-blue-600 border border-blue-600 rounded-md px-3 py-1 text-sm cursor-pointer hover:bg-blue-50">
-          Logout ({data.Username})
+          Logout ({data.username})
         </button>
       </form>
     {:else}
@@ -17,8 +20,8 @@
 
   <h1 class="text-2xl font-bold text-gray-900 mb-4">sveltego dashboard</h1>
 
-  {#if data.LoggedIn}
-    <p class="text-gray-700 mb-2">Welcome back, <strong class="font-semibold">{data.Username}</strong>.</p>
+  {#if data.loggedIn}
+    <p class="text-gray-700 mb-2">Welcome back, <strong class="font-semibold">{data.username}</strong>.</p>
     <p class="text-gray-700"><a href="/dashboard" class="text-blue-600 hover:underline">Go to your dashboard.</a></p>
   {:else}
     <p class="text-gray-600 mb-3">This playground demonstrates cookie-session authentication, CRUD via

--- a/playgrounds/dashboard/src/routes/dashboard/_page.server.go
+++ b/playgrounds/dashboard/src/routes/dashboard/_page.server.go
@@ -10,53 +10,39 @@ import (
 	"github.com/binsarjr/sveltego/playgrounds/dashboard/src/lib/store"
 )
 
+const Templates = "svelte"
+
 const dashFlashCookie = "dash_flash"
+
+type Item struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Note      string `json:"note"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+type MetricBar struct {
+	Label string `json:"label"`
+	Value int    `json:"value"`
+	Width string `json:"width"`
+}
+
+type PageData struct {
+	Username       string      `json:"username"`
+	Items          []Item      `json:"items"`
+	FlashMsg       string      `json:"flashMsg"`
+	MetricLatest   int         `json:"metricLatest"`
+	MetricLatestTS string      `json:"metricLatestTs"`
+	MetricBars     []MetricBar `json:"metricBars"`
+	Form           any         `json:"form"`
+}
 
 // Load returns the user's items + the polling chart's latest sample +
 // any flash message queued by a redirected Action.
-//
-// PageData inference (ADR 0004 amendment) only walks anonymous struct
-// literals, so the return statement uses an inline struct literal —
-// not a named alias — and every nested type follows the same rule.
-func Load(ctx *kit.LoadCtx) (struct {
-	Username string
-	Items    []struct {
-		ID        string
-		Title     string
-		Note      string
-		UpdatedAt string
-	}
-	FlashMsg       string
-	MetricLatest   int
-	MetricLatestTS string
-	MetricBars     []struct {
-		Label string
-		Value int
-		Width string
-	}
-	Form any
-}, error,
-) {
+func Load(ctx *kit.LoadCtx) (PageData, error) {
 	u, _ := ctx.Locals["user"].(*store.User)
 	if u == nil {
-		return struct {
-			Username string
-			Items    []struct {
-				ID        string
-				Title     string
-				Note      string
-				UpdatedAt string
-			}
-			FlashMsg       string
-			MetricLatest   int
-			MetricLatestTS string
-			MetricBars     []struct {
-				Label string
-				Value int
-				Width string
-			}
-			Form any
-		}{}, kit.Redirect(303, "/login")
+		return PageData{}, kit.Redirect(303, "/login")
 	}
 
 	flash := ""
@@ -66,19 +52,9 @@ func Load(ctx *kit.LoadCtx) (struct {
 	}
 
 	raw := store.Default.List(u.ID)
-	items := make([]struct {
-		ID        string
-		Title     string
-		Note      string
-		UpdatedAt string
-	}, len(raw))
+	items := make([]Item, len(raw))
 	for i, it := range raw {
-		items[i] = struct {
-			ID        string
-			Title     string
-			Note      string
-			UpdatedAt string
-		}{
+		items[i] = Item{
 			ID:        it.ID,
 			Title:     it.Title,
 			Note:      it.Note,
@@ -87,11 +63,7 @@ func Load(ctx *kit.LoadCtx) (struct {
 	}
 
 	samples := store.Default.Metrics()
-	bars := make([]struct {
-		Label string
-		Value int
-		Width string
-	}, len(samples))
+	bars := make([]MetricBar, len(samples))
 	maxV := 1
 	for _, s := range samples {
 		if s.Value > maxV {
@@ -100,11 +72,7 @@ func Load(ctx *kit.LoadCtx) (struct {
 	}
 	for i, s := range samples {
 		w := s.Value * 200 / maxV
-		bars[i] = struct {
-			Label string
-			Value int
-			Width string
-		}{
+		bars[i] = MetricBar{
 			Label: s.TS.Format("15:04:05"),
 			Value: s.Value,
 			Width: "width:" + strconv.Itoa(w) + "px",
@@ -117,24 +85,7 @@ func Load(ctx *kit.LoadCtx) (struct {
 		latestTS = samples[len(samples)-1].TS.Format("15:04:05")
 	}
 
-	return struct {
-		Username string
-		Items    []struct {
-			ID        string
-			Title     string
-			Note      string
-			UpdatedAt string
-		}
-		FlashMsg       string
-		MetricLatest   int
-		MetricLatestTS string
-		MetricBars     []struct {
-			Label string
-			Value int
-			Width string
-		}
-		Form any
-	}{
+	return PageData{
 		Username:       u.Username,
 		Items:          items,
 		FlashMsg:       flash,

--- a/playgrounds/dashboard/src/routes/dashboard/_page.svelte
+++ b/playgrounds/dashboard/src/routes/dashboard/_page.svelte
@@ -1,4 +1,7 @@
-<script lang="go"></script>
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
 
 <div class="max-w-4xl mx-auto px-4 py-8">
   <nav class="flex items-center gap-4 pb-3 mb-6 border-b border-gray-200">
@@ -6,16 +9,16 @@
     <a href="/dashboard" class="text-blue-600 hover:underline text-sm font-medium">Dashboard</a>
     <form method="post" action="/?/logout" class="inline m-0">
       <button type="submit" class="bg-white text-blue-600 border border-blue-600 rounded-md px-3 py-1 text-sm cursor-pointer hover:bg-blue-50">
-        Logout ({data.Username})
+        Logout ({data.username})
       </button>
     </form>
   </nav>
 
   <h1 class="text-2xl font-bold text-gray-900 mb-2">Dashboard</h1>
-  <p class="text-gray-600 mb-6">Signed in as <strong class="font-semibold text-gray-900">{data.Username}</strong>.</p>
+  <p class="text-gray-600 mb-6">Signed in as <strong class="font-semibold text-gray-900">{data.username}</strong>.</p>
 
-  {#if data.FlashMsg != ""}
-    <p class="text-red-600 text-sm mb-4">{data.FlashMsg}</p>
+  {#if data.flashMsg !== ''}
+    <p class="text-red-600 text-sm mb-4">{data.flashMsg}</p>
   {/if}
 
   <h2 class="text-lg font-semibold text-gray-800 mb-3">Items</h2>
@@ -42,7 +45,7 @@
     </button>
   </form>
 
-  {#if len(data.Items) > 0}
+  {#if data.items.length > 0}
     <div class="overflow-x-auto mb-8">
       <table class="w-full border-collapse text-sm">
         <thead>
@@ -55,15 +58,15 @@
           </tr>
         </thead>
         <tbody>
-          {#each data.Items as it}
+          {#each data.items as it}
             <tr class="border-b border-gray-100 hover:bg-gray-50">
-              <td class="py-2 px-3"><code class="text-xs bg-gray-100 px-1 py-0.5 rounded">{it.ID}</code></td>
-              <td class="py-2 px-3"><a href={"/dashboard/items/" + it.ID} class="text-blue-600 hover:underline">{it.Title}</a></td>
-              <td class="py-2 px-3 text-gray-600">{it.Note}</td>
-              <td class="py-2 px-3 text-gray-500 text-xs">{it.UpdatedAt}</td>
+              <td class="py-2 px-3"><code class="text-xs bg-gray-100 px-1 py-0.5 rounded">{it.id}</code></td>
+              <td class="py-2 px-3"><a href={'/dashboard/items/' + it.id} class="text-blue-600 hover:underline">{it.title}</a></td>
+              <td class="py-2 px-3 text-gray-600">{it.note}</td>
+              <td class="py-2 px-3 text-gray-500 text-xs">{it.updatedAt}</td>
               <td class="py-2 px-3">
-                <form method="post" action={"/dashboard?/delete"} class="inline m-0">
-                  <input type="hidden" name="id" value={it.ID}>
+                <form method="post" action={'/dashboard?/delete'} class="inline m-0">
+                  <input type="hidden" name="id" value={it.id}>
                   <button
                     type="submit"
                     class="rounded-md bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 cursor-pointer"
@@ -86,12 +89,12 @@
   <meta http-equiv="refresh" content="5;url=/dashboard">
 
   <div class="border border-dashed border-gray-300 rounded-lg p-4 bg-gray-50 font-mono text-sm mb-4">
-    <p class="mb-3 text-gray-700">Latest sample: <strong class="text-gray-900">{data.MetricLatest}</strong> @ <code class="text-xs bg-gray-100 px-1 py-0.5 rounded">{data.MetricLatestTS}</code></p>
-    {#each data.MetricBars as b}
+    <p class="mb-3 text-gray-700">Latest sample: <strong class="text-gray-900">{data.metricLatest}</strong> @ <code class="text-xs bg-gray-100 px-1 py-0.5 rounded">{data.metricLatestTs}</code></p>
+    {#each data.metricBars as b}
       <div class="flex items-center gap-2 mb-1">
-        <span class="inline-block h-4 bg-blue-600 rounded-sm" style={b.Width}></span>
-        <code class="text-xs text-gray-600">{b.Label}</code>
-        <span class="text-xs text-gray-500">{b.Value}</span>
+        <span class="inline-block h-4 bg-blue-600 rounded-sm" style={b.width}></span>
+        <code class="text-xs text-gray-600">{b.label}</code>
+        <span class="text-xs text-gray-500">{b.value}</span>
       </div>
     {/each}
   </div>

--- a/playgrounds/dashboard/src/routes/dashboard/items/[id]/_page.server.go
+++ b/playgrounds/dashboard/src/routes/dashboard/items/[id]/_page.server.go
@@ -9,68 +9,44 @@ import (
 	"github.com/binsarjr/sveltego/playgrounds/dashboard/src/lib/store"
 )
 
+const Templates = "svelte"
+
 const detailFlashCookie = "item_flash"
 
-// Load fetches the item by [id], scoped to the signed-in user. Missing
-// items 303 to /dashboard. Inline struct literals only (ADR 0004
-// amendment): PageData inference walks the return statement's literal
-// type and skips named aliases.
-func Load(ctx *kit.LoadCtx) (struct {
-	Username string
-	Item     struct {
-		ID        string
-		Title     string
-		Note      string
-		UpdatedAt string
-	}
-	FlashMsg string
-	Form     any
-}, error,
-) {
-	zero := struct {
-		Username string
-		Item     struct {
-			ID        string
-			Title     string
-			Note      string
-			UpdatedAt string
-		}
-		FlashMsg string
-		Form     any
-	}{}
+type Item struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Note      string `json:"note"`
+	UpdatedAt string `json:"updatedAt"`
+}
 
+type PageData struct {
+	Username string `json:"username"`
+	Item     Item   `json:"item"`
+	FlashMsg string `json:"flashMsg"`
+	Form     any    `json:"form"`
+}
+
+// Load fetches the item by [id], scoped to the signed-in user. Missing
+// items 303 to /dashboard.
+func Load(ctx *kit.LoadCtx) (PageData, error) {
 	u, _ := ctx.Locals["user"].(*store.User)
 	if u == nil {
-		return zero, kit.Redirect(303, "/login")
+		return PageData{}, kit.Redirect(303, "/login")
 	}
 	id := ctx.Params["id"]
 	it := store.Default.Get(u.ID, id)
 	if it == nil {
-		return zero, kit.Redirect(303, "/dashboard")
+		return PageData{}, kit.Redirect(303, "/dashboard")
 	}
 	flash := ""
 	if v, ok := ctx.Cookies.Get(detailFlashCookie); ok {
 		flash = v
 		ctx.Cookies.Delete(detailFlashCookie, kit.CookieOpts{Path: "/"})
 	}
-	return struct {
-		Username string
-		Item     struct {
-			ID        string
-			Title     string
-			Note      string
-			UpdatedAt string
-		}
-		FlashMsg string
-		Form     any
-	}{
+	return PageData{
 		Username: u.Username,
-		Item: struct {
-			ID        string
-			Title     string
-			Note      string
-			UpdatedAt string
-		}{
+		Item: Item{
 			ID:        it.ID,
 			Title:     it.Title,
 			Note:      it.Note,

--- a/playgrounds/dashboard/src/routes/dashboard/items/[id]/_page.svelte
+++ b/playgrounds/dashboard/src/routes/dashboard/items/[id]/_page.svelte
@@ -1,4 +1,7 @@
-<script lang="go"></script>
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
 
 <div class="max-w-3xl mx-auto px-4 py-8">
   <nav class="flex items-center gap-4 pb-3 mb-6 border-b border-gray-200">
@@ -6,29 +9,29 @@
     <a href="/dashboard" class="text-blue-600 hover:underline text-sm font-medium">Dashboard</a>
     <form method="post" action="/?/logout" class="inline m-0">
       <button type="submit" class="bg-white text-blue-600 border border-blue-600 rounded-md px-3 py-1 text-sm cursor-pointer hover:bg-blue-50">
-        Logout ({data.Username})
+        Logout ({data.username})
       </button>
     </form>
   </nav>
 
   <h1 class="text-2xl font-bold text-gray-900 mb-4">Edit item</h1>
 
-  {#if data.FlashMsg != ""}
-    <p class="text-red-600 text-sm mb-4">{data.FlashMsg}</p>
+  {#if data.flashMsg !== ''}
+    <p class="text-red-600 text-sm mb-4">{data.flashMsg}</p>
   {/if}
 
   <div class="text-sm text-gray-600 mb-4 space-y-1">
-    <p><strong class="font-medium text-gray-700">ID:</strong> <code class="bg-gray-100 px-1 py-0.5 rounded text-xs">{data.Item.ID}</code></p>
-    <p><strong class="font-medium text-gray-700">Last updated:</strong> {data.Item.UpdatedAt}</p>
+    <p><strong class="font-medium text-gray-700">ID:</strong> <code class="bg-gray-100 px-1 py-0.5 rounded text-xs">{data.item.id}</code></p>
+    <p><strong class="font-medium text-gray-700">Last updated:</strong> {data.item.updatedAt}</p>
   </div>
 
-  <form method="post" action={"/dashboard/items/" + data.Item.ID + "?/update"} class="space-y-4 max-w-sm mb-6">
+  <form method="post" action={'/dashboard/items/' + data.item.id + '?/update'} class="space-y-4 max-w-sm mb-6">
     <div>
       <label class="block text-sm font-medium text-gray-700 mb-1">Title
         <input
           type="text"
           name="title"
-          value={data.Item.Title}
+          value={data.item.title}
           required
           class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         >
@@ -39,7 +42,7 @@
         <input
           type="text"
           name="note"
-          value={data.Item.Note}
+          value={data.item.note}
           class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         >
       </label>
@@ -52,7 +55,7 @@
     </button>
   </form>
 
-  <form method="post" action={"/dashboard/items/" + data.Item.ID + "?/delete"}>
+  <form method="post" action={'/dashboard/items/' + data.item.id + '?/delete'}>
     <button
       type="submit"
       class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 cursor-pointer"

--- a/playgrounds/dashboard/src/routes/login/_page.server.go
+++ b/playgrounds/dashboard/src/routes/login/_page.server.go
@@ -9,21 +9,24 @@ import (
 	"github.com/binsarjr/sveltego/playgrounds/dashboard/src/lib/store"
 )
 
+const Templates = "svelte"
+
 const (
 	flashErrorCookie = "flash_error"
 	flashUserCookie  = "flash_user"
 )
 
+type PageData struct {
+	LastUsername string `json:"lastUsername"`
+	LastError    string `json:"lastError"`
+	Form         any    `json:"form"`
+}
+
 // Load surfaces the last-typed username and the flash error message so
 // a failed login round-trip can re-render without forcing the user to
 // retype. The cookies are consumed-and-deleted so a refresh does not
 // resurface the stale error.
-func Load(ctx *kit.LoadCtx) (struct {
-	LastUsername string
-	LastError    string
-	Form         any
-}, error,
-) {
+func Load(ctx *kit.LoadCtx) (PageData, error) {
 	username := ""
 	errMsg := ""
 	if v, ok := ctx.Cookies.Get(flashErrorCookie); ok {
@@ -34,11 +37,7 @@ func Load(ctx *kit.LoadCtx) (struct {
 		username = v
 		ctx.Cookies.Delete(flashUserCookie, kit.CookieOpts{Path: "/"})
 	}
-	return struct {
-		LastUsername string
-		LastError    string
-		Form         any
-	}{
+	return PageData{
 		LastUsername: username,
 		LastError:    errMsg,
 	}, nil

--- a/playgrounds/dashboard/src/routes/login/_page.svelte
+++ b/playgrounds/dashboard/src/routes/login/_page.svelte
@@ -1,4 +1,7 @@
-<script lang="go"></script>
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
 
 <div class="max-w-3xl mx-auto px-4 py-8">
   <nav class="flex items-center gap-4 pb-3 mb-6 border-b border-gray-200">
@@ -8,8 +11,8 @@
 
   <h1 class="text-2xl font-bold text-gray-900 mb-6">Sign in</h1>
 
-  {#if data.LastError != ""}
-    <p class="text-red-600 text-sm mb-4">{data.LastError}</p>
+  {#if data.lastError !== ''}
+    <p class="text-red-600 text-sm mb-4">{data.lastError}</p>
   {/if}
 
   <form method="post" action="/login?/default" class="space-y-4 max-w-sm">
@@ -18,7 +21,7 @@
         <input
           type="text"
           name="username"
-          value={data.LastUsername}
+          value={data.lastUsername}
           required
           class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         >

--- a/templates/ai/.cursorrules
+++ b/templates/ai/.cursorrules
@@ -1,32 +1,38 @@
 # Cursor rules for sveltego
 
-This is a sveltego project. SSR is generated from `.svelte` to Go via `sveltego compile`. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before generating code.
+This is a sveltego project. `.svelte` files are pure Svelte 5; `sveltego compile` reads sibling `_*.server.go` files and emits TypeScript declarations (`.svelte.d.ts`) so the Svelte LSP types `data` end-to-end. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before generating code.
 
 For the master ruleset, see `AGENTS.md` in the project root. This file is the Cursor-specific shim and stays in sync with `AGENTS.md` and `CLAUDE.md`.
 
-## Template expressions are Go, not JavaScript
+## Templates are pure Svelte / JS / TS
 
-Inside `{...}` mustaches, write **Go**. Field access is **PascalCase** (Go exported fields).
+Inside `.svelte` files, write **Svelte/JS/TS only**. Field access uses **camelCase** keys derived from JSON tags on the Go-side `PageData` struct.
 
-| Wrong (JS) | Right (Go) |
+| Wrong (Go in mustaches) | Right (pure Svelte) |
 |---|---|
-| `{user.name}` | `{Data.User.Name}` |
-| `{posts.length}` | `{len(Data.Posts)}` |
-| `{count + 1}` | `{Count + 1}` |
-| `{n.toString()}` | `{strconv.Itoa(N)}` |
-| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
-| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
-| `null` | `nil` |
+| `{Data.User.Name}` | `{data.user.name}` |
+| `{len(Data.Posts)}` | `{data.posts.length}` |
+| `{Count + 1}` | `{count + 1}` |
+| `{strconv.Itoa(N)}` | `{n.toString()}` |
+| `nil` | `null` |
+| `{#if Data.User != nil}` | `{#if data.user != null}` |
 
-Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+Server-side data shaping (filtering, formatting, computing derived fields) belongs in `Load()`. Templates only render.
 
-Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+```svelte
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+```
 
 ## File conventions
 
 ```
 src/routes/
-  _page.svelte           SSR template, Go expressions inside {...}
+  _page.svelte           SSR template, pure Svelte
   _page.server.go        Load(), Actions      (Go skips '_*' automatically)
   _layout.svelte         layout chain
   _layout.server.go      layout-level Load    (Go skips '_*' automatically)
@@ -47,28 +53,32 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-Every user `.go` file under `src/` (and `hooks.server.go` at the project root) **must** start with `//go:build sveltego` so the standard Go toolchain skips it. Codegen reads these files via `go/parser` directly.
+Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
 
 ## Common patterns
 
 ### Load
 
 ```go
+//go:build sveltego
+
 package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
+const Templates = "svelte"
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
+
 func Load(ctx *kit.LoadCtx) (PageData, error) {
     return PageData{User: currentUser(ctx), Posts: fetchPosts(ctx)}, nil
 }
-
-type PageData struct {
-    User  User
-    Posts []Post
-}
 ```
 
-`PageData` is inferred from the `Load` return type; the template references its fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+`PageData`'s JSON tags drive the Go ↔ TypeScript boundary; reference fields as `{data.user.name}`, `{data.posts.length}`.
 
 ### Actions
 
@@ -84,7 +94,7 @@ var Actions = kit.ActionMap{
 }
 ```
 
-The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
+The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants. When a route declares `Actions`, add `Form any \`json:"form"\`` to its `PageData`.
 
 ### Redirect / Fail from Load
 
@@ -95,6 +105,17 @@ if user == nil {
     return PageData{}, kit.Redirect(303, "/login")
 }
 ```
+
+### Prerender (SSG)
+
+```go
+const (
+    Templates = "svelte"
+    Prerender = true
+)
+```
+
+`sveltego build` runs Node once at build time and writes `static/_prerendered/<path>/index.html`.
 
 ### Cookies
 
@@ -136,16 +157,16 @@ var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*ki
 var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
 ```
 
-`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
 
 ## Don't
 
-- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Go expressions in mustaches (`{Data.User.Name}`, `{len(...)}`, `nil`). Pure Svelte/JS/TS only.
+- PascalCase field access in templates. Use camelCase JSON-tag keys.
+- Omit JSON tags on `PageData` fields — without them, the boundary breaks.
 - Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
-- `null` — write `nil`.
-- camelCase field access in templates.
-- A JS server runtime. No Node / Bun / Deno on the server.
-- Editing `.gen/*.go` directly.
+- A JS server runtime at request time. Node only at build time for SSG.
+- Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
 - Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).

--- a/templates/ai/.github/copilot-instructions.md
+++ b/templates/ai/.github/copilot-instructions.md
@@ -1,32 +1,38 @@
 # GitHub Copilot instructions for sveltego
 
-This is a sveltego project. SSR is generated from `.svelte` to Go via `sveltego compile`. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before suggesting code.
+This is a sveltego project. `.svelte` files are pure Svelte 5; `sveltego compile` reads sibling `_*.server.go` files and emits TypeScript declarations (`.svelte.d.ts`) so the Svelte LSP types `data` end-to-end. The server runtime is pure Go; the client uses Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) via Vite for hydration only. Read this file before suggesting code.
 
 For the master ruleset, see `AGENTS.md` in the project root. This file is the GitHub Copilot-specific shim and stays in sync with `AGENTS.md` and `CLAUDE.md`.
 
-## Template expressions are Go, not JavaScript
+## Templates are pure Svelte / JS / TS
 
-Inside `{...}` mustaches, write **Go**. Field access is **PascalCase** (Go exported fields).
+Inside `.svelte` files, write **Svelte/JS/TS only**. Field access uses **camelCase** keys derived from JSON tags on the Go-side `PageData` struct.
 
-| Wrong (JS) | Right (Go) |
+| Wrong (Go in mustaches) | Right (pure Svelte) |
 |---|---|
-| `{user.name}` | `{Data.User.Name}` |
-| `{posts.length}` | `{len(Data.Posts)}` |
-| `{count + 1}` | `{Count + 1}` |
-| `{n.toString()}` | `{strconv.Itoa(N)}` |
-| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
-| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
-| `null` | `nil` |
+| `{Data.User.Name}` | `{data.user.name}` |
+| `{len(Data.Posts)}` | `{data.posts.length}` |
+| `{Count + 1}` | `{count + 1}` |
+| `{strconv.Itoa(N)}` | `{n.toString()}` |
+| `nil` | `null` |
+| `{#if Data.User != nil}` | `{#if data.user != null}` |
 
-Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+Server-side data shaping (filtering, formatting, computing derived fields) belongs in `Load()`. Templates only render.
 
-Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+```svelte
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+```
 
 ## File conventions
 
 ```
 src/routes/
-  _page.svelte           SSR template, Go expressions inside {...}
+  _page.svelte           SSR template, pure Svelte
   _page.server.go        Load(), Actions      (Go skips '_*' automatically)
   _layout.svelte         layout chain
   _layout.server.go      layout-level Load    (Go skips '_*' automatically)
@@ -47,28 +53,32 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-Every user `.go` file under `src/` (and `hooks.server.go` at the project root) **must** start with `//go:build sveltego` so the standard Go toolchain skips it. Codegen reads these files via `go/parser` directly.
+Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
 
 ## Common patterns
 
 ### Load
 
 ```go
+//go:build sveltego
+
 package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
+const Templates = "svelte"
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
+
 func Load(ctx *kit.LoadCtx) (PageData, error) {
     return PageData{User: currentUser(ctx), Posts: fetchPosts(ctx)}, nil
 }
-
-type PageData struct {
-    User  User
-    Posts []Post
-}
 ```
 
-`PageData` is inferred from the `Load` return type; reference fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+`PageData`'s JSON tags drive the Go ↔ TypeScript boundary; reference fields as `{data.user.name}`, `{data.posts.length}`.
 
 ### Actions
 
@@ -84,7 +94,7 @@ var Actions = kit.ActionMap{
 }
 ```
 
-The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
+The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants. When a route declares `Actions`, add `Form any \`json:"form"\`` to its `PageData`.
 
 ### Redirect / Fail from Load
 
@@ -95,6 +105,17 @@ if user == nil {
     return PageData{}, kit.Redirect(303, "/login")
 }
 ```
+
+### Prerender (SSG)
+
+```go
+const (
+    Templates = "svelte"
+    Prerender = true
+)
+```
+
+`sveltego build` runs Node once at build time and writes `static/_prerendered/<path>/index.html`.
 
 ### Cookies
 
@@ -136,16 +157,16 @@ var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*ki
 var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
 ```
 
-`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
 
 ## Don't
 
-- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Go expressions in mustaches (`{Data.User.Name}`, `{len(...)}`, `nil`). Pure Svelte/JS/TS only.
+- PascalCase field access in templates. Use camelCase JSON-tag keys.
+- Omit JSON tags on `PageData` fields — without them, the boundary breaks.
 - Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
-- `null` — write `nil`.
-- camelCase field access in templates.
-- A JS server runtime. No Node / Bun / Deno on the server.
-- Editing `.gen/*.go` directly.
+- A JS server runtime at request time. Node only at build time for SSG.
+- Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
 - Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).

--- a/templates/ai/AGENTS.md
+++ b/templates/ai/AGENTS.md
@@ -14,31 +14,38 @@ All four files carry the same canonical rules; the per-tool variants add tool-sp
 
 ## 1. Stack
 
-- This is a **sveltego** project. SSR is generated at build time from `.svelte` to Go via `sveltego compile`.
-- The server runtime is **pure Go**. There is no JS/Node runtime on the server.
+- This is a **sveltego** project. `.svelte` files are pure Svelte 5; `sveltego compile` reads sibling `_*.server.go` files and emits TypeScript declarations (`.svelte.d.ts`) so editors and the Svelte LSP get strong types for `data`, plus the Go runtime that hosts SSG output and SPA payloads.
+- The server runtime is **pure Go**. There is no JS/Node runtime on the server at request time. Node may run **at build time only** to prerender SSG routes through `svelte/server`.
 - The client uses **Svelte 5 runes** (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) bundled by Vite for hydration only.
-- Generated code lives under `.gen/` (gitignored). Never edit `.gen/*.go` by hand — edit the `.svelte` source.
+- Generated code lives under `.gen/` (gitignored). Never edit `.gen/*` by hand — edit the `.svelte` source or its `_*.server.go` sibling.
 
 ---
 
-## 2. Template expressions are Go, not JavaScript
+## 2. Templates are pure Svelte / JS / TS
 
-Inside `{...}` mustaches, write **Go** expressions. Field access is **PascalCase** (Go exported fields).
+Inside `.svelte` files, write **Svelte/JS/TS only**. Field access uses **camelCase** keys derived from JSON tags on the Go-side `PageData` struct.
 
-| Wrong (JS) | Right (Go) |
+| Wrong (Go in mustaches) | Right (pure Svelte) |
 |---|---|
-| `{user.name}` | `{Data.User.Name}` |
-| `{posts.length}` | `{len(Data.Posts)}` |
-| `{count + 1}` | `{Count + 1}` |
-| `{"Hello, " + name}` | `{"Hello, " + Name}` |
-| `{n.toString()}` | `{strconv.Itoa(N)}` |
-| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
-| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
-| `null` | `nil` |
+| `{Data.User.Name}` | `{data.user.name}` |
+| `{len(Data.Posts)}` | `{data.posts.length}` |
+| `{Count + 1}` | `{count + 1}` |
+| `{strconv.Itoa(N)}` | `{n.toString()}` |
+| `nil` | `null` |
+| `{#if Data.User != nil}` | `{#if data.user != null}` |
 
-Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error, not a runtime error.
+Server-side data shaping (filtering, formatting, computing derived fields) belongs in `Load()`. Templates only render.
 
-Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+Imports inside `<script lang="ts">` are normal TypeScript. Reach for `PageData` from the sibling `.svelte.d.ts` codegen emits:
+
+```svelte
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+```
 
 ---
 
@@ -46,7 +53,7 @@ Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<s
 
 ```
 src/routes/
-  _page.svelte           SSR template, Go expressions inside {...}
+  _page.svelte           SSR template, pure Svelte
   _page.server.go        Load(), Actions      (Go skips '_*' automatically)
   _layout.svelte         layout chain
   _layout.server.go      layout-level Load    (Go skips '_*' automatically)
@@ -67,15 +74,7 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files under `src/routes/` use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page@.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`. The `_` prefix on `.go` files makes Go's default toolchain skip them automatically.
 - `hooks.server.go` (project root) and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
 
-**Build constraint:** files under `src/routes/**` use the `_` prefix (`_page.server.go`, `_layout.server.go`, `_server.go`); Go's default toolchain skips files whose names start with `_`, so no constraint is required there. Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** still start with:
-
-```go
-//go:build sveltego
-
-package myroute
-```
-
-Without that line on those files, `go build` / `go vet` / `golangci-lint` would try to compile them in a default Go module that lacks sveltego's generated context. Codegen reads every user `.go` file through `go/parser` directly regardless of the constraint.
+Without that constraint on the non-`_` files, `go build` / `go vet` / `golangci-lint` would try to compile them in a default Go module that lacks sveltego's generated context. Codegen reads every user `.go` file through `go/parser` directly regardless of the constraint.
 
 ---
 
@@ -84,9 +83,28 @@ Without that line on those files, `go build` / `go vet` / `golangci-lint` would 
 ### `Load` (`_page.server.go`)
 
 ```go
+//go:build sveltego
+
 package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+
+const Templates = "svelte"
+
+type User struct {
+    ID   string `json:"id"`
+    Name string `json:"name"`
+}
+
+type Post struct {
+    ID    string `json:"id"`
+    Title string `json:"title"`
+}
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
 
 func Load(ctx *kit.LoadCtx) (PageData, error) {
     return PageData{
@@ -94,14 +112,9 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
         Posts: fetchPosts(ctx),
     }, nil
 }
-
-type PageData struct {
-    User  User
-    Posts []Post
-}
 ```
 
-`PageData` is inferred from the `Load` return type. The template references its fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+The struct's JSON tags drive the Go ↔ TypeScript boundary. The template references its fields as `{data.user.name}`, `{data.posts.length}`. Codegen generates a sibling `.svelte.d.ts` declaration so the Svelte LSP type-checks `data` end-to-end.
 
 ### Actions (form POST)
 
@@ -121,6 +134,8 @@ var Actions = kit.ActionMap{
 ```
 
 `kit.ActionRedirect`, `kit.ActionFail`, `kit.ActionDataResult` are the three sealed `ActionResult` constructors — do not invent new variants.
+
+When a route declares `Actions`, codegen widens the page payload with a `form` field. Add `Form any \`json:"form"\`` to your `PageData` struct so the template can render the action result via `{data.form?.error}` or similar.
 
 ### Redirect / Fail from Load
 
@@ -153,6 +168,19 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
 
 `LoadCtx.Parent()` returns `any`. Type-assert to the immediate parent's data type.
 
+### Prerender (SSG)
+
+For routes that are content-stable at build time, opt into static prerender:
+
+```go
+const (
+    Templates = "svelte"
+    Prerender = true
+)
+```
+
+`sveltego build` runs Node once at build time and writes `static/_prerendered/<path>/index.html`. The deployed binary serves it as a static file — no Node, no Go template work per request.
+
 ### REST endpoints (`_server.go`)
 
 ```go
@@ -177,7 +205,7 @@ var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*ki
 var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
 ```
 
-`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). The `_error.svelte` template binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). The `_error.svelte` template binds `data` to this type directly: `{data.code}`, `{data.message}`.
 
 ---
 
@@ -185,12 +213,12 @@ var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.Sa
 
 Reject these at code review. They will fail at codegen or produce wrong runtime behavior.
 
-- **JS expressions in mustaches.** No `?.`, no `??`, no template literals, no `.map`/`.filter`/`.length`. Compute in `Load()` and expose via `Data`.
+- **Go expressions in mustaches.** No `{Data.User.Name}`, no `{len(...)}`, no `nil`. Pure Svelte/JS/TS only — `{data.user.name}`, `{data.posts.length}`, `null`. The legacy `Templates: "go-mustache"` mode is removed.
+- **PascalCase field access in templates.** Templates read JSON-tagged fields, so use camelCase: `{data.user.name}`, not `{data.User.Name}`.
+- **Missing JSON tags on `PageData` fields.** Without explicit `\`json:"..."\`` tags, Go marshals fields with their PascalCase Go names and the template `{data.foo}` won't match.
 - **Svelte 4 reactivity.** No `export let`, no `$:` blocks, no store autoload. Use `$props()`, `$state()`, `$derived()`, `$effect()`.
-- **`null` instead of `nil`.** Templates evaluate as Go.
-- **camelCase field access in templates.** `{data.user.name}` will not compile against a `PageData` whose field is `User`.
-- **Adding a JS server runtime.** No Node, no Bun, no Deno on the server. The point of sveltego is Go-only SSR.
-- **Editing `.gen/*.go`.** Generated files are overwritten on every `sveltego compile`.
+- **Adding a JS server runtime at request time.** No Node, no Bun, no Deno on the request path. Node may run at build time for SSG only.
+- **Editing `.gen/*` files.** Generated files are overwritten on every `sveltego compile`.
 - **Universal `Load` (e.g. SvelteKit's `+page.ts`).** sveltego is server-only by design (ADR 0005). All `Load` runs on the server in Go.
 - **`+` prefix on route files** (SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead (`_page.svelte`, `_layout.svelte`, `_page.server.go`).
 - **Missing `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go`.** The standard Go toolchain will try to compile those files (they have no `_` prefix to auto-skip them). Route files under `src/routes/**` no longer need the constraint — the `_` prefix handles skipping.

--- a/templates/ai/CLAUDE.md
+++ b/templates/ai/CLAUDE.md
@@ -8,30 +8,36 @@ This is the Claude Code-specific entry point. The same canonical rules live in [
 
 ## Stack
 
-- **sveltego** project. SSR generated at build time from `.svelte` to Go via `sveltego compile`.
-- **Server runtime is pure Go.** No JS/Node on the server.
+- **sveltego** project. `.svelte` files are pure Svelte 5; `sveltego compile` reads sibling `_*.server.go` files and emits TypeScript declarations (`.svelte.d.ts`) so editors and the Svelte LSP get strong types for `data`.
+- **Server runtime is pure Go.** No JS/Node on the server at request time. Node runs **only at build time** to prerender SSG routes through `svelte/server`.
 - **Client uses Svelte 5 runes** (`$props`, `$state`, `$derived`, `$effect`, `$bindable`) bundled by Vite for hydration only.
-- Generated code under `.gen/` is gitignored. Never edit `.gen/*.go` — edit the `.svelte` source.
+- Generated code under `.gen/` is gitignored. Never edit `.gen/*` — edit the `.svelte` source or its `_*.server.go` sibling.
 
 ---
 
-## Template expressions are Go, not JavaScript
+## Templates are pure Svelte / JS / TS
 
-Inside `{...}` mustaches, write **Go**. Field access is **PascalCase**.
+Inside `.svelte` files, write **Svelte/JS/TS only**. Field access uses **camelCase** keys derived from JSON tags on the Go-side `PageData` struct.
 
-| Wrong (JS) | Right (Go) |
+| Wrong (Go in mustaches) | Right (pure Svelte) |
 |---|---|
-| `{user.name}` | `{Data.User.Name}` |
-| `{posts.length}` | `{len(Data.Posts)}` |
-| `{count + 1}` | `{Count + 1}` |
-| `{n.toString()}` | `{strconv.Itoa(N)}` |
-| `{user?.name ?? "guest"}` | resolve in `Load()`, expose via `Data` |
-| `{users.filter(u => u.active)}` | filter in `Load()`, expose pre-filtered slice |
-| `null` | `nil` |
+| `{Data.User.Name}` | `{data.user.name}` |
+| `{len(Data.Posts)}` | `{data.posts.length}` |
+| `{Count + 1}` | `{count + 1}` |
+| `{strconv.Itoa(N)}` | `{n.toString()}` |
+| `nil` | `null` |
+| `{#if Data.User != nil}` | `{#if data.user != null}` |
 
-Expressions are validated at codegen via `go/parser.ParseExpr`. Anything that does not parse as a Go expression is a build error.
+Server-side data shaping (filtering, formatting, computing derived fields) belongs in `Load()`. Templates only render.
 
-Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<script lang="go">` block of the same component.
+```svelte
+<script lang="ts">
+  import type { PageData } from './_page.svelte';
+  let { data }: { data: PageData } = $props();
+</script>
+
+<h1>{data.title}</h1>
+```
 
 ---
 
@@ -39,7 +45,7 @@ Imports for any package referenced inside `{...}` (e.g. `strconv`) go in the `<s
 
 ```
 src/routes/
-  _page.svelte           SSR template, Go expressions inside {...}
+  _page.svelte           SSR template, pure Svelte
   _page.server.go        Load(), Actions      (Go skips '_*' automatically)
   _layout.svelte         layout chain
   _layout.server.go      layout-level Load    (Go skips '_*' automatically)
@@ -69,9 +75,18 @@ User `.go` files under `src/routes/**` are auto-skipped by Go via the `_` prefix
 ### Load
 
 ```go
+//go:build sveltego
+
 package routes
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+
+const Templates = "svelte"
+
+type PageData struct {
+    User  User   `json:"user"`
+    Posts []Post `json:"posts"`
+}
 
 func Load(ctx *kit.LoadCtx) (PageData, error) {
     return PageData{
@@ -79,14 +94,9 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
         Posts: fetchPosts(ctx),
     }, nil
 }
-
-type PageData struct {
-    User  User
-    Posts []Post
-}
 ```
 
-`PageData` is inferred from the `Load` return type; reference fields as `{Data.User.Name}`, `{len(Data.Posts)}`.
+`PageData`'s JSON tags drive the Go ↔ TypeScript boundary; reference fields as `{data.user.name}`, `{data.posts.length}`.
 
 ### Actions
 
@@ -104,6 +114,8 @@ var Actions = kit.ActionMap{
 
 The three sealed `ActionResult` constructors are `kit.ActionDataResult`, `kit.ActionFail`, `kit.ActionRedirect`. Do not invent new variants.
 
+When a route declares `Actions`, add `Form any \`json:"form"\`` to its `PageData` so the action result is reachable in the template (e.g. `{#if data.form}` ...).
+
 ### Redirect / Fail from Load
 
 `kit.Redirect(code, location)` and `kit.Fail(code, data)` return `error` values. Return them from `Load` to short-circuit:
@@ -115,6 +127,19 @@ if user == nil {
 ```
 
 The pipeline detects them via `errors.As`.
+
+### Prerender (SSG)
+
+For build-time-static routes:
+
+```go
+const (
+    Templates = "svelte"
+    Prerender = true
+)
+```
+
+`sveltego build` invokes Node once to render the component to `static/_prerendered/<path>/index.html`. The deployed Go binary serves it as a static file.
 
 ### Cookies
 
@@ -156,18 +181,18 @@ var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*ki
 var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
 ```
 
-`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.Code}`, `{data.Message}`.
+`HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
 
 ---
 
 ## Don't
 
-- JS expressions in mustaches (`?.`, `??`, template literals, `.map`/`.filter`/`.length`). Compute in `Load()` and expose via `Data`.
+- Go expressions in mustaches (`{Data.User.Name}`, `{len(...)}`, `nil`). Pure Svelte/JS/TS only.
+- PascalCase field access in templates. Use camelCase JSON-tag keys.
+- Omit JSON tags on `PageData` fields — without them, the boundary breaks.
 - Svelte 4 reactivity (`export let`, `$:` blocks, store autoload). Use Svelte 5 runes.
-- `null` — write `nil`.
-- camelCase field access in templates.
-- A JS server runtime. No Node / Bun / Deno on the server.
-- Editing `.gen/*.go` directly.
+- A JS server runtime at request time. Node only at build time for SSG.
+- Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
 - Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it).


### PR DESCRIPTION
## Summary

Phase 4 of [RFC #379](https://github.com/binsarjr/sveltego/issues/379). Migrates `playgrounds/blog`, `playgrounds/dashboard`, and the AI template fixtures (`templates/ai/`, `packages/init/internal/aitemplates/files/`) from Mustache-Go to pure Svelte/JS/TS.

`playgrounds/basic` was already migrated in Phase 3 (#402); verified still passing.

## Changes

- **Per-route `_page.server.go`** (blog, dashboard): lift inline anonymous structs to named `PageData` with explicit camelCase JSON tags so the Go → TypeScript boundary is byte-stable. Add `const Templates = "svelte"` to every page server.
- **Per-route `_page.svelte`** (blog, dashboard): replace `<script lang=\"go\">` blocks with `<script lang=\"ts\">` + `$props()` destructuring against the typegen-emitted `PageData`. Replace Go expressions inside mustaches with pure JS/TS (`{data.posts.length}`, `{#if ... != null}`, etc).
- **AI templates**: rewrite `AGENTS.md` / `CLAUDE.md` / `.cursorrules` / `copilot-instructions.md` to teach the pure-Svelte workflow (camelCase fields, JSON tags drive the type bridge, Node-only-at-build-time, `Prerender` opt-in) while keeping the rejected-pattern coverage the embed tests check (`+page.svelte`, `export let`).
- `templates/ai/` and `packages/init/internal/aitemplates/files/` kept identical so the init scaffolder ships the same content as the standalone export.

## Test plan

- [x] `gofumpt -l .`, `goimports -l -local github.com/binsarjr/sveltego .` clean.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] `go test ./...` green: `packages/sveltego` (1371), `packages/init` (29), `templates/ai` (5).
- [x] `sveltego compile` idempotent for all 3 playgrounds (sha256 round-trip equal).
- [x] `sveltego build --out ./build/app --no-client` succeeds for all 3 playgrounds.
- [x] Boot + curl smoke for all 3 playgrounds — SSR HTML serves correctly, hydration payload carries camelCase keys (`{\"loggedIn\":false,...}`, `{\"posts\":[...]}`), `/__data.json` endpoint returns expected JSON.
- [x] Generated `.svelte.d.ts` files type `data` end-to-end (`form: unknown` for `Form any`, `Item[]`, etc).

Closes #383. Targets `feat/pure-svelte-pivot-379`.