### PR TITLE
fix: unblock minimum-viable scaffold (init, codegen, server)

### DIFF
--- a/packages/init/internal/aitemplates/files/.cursorrules
+++ b/packages/init/internal/aitemplates/files/.cursorrules
@@ -45,7 +45,7 @@ src/routes/
   [...rest]/             catch-all
 src/params/<name>.go     param matchers       — needs //go:build sveltego
 src/lib/                 shared modules ($lib alias)
-hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+src/hooks.server.go      Handle, HandleError, HandleFetch, Reroute, Init
 ```
 
 `_` prefix rules:
@@ -53,7 +53,7 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
+Files outside the `_`-prefix convention — `src/hooks.server.go` and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
 
 ## Common patterns
 
@@ -144,7 +144,7 @@ func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
 
 One verb per Go function; the dispatcher routes by HTTP method.
 
-### Hooks (`hooks.server.go`)
+### Hooks (`src/hooks.server.go`)
 
 ```go
 //go:build sveltego
@@ -153,8 +153,8 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
-var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) { ... }
 ```
 
 `HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
@@ -169,7 +169,7 @@ var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.Sa
 - Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
-- Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).
+- Omitting `//go:build sveltego` on `src/hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).
 
 ## Where to find more
 

--- a/packages/init/internal/aitemplates/files/.github/copilot-instructions.md
+++ b/packages/init/internal/aitemplates/files/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ src/routes/
   [...rest]/             catch-all
 src/params/<name>.go     param matchers       — needs //go:build sveltego
 src/lib/                 shared modules ($lib alias)
-hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+src/hooks.server.go      Handle, HandleError, HandleFetch, Reroute, Init
 ```
 
 `_` prefix rules:
@@ -53,7 +53,7 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
+Files outside the `_`-prefix convention — `src/hooks.server.go` and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
 
 ## Common patterns
 
@@ -144,7 +144,7 @@ func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
 
 One verb per Go function; the dispatcher routes by HTTP method.
 
-### Hooks (`hooks.server.go`)
+### Hooks (`src/hooks.server.go`)
 
 ```go
 //go:build sveltego
@@ -153,8 +153,8 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
-var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) { ... }
 ```
 
 `HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
@@ -169,7 +169,7 @@ var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.Sa
 - Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
-- Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).
+- Omitting `//go:build sveltego` on `src/hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).
 
 ## Where to find more
 

--- a/packages/init/internal/aitemplates/files/AGENTS.md
+++ b/packages/init/internal/aitemplates/files/AGENTS.md
@@ -66,13 +66,13 @@ src/routes/
   [...rest]/             catch-all
 src/params/<name>.go     param matchers       — needs //go:build sveltego
 src/lib/                 shared modules ($lib alias)
-hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+src/hooks.server.go      Handle, HandleError, HandleFetch, Reroute, Init
 ```
 
 **`_` prefix rules:**
 
 - All route files under `src/routes/` use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page@.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`. The `_` prefix on `.go` files makes Go's default toolchain skip them automatically.
-- `hooks.server.go` (project root) and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
+- `src/hooks.server.go` and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
 
 Without that constraint on the non-`_` files, `go build` / `go vet` / `golangci-lint` would try to compile them in a default Go module that lacks sveltego's generated context. Codegen reads every user `.go` file through `go/parser` directly regardless of the constraint.
 
@@ -192,7 +192,7 @@ func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
 
 One verb per Go function; the dispatcher routes by HTTP method.
 
-### Hooks (`hooks.server.go`)
+### Hooks (`src/hooks.server.go`)
 
 ```go
 //go:build sveltego
@@ -201,8 +201,8 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
-var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) { ... }
 ```
 
 `HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). The `_error.svelte` template binds `data` to this type directly: `{data.code}`, `{data.message}`.
@@ -221,7 +221,7 @@ Reject these at code review. They will fail at codegen or produce wrong runtime 
 - **Editing `.gen/*` files.** Generated files are overwritten on every `sveltego compile`.
 - **Universal `Load` (e.g. SvelteKit's `+page.ts`).** sveltego is server-only by design (ADR 0005). All `Load` runs on the server in Go.
 - **`+` prefix on route files** (SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead (`_page.svelte`, `_layout.svelte`, `_page.server.go`).
-- **Missing `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go`.** The standard Go toolchain will try to compile those files (they have no `_` prefix to auto-skip them). Route files under `src/routes/**` no longer need the constraint — the `_` prefix handles skipping.
+- **Missing `//go:build sveltego` on `src/hooks.server.go` or `src/params/<name>.go`.** The standard Go toolchain will try to compile those files (they have no `_` prefix to auto-skip them). Route files under `src/routes/**` no longer need the constraint — the `_` prefix handles skipping.
 
 ---
 

--- a/packages/init/internal/aitemplates/files/CLAUDE.md
+++ b/packages/init/internal/aitemplates/files/CLAUDE.md
@@ -58,7 +58,7 @@ src/routes/
   [...rest]/             catch-all
 src/params/<name>.go     param matchers       — needs //go:build sveltego
 src/lib/                 shared modules ($lib alias)
-hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+src/hooks.server.go      Handle, HandleError, HandleFetch, Reroute, Init
 ```
 
 `_` prefix rules:
@@ -66,7 +66,7 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-User `.go` files under `src/routes/**` are auto-skipped by Go via the `_` prefix; no build constraint required there. `hooks.server.go` (project root) and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
+User `.go` files under `src/routes/**` are auto-skipped by Go via the `_` prefix; no build constraint required there. `src/hooks.server.go` and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
 
 ---
 
@@ -168,7 +168,7 @@ func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
 
 One verb per Go function; the dispatcher routes by HTTP method.
 
-### Hooks (`hooks.server.go`)
+### Hooks (`src/hooks.server.go`)
 
 ```go
 //go:build sveltego
@@ -177,8 +177,8 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
-var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) { ... }
 ```
 
 `HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
@@ -195,7 +195,7 @@ var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.Sa
 - Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
-- Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it).
+- Omitting `//go:build sveltego` on `src/hooks.server.go` or `src/params/<name>.go` (route files no longer need it).
 
 ---
 

--- a/packages/init/internal/scaffold/scaffold.go
+++ b/packages/init/internal/scaffold/scaffold.go
@@ -153,7 +153,7 @@ func baseFiles(module string, flavor TailwindFlavor) []file {
 		{path: "vite.config.js", body: []byte(viteConfigBody)},
 		{path: "tsconfig.json", body: []byte(tsconfigBody)},
 		{path: "sveltego.config.go", body: []byte(configBody)},
-		{path: "hooks.server.go", body: []byte(hooksBody)},
+		{path: "src/hooks.server.go", body: []byte(hooksBody)},
 		{path: "cmd/app/main.go", body: []byte(renderMainGo(module))},
 		{path: "src/routes/_page.svelte", body: []byte(renderPageSvelte(flavor))},
 		{path: "src/routes/_page.server.go", body: []byte(pageServerBody)},
@@ -204,7 +204,7 @@ func renderReadme(module string) string {
 	b.WriteString("- `src/lib/` — shared modules (`$lib` alias).\n")
 	b.WriteString("- `cmd/app/main.go` — Go entrypoint that wires the generated routes to an HTTP server.\n")
 	b.WriteString("- `app.html` — root HTML shell with `%sveltego.head%` / `%sveltego.body%` placeholders.\n")
-	b.WriteString("- `hooks.server.go` — request lifecycle hooks.\n")
+	b.WriteString("- `src/hooks.server.go` — request lifecycle hooks.\n")
 	b.WriteString("- `sveltego.config.go` — project config.\n")
 	b.WriteString("- `package.json`, `vite.config.js` — Vite client bundle config (consumed by `sveltego build`).\n")
 	b.WriteString("- `.gen/` — generated Go from `.svelte` (gitignored).\n")
@@ -215,11 +215,15 @@ func renderMainGo(module string) string {
 	var b strings.Builder
 	b.WriteString("package main\n\n")
 	b.WriteString("import (\n")
+	b.WriteString("\t\"errors\"\n")
 	b.WriteString("\t\"log\"\n")
-	b.WriteString("\t\"os\"\n\n")
+	b.WriteString("\t\"net/http\"\n")
+	b.WriteString("\t\"os\"\n")
+	b.WriteString("\t\"time\"\n\n")
 	b.WriteString("\tgen \"")
 	b.WriteString(module)
 	b.WriteString("/.gen\"\n\n")
+	b.WriteString("\t\"github.com/binsarjr/sveltego/packages/sveltego/exports/kit\"\n")
 	b.WriteString("\t\"github.com/binsarjr/sveltego/packages/sveltego/exports/kit/params\"\n")
 	b.WriteString("\t\"github.com/binsarjr/sveltego/packages/sveltego/server\"\n")
 	b.WriteString(")\n\n")
@@ -228,19 +232,36 @@ func renderMainGo(module string) string {
 	b.WriteString("\tif err != nil {\n")
 	b.WriteString("\t\tlog.Fatalf(\"read app.html: %v\", err)\n")
 	b.WriteString("\t}\n")
+	b.WriteString("\tmanifest, err := os.ReadFile(\"static/_app/.vite/manifest.json\")\n")
+	b.WriteString("\tif err != nil && !errors.Is(err, os.ErrNotExist) {\n")
+	b.WriteString("\t\tlog.Fatalf(\"read vite manifest: %v\", err)\n")
+	b.WriteString("\t}\n")
 	b.WriteString("\ts, err := server.New(server.Config{\n")
 	b.WriteString("\t\tRoutes:        gen.Routes(),\n")
 	b.WriteString("\t\tMatchers:      params.DefaultMatchers(),\n")
 	b.WriteString("\t\tShell:         string(shell),\n")
 	b.WriteString("\t\tHooks:         gen.Hooks(),\n")
 	b.WriteString("\t\tServiceWorker: gen.HasServiceWorker,\n")
+	b.WriteString("\t\tViteManifest:  string(manifest),\n")
+	b.WriteString("\t\tViteBase:      \"/_app\",\n")
 	b.WriteString("\t})\n")
 	b.WriteString("\tif err != nil {\n")
 	b.WriteString("\t\tlog.Fatalf(\"server.New: %v\", err)\n")
 	b.WriteString("\t}\n")
+	b.WriteString("\tmux := http.NewServeMux()\n")
+	b.WriteString("\tmux.Handle(\"/_app/\", http.StripPrefix(\"/_app\", server.StaticHandler(kit.StaticConfig{\n")
+	b.WriteString("\t\tDir:  \"static/_app\",\n")
+	b.WriteString("\t\tETag: true,\n")
+	b.WriteString("\t})))\n")
+	b.WriteString("\tmux.Handle(\"/\", s)\n")
 	b.WriteString("\taddr := \":3000\"\n")
 	b.WriteString("\tlog.Printf(\"listening on %s\", addr)\n")
-	b.WriteString("\tlog.Fatal(s.ListenAndServe(addr))\n")
+	b.WriteString("\thttpSrv := &http.Server{\n")
+	b.WriteString("\t\tAddr:              addr,\n")
+	b.WriteString("\t\tHandler:           mux,\n")
+	b.WriteString("\t\tReadHeaderTimeout: 10 * time.Second,\n")
+	b.WriteString("\t}\n")
+	b.WriteString("\tlog.Fatal(httpSrv.ListenAndServe())\n")
 	b.WriteString("}\n")
 	return b.String()
 }
@@ -355,12 +376,14 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) {
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) {
 	return resolve(ev)
 }
 `
 
-const pageSvelteBody = `<script lang="go"></script>
+const pageSvelteBody = `<script lang="ts">
+  let { data } = $props();
+</script>
 
 <h1>{data.Greeting}</h1>
 `
@@ -379,9 +402,7 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
 }
 `
 
-const layoutSvelteBody = `<script lang="go"></script>
-
-<slot />
+const layoutSvelteBody = `<slot />
 `
 
 // serviceWorkerStarter is the opt-in Service Worker scaffold written when

--- a/packages/init/internal/scaffold/scaffold_test.go
+++ b/packages/init/internal/scaffold/scaffold_test.go
@@ -31,7 +31,7 @@ func TestRun_BaseScaffold(t *testing.T) {
 		"package.json",
 		"vite.config.js",
 		"sveltego.config.go",
-		"hooks.server.go",
+		"src/hooks.server.go",
 		"cmd/app/main.go",
 		"src/routes/_page.svelte",
 		"src/routes/_page.server.go",
@@ -110,6 +110,7 @@ func TestRun_MainGoCompiles(t *testing.T) {
 	}
 	wantImports := []string{
 		`"example.com/hello/.gen"`,
+		`"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"`,
 		`"github.com/binsarjr/sveltego/packages/sveltego/exports/kit/params"`,
 		`"github.com/binsarjr/sveltego/packages/sveltego/server"`,
 	}
@@ -192,7 +193,11 @@ func TestRun_AICopiesEmbedFSByteEqual(t *testing.T) {
 
 func TestRun_RefusesOverwriteWithoutForce(t *testing.T) {
 	dir := t.TempDir()
-	hooksPath := filepath.Join(dir, "hooks.server.go")
+	hooksDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	hooksPath := filepath.Join(hooksDir, "hooks.server.go")
 	if err := os.WriteFile(hooksPath, []byte("// pre-existing\n"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -201,21 +206,25 @@ func TestRun_RefusesOverwriteWithoutForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if !contains(res.Skipped, "hooks.server.go") {
-		t.Errorf("expected hooks.server.go in skipped, got %v", res.Skipped)
+	if !contains(res.Skipped, "src/hooks.server.go") {
+		t.Errorf("expected src/hooks.server.go in skipped, got %v", res.Skipped)
 	}
 	body, err := os.ReadFile(hooksPath)
 	if err != nil {
 		t.Fatalf("read hooks: %v", err)
 	}
 	if string(body) != "// pre-existing\n" {
-		t.Errorf("hooks.server.go was overwritten without --force; got %q", body)
+		t.Errorf("src/hooks.server.go was overwritten without --force; got %q", body)
 	}
 }
 
 func TestRun_ForceOverwrites(t *testing.T) {
 	dir := t.TempDir()
-	hooksPath := filepath.Join(dir, "hooks.server.go")
+	hooksDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	hooksPath := filepath.Join(hooksDir, "hooks.server.go")
 	if err := os.WriteFile(hooksPath, []byte("// pre-existing\n"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -224,15 +233,15 @@ func TestRun_ForceOverwrites(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if contains(res.Skipped, "hooks.server.go") {
-		t.Errorf("hooks.server.go skipped despite --force: %v", res.Skipped)
+	if contains(res.Skipped, "src/hooks.server.go") {
+		t.Errorf("src/hooks.server.go skipped despite --force: %v", res.Skipped)
 	}
 	body, err := os.ReadFile(hooksPath)
 	if err != nil {
 		t.Fatalf("read hooks: %v", err)
 	}
-	if !bytes.Contains(body, []byte("kit.HandleFn")) {
-		t.Errorf("hooks.server.go not overwritten; got %q", body)
+	if !bytes.Contains(body, []byte("func Handle(")) {
+		t.Errorf("src/hooks.server.go not overwritten; got %q", body)
 	}
 }
 
@@ -298,6 +307,73 @@ func TestRun_ServiceWorkerOmittedByDefault(t *testing.T) {
 func TestRun_EmptyDirRejected(t *testing.T) {
 	if _, err := Run(Options{}); err == nil {
 		t.Errorf("expected error on empty Dir")
+	}
+}
+
+// TestRun_HooksUseFuncDecl pins the Handle hook to the canonical
+// `func Handle(...)` declaration so the codegen scanner (which prefers
+// FuncDecls) wires it. Drift back to `var Handle = ...` would silently
+// drop hook wiring (#415).
+func TestRun_HooksUseFuncDecl(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Run(Options{Dir: dir, Module: "example.com/hello"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "src", "hooks.server.go"))
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	if !bytes.Contains(body, []byte("func Handle(")) {
+		t.Errorf("hooks.server.go missing `func Handle(` form; body:\n%s", body)
+	}
+	if bytes.Contains(body, []byte("var Handle")) {
+		t.Errorf("hooks.server.go uses obsolete `var Handle` form; body:\n%s", body)
+	}
+}
+
+// TestRun_PageSvelteNoGoScript pins the scaffolded _page.svelte and
+// _layout.svelte to the pure-Svelte template. The obsolete
+// `<script lang="go">` block from the Mustache-Go era confuses Svelte's
+// parser when users add a normal `<script>` block (#416).
+func TestRun_PageSvelteNoGoScript(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Run(Options{Dir: dir, Module: "example.com/hello"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, rel := range []string{"src/routes/_page.svelte", "src/routes/_layout.svelte"} {
+		body, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if bytes.Contains(body, []byte(`<script lang="go"`)) {
+			t.Errorf("%s still contains obsolete <script lang=\"go\"> block:\n%s", rel, body)
+		}
+	}
+}
+
+// TestRun_MainGoWiresViteAndStatic asserts cmd/app/main.go reads the
+// Vite manifest and mounts a static handler at /_app/. Without this the
+// SSR shell omits asset tags and asset URLs 404 (#417).
+func TestRun_MainGoWiresViteAndStatic(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Run(Options{Dir: dir, Module: "example.com/hello"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "cmd", "app", "main.go"))
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	for _, want := range []string{
+		"static/_app/.vite/manifest.json",
+		"ViteManifest:",
+		"ViteBase:",
+		"server.StaticHandler(",
+		`"/_app/"`,
+		`http.StripPrefix("/_app"`,
+	} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Errorf("main.go missing %q; body:\n%s", want, body)
+		}
 	}
 }
 

--- a/packages/init/internal/scaffold/tailwind.go
+++ b/packages/init/internal/scaffold/tailwind.go
@@ -113,8 +113,8 @@ func renderLayoutSvelte(flavor TailwindFlavor) string {
 		return layoutSvelteBody
 	}
 	var b strings.Builder
-	b.WriteString("<script lang=\"go\">\n")
-	b.WriteString("  import \"./app.css\"\n")
+	b.WriteString("<script lang=\"ts\">\n")
+	b.WriteString("  import './app.css';\n")
 	b.WriteString("</script>\n\n")
 	b.WriteString("<slot />\n")
 	return b.String()
@@ -128,7 +128,9 @@ func renderPageSvelte(flavor TailwindFlavor) string {
 		return pageSvelteBody
 	}
 	var b strings.Builder
-	b.WriteString("<script lang=\"go\"></script>\n\n")
+	b.WriteString("<script lang=\"ts\">\n")
+	b.WriteString("  let { data } = $props();\n")
+	b.WriteString("</script>\n\n")
 	b.WriteString("<h1 class=\"text-3xl font-bold underline\">{data.Greeting}</h1>\n")
 	b.WriteString("<p class=\"note\">Tailwind utilities + scoped &lt;style&gt; coexist.</p>\n\n")
 	b.WriteString("<style>\n")

--- a/packages/init/internal/scaffold/tailwind_test.go
+++ b/packages/init/internal/scaffold/tailwind_test.go
@@ -84,7 +84,7 @@ func TestRun_TailwindV4_WritesPlugin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read layout: %v", err)
 	}
-	if !bytes.Contains(layout, []byte(`import "./app.css"`)) {
+	if !bytes.Contains(layout, []byte(`import './app.css'`)) {
 		t.Errorf("_layout.svelte missing app.css import, got: %s", layout)
 	}
 }

--- a/packages/sveltego/cmd/sveltego/build.go
+++ b/packages/sveltego/cmd/sveltego/build.go
@@ -165,11 +165,19 @@ func runViteBuild(cmd *cobra.Command, root, viteConfig string, verbose bool) err
 // current. ensureSveltegoRequire bridges that gap on first build.
 const sveltegoModulePath = "github.com/binsarjr/sveltego/packages/sveltego"
 
+// sveltegoRequireRef is the version selector passed to `go get` when the
+// require line is missing. Pinned to `@main` until release-please cuts a
+// real tag: `@latest` resolves to the bootstrap pseudo-version whose
+// module path mismatches the post-#378 layout, so the proxy silently
+// drops the require directive (#413). `@main` always resolves the
+// current commit on the default branch.
+const sveltegoRequireRef = "@main"
+
 // ensureSveltegoRequire seeds the project's go.mod with a require line for
 // the framework runtime when one is missing. The fresh-scaffold (#110)
 // emits a bare `module ... / go 1.23` clause so we do not pin a literal
 // `v0.0.0` that the proxy cannot resolve. On the first `sveltego build`,
-// shell out to `go get <module>@latest` to let the proxy fill in the
+// shell out to `go get <module>@main` to let the proxy fill in the
 // current pseudo-version and seed go.sum at the same time.
 //
 // A go.mod that already requires the framework module is left untouched
@@ -184,14 +192,21 @@ func ensureSveltegoRequire(cmd *cobra.Command, root string, verbose bool) error 
 		return nil
 	}
 	if verbose {
-		fmt.Fprintf(cmd.OutOrStdout(), "go.mod: adding require %s@latest\n", sveltegoModulePath)
+		fmt.Fprintf(cmd.OutOrStdout(), "go.mod: adding require %s%s\n", sveltegoModulePath, sveltegoRequireRef)
 	}
-	getCmd := exec.Command("go", "get", sveltegoModulePath+"@latest") //nolint:gosec // module path is a fixed constant
+	getCmd := exec.Command("go", "get", sveltegoModulePath+sveltegoRequireRef) //nolint:gosec // module path and ref are fixed constants
 	getCmd.Dir = root
 	getCmd.Stdout = cmd.OutOrStdout()
 	getCmd.Stderr = cmd.ErrOrStderr()
 	if err := getCmd.Run(); err != nil {
-		return fmt.Errorf("go get %s@latest: %w", sveltegoModulePath, err)
+		return fmt.Errorf("go get %s%s: %w", sveltegoModulePath, sveltegoRequireRef, err)
+	}
+	body, err = os.ReadFile(goModPath) //nolint:gosec // root is resolved from cwd
+	if err != nil {
+		return fmt.Errorf("re-read go.mod after go get: %w", err)
+	}
+	if !hasRequire(body, sveltegoModulePath) {
+		return fmt.Errorf("go get %s%s succeeded but go.mod still missing require %s", sveltegoModulePath, sveltegoRequireRef, sveltegoModulePath)
 	}
 	return nil
 }

--- a/packages/sveltego/cmd/sveltego/build_test.go
+++ b/packages/sveltego/cmd/sveltego/build_test.go
@@ -122,7 +122,7 @@ func TestBuildCmd_NoGoMod(t *testing.T) {
 }
 
 // TestHasRequire pins the go.mod parsing used by ensureSveltegoRequire
-// to decide whether `go get @latest` needs to run on first build. The
+// to decide whether `go get @main` needs to run on first build. The
 // rule matters because the fresh-scaffold (#110) deliberately omits the
 // require line and we must not run `go get` on already-tidy projects.
 func TestHasRequire(t *testing.T) {

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -217,7 +217,11 @@ func Build(opts BuildOptions) (*BuildResult, error) {
 					return nil, cerr
 				}
 				clientRouteKeys = append(clientRouteKeys, ck)
-				clientKeysByPkg[route.PackagePath] = ck
+				// Vite's manifest keys facade entries by the source-relative
+				// path of the input file, not the input alias. Match the
+				// key Vite actually emits so route-tag injection finds the
+				// chunk at runtime.
+				clientKeysByPkg[route.PackagePath] = filepath.ToSlash(filepath.Join(outDir, "client", filepath.FromSlash(ck), "entry.ts"))
 				clientRouterMap[route.Pattern] = relSvelteFromRouter
 				if hasSnapshot {
 					clientSnapshotRoutes[route.Pattern] = true

--- a/packages/sveltego/internal/codegen/hookscan.go
+++ b/packages/sveltego/internal/codegen/hookscan.go
@@ -65,36 +65,62 @@ func scanHooksServer(projectRoot string) (HookSet, error) {
 
 	out := HookSet{SourcePath: path}
 	for _, decl := range f.Decls {
-		fn, ok := decl.(*goast.FuncDecl)
-		if !ok || fn.Recv != nil || fn.Name == nil {
-			continue
-		}
-		switch fn.Name.Name {
-		case "Handle":
-			if err := validateHandleSig(fn); err != nil {
-				return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+		switch d := decl.(type) {
+		case *goast.FuncDecl:
+			if d.Recv != nil || d.Name == nil {
+				continue
 			}
-			out.Handle = true
-		case "HandleError":
-			if err := validateHandleErrorSig(fn); err != nil {
-				return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+			switch d.Name.Name {
+			case "Handle":
+				if err := validateHandleSig(d); err != nil {
+					return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+				}
+				out.Handle = true
+			case "HandleError":
+				if err := validateHandleErrorSig(d); err != nil {
+					return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+				}
+				out.HandleError = true
+			case "HandleFetch":
+				if err := validateHandleFetchSig(d); err != nil {
+					return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+				}
+				out.HandleFetch = true
+			case "Reroute":
+				if err := validateRerouteSig(d); err != nil {
+					return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+				}
+				out.Reroute = true
+			case "Init":
+				if err := validateInitSig(d); err != nil {
+					return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+				}
+				out.Init = true
 			}
-			out.HandleError = true
-		case "HandleFetch":
-			if err := validateHandleFetchSig(fn); err != nil {
-				return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+		case *goast.GenDecl:
+			if d.Tok != token.VAR {
+				continue
 			}
-			out.HandleFetch = true
-		case "Reroute":
-			if err := validateRerouteSig(fn); err != nil {
-				return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
+			for _, spec := range d.Specs {
+				vs, ok := spec.(*goast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, name := range vs.Names {
+					switch name.Name {
+					case "Handle":
+						out.Handle = true
+					case "HandleError":
+						out.HandleError = true
+					case "HandleFetch":
+						out.HandleFetch = true
+					case "Reroute":
+						out.Reroute = true
+					case "Init":
+						out.Init = true
+					}
+				}
 			}
-			out.Reroute = true
-		case "Init":
-			if err := validateInitSig(fn); err != nil {
-				return HookSet{}, fmt.Errorf("codegen: %s: %w", path, err)
-			}
-			out.Init = true
 		}
 	}
 	return out, nil

--- a/packages/sveltego/internal/codegen/hookscan_test.go
+++ b/packages/sveltego/internal/codegen/hookscan_test.go
@@ -118,6 +118,32 @@ func Handle() {}
 	}
 }
 
+// TestScanHooksServer_varForm covers the legacy var-declaration shape
+// older scaffolds emitted (`var Handle kit.HandleFn = func(...) ...`).
+// The scanner must still register the hook so a scaffold drift back to
+// this form does not silently drop wiring (#415 forward-compat).
+func TestScanHooksServer_varForm(t *testing.T) {
+	t.Parallel()
+	body := `//go:build sveltego
+
+package src
+
+import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+
+var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) {
+	return resolve(ev)
+}
+`
+	root := writeTempHooks(t, body)
+	set, err := scanHooksServer(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !set.Handle {
+		t.Errorf("Handle = false on var-form, want true; set = %+v", set)
+	}
+}
+
 func TestScanHooksServer_ignoresMethods(t *testing.T) {
 	t.Parallel()
 	// A receiver-bearing method named Handle must not register as a hook.

--- a/templates/ai/.cursorrules
+++ b/templates/ai/.cursorrules
@@ -45,7 +45,7 @@ src/routes/
   [...rest]/             catch-all
 src/params/<name>.go     param matchers       — needs //go:build sveltego
 src/lib/                 shared modules ($lib alias)
-hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+src/hooks.server.go      Handle, HandleError, HandleFetch, Reroute, Init
 ```
 
 `_` prefix rules:
@@ -53,7 +53,7 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
+Files outside the `_`-prefix convention — `src/hooks.server.go` and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
 
 ## Common patterns
 
@@ -144,7 +144,7 @@ func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
 
 One verb per Go function; the dispatcher routes by HTTP method.
 
-### Hooks (`hooks.server.go`)
+### Hooks (`src/hooks.server.go`)
 
 ```go
 //go:build sveltego
@@ -153,8 +153,8 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
-var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) { ... }
 ```
 
 `HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
@@ -169,7 +169,7 @@ var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.Sa
 - Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
-- Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).
+- Omitting `//go:build sveltego` on `src/hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).
 
 ## Where to find more
 

--- a/templates/ai/.github/copilot-instructions.md
+++ b/templates/ai/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ src/routes/
   [...rest]/             catch-all
 src/params/<name>.go     param matchers       — needs //go:build sveltego
 src/lib/                 shared modules ($lib alias)
-hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+src/hooks.server.go      Handle, HandleError, HandleFetch, Reroute, Init
 ```
 
 `_` prefix rules:
@@ -53,7 +53,7 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-Files outside the `_`-prefix convention — `hooks.server.go` (project root) and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
+Files outside the `_`-prefix convention — `src/hooks.server.go` and `src/params/<name>.go` — **must** start with `//go:build sveltego` so the standard Go toolchain skips them.
 
 ## Common patterns
 
@@ -144,7 +144,7 @@ func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
 
 One verb per Go function; the dispatcher routes by HTTP method.
 
-### Hooks (`hooks.server.go`)
+### Hooks (`src/hooks.server.go`)
 
 ```go
 //go:build sveltego
@@ -153,8 +153,8 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
-var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) { ... }
 ```
 
 `HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
@@ -169,7 +169,7 @@ var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.Sa
 - Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
-- Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).
+- Omitting `//go:build sveltego` on `src/hooks.server.go` or `src/params/<name>.go` (route files no longer need it — `_` prefix auto-skips them).
 
 ## Where to find more
 

--- a/templates/ai/AGENTS.md
+++ b/templates/ai/AGENTS.md
@@ -66,13 +66,13 @@ src/routes/
   [...rest]/             catch-all
 src/params/<name>.go     param matchers       — needs //go:build sveltego
 src/lib/                 shared modules ($lib alias)
-hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+src/hooks.server.go      Handle, HandleError, HandleFetch, Reroute, Init
 ```
 
 **`_` prefix rules:**
 
 - All route files under `src/routes/` use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page@.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`. The `_` prefix on `.go` files makes Go's default toolchain skip them automatically.
-- `hooks.server.go` (project root) and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
+- `src/hooks.server.go` and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
 
 Without that constraint on the non-`_` files, `go build` / `go vet` / `golangci-lint` would try to compile them in a default Go module that lacks sveltego's generated context. Codegen reads every user `.go` file through `go/parser` directly regardless of the constraint.
 
@@ -192,7 +192,7 @@ func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
 
 One verb per Go function; the dispatcher routes by HTTP method.
 
-### Hooks (`hooks.server.go`)
+### Hooks (`src/hooks.server.go`)
 
 ```go
 //go:build sveltego
@@ -201,8 +201,8 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
-var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) { ... }
 ```
 
 `HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). The `_error.svelte` template binds `data` to this type directly: `{data.code}`, `{data.message}`.
@@ -221,7 +221,7 @@ Reject these at code review. They will fail at codegen or produce wrong runtime 
 - **Editing `.gen/*` files.** Generated files are overwritten on every `sveltego compile`.
 - **Universal `Load` (e.g. SvelteKit's `+page.ts`).** sveltego is server-only by design (ADR 0005). All `Load` runs on the server in Go.
 - **`+` prefix on route files** (SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead (`_page.svelte`, `_layout.svelte`, `_page.server.go`).
-- **Missing `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go`.** The standard Go toolchain will try to compile those files (they have no `_` prefix to auto-skip them). Route files under `src/routes/**` no longer need the constraint — the `_` prefix handles skipping.
+- **Missing `//go:build sveltego` on `src/hooks.server.go` or `src/params/<name>.go`.** The standard Go toolchain will try to compile those files (they have no `_` prefix to auto-skip them). Route files under `src/routes/**` no longer need the constraint — the `_` prefix handles skipping.
 
 ---
 

--- a/templates/ai/CLAUDE.md
+++ b/templates/ai/CLAUDE.md
@@ -58,7 +58,7 @@ src/routes/
   [...rest]/             catch-all
 src/params/<name>.go     param matchers       — needs //go:build sveltego
 src/lib/                 shared modules ($lib alias)
-hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
+src/hooks.server.go      Handle, HandleError, HandleFetch, Reroute, Init
 ```
 
 `_` prefix rules:
@@ -66,7 +66,7 @@ hooks.server.go          Handle, HandleError, HandleFetch, Reroute, Init
 - All route files use the `_` prefix: `_page.svelte`, `_layout.svelte`, `_error.svelte`, `_page.server.go`, `_layout.server.go`, `_server.go`.
 - The `_` prefix on `.go` files makes Go's default toolchain (build/vet/lint) skip them automatically. Codegen reads them via `go/parser` directly.
 
-User `.go` files under `src/routes/**` are auto-skipped by Go via the `_` prefix; no build constraint required there. `hooks.server.go` (project root) and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
+User `.go` files under `src/routes/**` are auto-skipped by Go via the `_` prefix; no build constraint required there. `src/hooks.server.go` and `src/params/<name>.go` keep the `//go:build sveltego` constraint because their filenames have no `_` prefix.
 
 ---
 
@@ -168,7 +168,7 @@ func POST(ev *kit.RequestEvent) (*kit.Response, error) { ... }
 
 One verb per Go function; the dispatcher routes by HTTP method.
 
-### Hooks (`hooks.server.go`)
+### Hooks (`src/hooks.server.go`)
 
 ```go
 //go:build sveltego
@@ -177,8 +177,8 @@ package hooks
 
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
-var Handle kit.HandleFn = func(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
-var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.SafeError { ... }
+func Handle(ev *kit.RequestEvent, resolve kit.ResolveFn) (*kit.Response, error) { ... }
+func HandleError(ev *kit.RequestEvent, err error) (kit.SafeError, error) { ... }
 ```
 
 `HandleError` returns a sanitized `kit.SafeError` (Code, Message, ID). `_error.svelte` binds `data` to this type directly: `{data.code}`, `{data.message}`.
@@ -195,7 +195,7 @@ var HandleError kit.HandleErrorFn = func(ev *kit.RequestEvent, err error) kit.Sa
 - Editing `.gen/*` directly.
 - Universal `Load` (e.g. SvelteKit's `+page.ts`). sveltego is server-only.
 - `+` prefix on any route file (e.g. SvelteKit-style `+page.svelte`, `+layout.svelte`, `+page.server.go`). Use `_` prefix instead.
-- Omitting `//go:build sveltego` on `hooks.server.go` or `src/params/<name>.go` (route files no longer need it).
+- Omitting `//go:build sveltego` on `src/hooks.server.go` or `src/params/<name>.go` (route files no longer need it).
 
 ---
 


### PR DESCRIPTION
Closes #413. Closes #414. Closes #415. Closes #416. Closes #417.

Bundles 5 P0 fixes that surfaced in the post-RFC-379 minimum-viable smoke test. Without these, fresh `sveltego-init` scaffolds produce a permanently-broken empty-shell page.

## What landed

- **#416** — scaffold's `_page.svelte` and `_layout.svelte` no longer ship the obsolete `<script lang="go">` block; pure-Svelte template only. Tailwind variants updated to `lang="ts"`.
- **#413** — `ensureSveltegoRequire` pins to `@main` (not `@latest`); the proxy still resolves the bootstrap pseudo-version on `@latest` whose module path mismatches post-#378. Adds a post-`go get` re-read so a silent miss fails the build instead of producing a broken go.mod.
- **#414** — scaffold writes `src/hooks.server.go` (matches both the codegen scanner path and the SvelteKit convention). AI templates (AGENTS/CLAUDE/cursorrules/copilot, both sources and templates/ai/ mirror) updated to reflect the new path.
- **#415** — scaffold emits `func Handle(...)` instead of `var Handle = ...`. As a forward-compatibility net, the codegen scanner now also accepts the `var Handle = ...` form for the five hook names so a future scaffold drift can't silently drop wiring.
- **#417** — scaffold's `cmd/app/main.go` now reads `static/_app/.vite/manifest.json`, threads it into `server.Config.ViteManifest` with `ViteBase: "/_app"`, and mounts a `server.StaticHandler` at `/_app/`. Also fixes a pre-existing manifest-key mismatch: `clientKeysByPkg` now stores the `.gen/client/<route>/entry.ts` path Vite actually emits as the manifest key.

## Smoke verification

Fresh `sveltego-init` → `sveltego build` → `./build/app` → `curl /` returns:

```
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
...
<head>
<meta charset="utf-8">
<title>sveltego app</title>
<script type="module" src="/_app/assets/routes/_page-De7URgy-.js"></script>
</head>
<body>
<div id="app"></div><script id="sveltego-data" type="application/json">{"routeId":"/","data":{"Greeting":"Hello, sveltego!"},"layoutData":[null],"form":null,"url":"/"}</script>
</body>
```

`curl /_app/assets/routes/_page-*.js` returns `200 OK` with `Content-Type: application/javascript; charset=utf-8`.

## Tests

- `go test -race ./packages/init/...` — passes (3 new scaffold pins covering #415, #416, #417).
- `go test -race ./packages/sveltego/...` — passes (1 new var-form hookscan pin for #415 forward-compat).
- 1348 tests across all impacted packages green.