### PR TITLE
feat(codegen): node sidecar acorn JSON-AST extension

### DIFF
--- a/packages/sveltego/internal/codegen/svelterender/sidecar/index.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/index.mjs
@@ -1,0 +1,68 @@
+// Build-time Node sidecar entry point. Two modes:
+//
+//   --mode=ssg  prerender pure-Svelte routes to static HTML (ADR 0008).
+//   --mode=ssr  compile each route via svelte/compiler generate:'server'
+//               then parse the resulting JS via Acorn and write the
+//               ESTree JSON AST to .gen/svelte_js2go/<route>/ast.json
+//               (ADR 0009, RFC #421).
+//
+// The sidecar is build-time-only. Production deploys ship the Go binary
+// plus static/ — never this script.
+
+import { runSSG } from "./ssg.mjs";
+import { runSSR } from "./ssr.mjs";
+
+function parseArgs(argv) {
+	const args = { mode: "", manifest: "", out: "", root: "" };
+	for (const raw of argv.slice(2)) {
+		const eq = raw.indexOf("=");
+		if (eq < 0) continue;
+		const key = raw.slice(0, eq);
+		const val = raw.slice(eq + 1);
+		switch (key) {
+			case "--mode":
+				args.mode = val;
+				break;
+			case "--manifest":
+				args.manifest = val;
+				break;
+			case "--out":
+				args.out = val;
+				break;
+			case "--root":
+				args.root = val;
+				break;
+		}
+	}
+	return args;
+}
+
+async function main() {
+	const args = parseArgs(process.argv);
+	if (!args.mode) {
+		process.stderr.write(
+			"svelterender-sidecar: --mode=ssg|ssr is required\n",
+		);
+		process.exit(2);
+	}
+	switch (args.mode) {
+		case "ssg":
+			await runSSG(args);
+			return;
+		case "ssr":
+			await runSSR(args);
+			return;
+		default:
+			process.stderr.write(
+				`svelterender-sidecar: unknown --mode=${args.mode} (want ssg or ssr)\n`,
+			);
+			process.exit(2);
+	}
+}
+
+main().catch((err) => {
+	process.stderr.write(
+		`svelterender-sidecar: ${err && err.stack ? err.stack : err}\n`,
+	);
+	process.exit(1);
+});

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/package-lock.json
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/package-lock.json
@@ -1,0 +1,211 @@
+{
+  "name": "@sveltego/svelterender-sidecar",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sveltego/svelterender-sidecar",
+      "version": "0.0.1",
+      "dependencies": {
+        "acorn": "8.16.0",
+        "svelte": "5.55.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
+      "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+      "license": "MIT"
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
+      "integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.55.5",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
+      "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.6.4",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.4",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/package.json
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@sveltego/svelterender-sidecar",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Build-time Node sidecar for sveltego: SSG prerender + SSR JSON-AST emission (ADR 0008, ADR 0009).",
+  "main": "index.mjs",
+  "scripts": {
+    "ssg": "node index.mjs --mode=ssg",
+    "ssr": "node index.mjs --mode=ssr"
+  },
+  "dependencies": {
+    "acorn": "8.16.0",
+    "svelte": "5.55.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/ssg.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/ssg.mjs
@@ -1,0 +1,15 @@
+// SSG mode placeholder. The pure-Svelte SSG pipeline (RFC #379 phase 4,
+// #383) wires Vite's SSR output into svelte/server.render() and writes
+// HTML under static/_prerendered/. Until that lands the Go orchestrator
+// only invokes EnsureNode(); no SSG manifest is dispatched here yet.
+//
+// Keeping the dispatcher entry shape stable means the Phase 4 wiring is
+// a body-only change inside this file — the sidecar contract (one
+// binary, two modes, --manifest input) does not move.
+
+export async function runSSG(_args) {
+	process.stderr.write(
+		"svelterender-sidecar: ssg mode is not yet implemented (RFC #379 phase 4 / #383)\n",
+	);
+	process.exit(2);
+}

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/ssr.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/ssr.mjs
@@ -1,0 +1,127 @@
+// SSR mode: compile each .svelte route via svelte/compiler in
+// generate:'server' mode, parse the compiled JS with Acorn, and write
+// the ESTree AST as JSON. Output is byte-deterministic — the same input
+// produces the same file on every run, on every host.
+//
+// Manifest format (JSON, fed via --manifest=<path>):
+//
+//   {
+//     "root":  "<absolute project root>",
+//     "outDir": "<absolute path; usually <root>/.gen/svelte_js2go>",
+//     "jobs": [
+//       { "route": "/", "source": "src/routes/_page.svelte" },
+//       { "route": "/about", "source": "src/routes/about/_page.svelte" }
+//     ]
+//   }
+//
+// Output per job: <outDir>/<route-slug>/ast.json containing
+//   { "schema": "<version>", "route": "<route>", "ast": <ESTree Program> }
+//
+// route-slug = route with leading '/' stripped, '/' replaced by '__',
+// and the special root route "/" mapped to "_root". Slugging keeps the
+// directory tree filesystem-safe across platforms.
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { parse as acornParse } from "acorn";
+import { compile } from "svelte/compiler";
+
+export const SCHEMA_VERSION = "ssr-json-ast/v1";
+
+export function routeSlug(route) {
+	if (route === "/" || route === "") return "_root";
+	const trimmed = route.replace(/^\/+/, "").replace(/\/+$/, "");
+	return trimmed.split("/").join("__");
+}
+
+export function compileServerJS(source, filename) {
+	const result = compile(source, {
+		generate: "server",
+		filename,
+		dev: false,
+		hmr: false,
+	});
+	if (!result || typeof result.js?.code !== "string") {
+		throw new Error(
+			`svelte/compiler returned no js.code for ${filename}`,
+		);
+	}
+	return result.js.code;
+}
+
+export function parseToAST(jsSource) {
+	return acornParse(jsSource, {
+		sourceType: "module",
+		ecmaVersion: "latest",
+		locations: false,
+	});
+}
+
+// stableStringify emits JSON with sorted object keys at every level so
+// minor changes in Acorn's property emission order can never produce a
+// different golden file. Arrays preserve order (semantics depend on
+// position). null and primitives pass through.
+export function stableStringify(value) {
+	const seen = new WeakSet();
+	const walk = (node) => {
+		if (node === null || typeof node !== "object") return node;
+		if (seen.has(node)) {
+			throw new Error("stableStringify: cycle in AST");
+		}
+		seen.add(node);
+		if (Array.isArray(node)) return node.map(walk);
+		const out = {};
+		for (const key of Object.keys(node).sort()) {
+			out[key] = walk(node[key]);
+		}
+		return out;
+	};
+	return JSON.stringify(walk(value), null, 2) + "\n";
+}
+
+async function processJob(job, ctx) {
+	const sourcePath = resolve(ctx.root, job.source);
+	const source = await readFile(sourcePath, "utf8");
+	const js = compileServerJS(source, job.source);
+	const ast = parseToAST(js);
+	const slug = routeSlug(job.route);
+	const outPath = join(ctx.outDir, slug, "ast.json");
+	await mkdir(dirname(outPath), { recursive: true });
+	const payload = {
+		ast,
+		route: job.route,
+		schema: SCHEMA_VERSION,
+	};
+	await writeFile(outPath, stableStringify(payload), "utf8");
+	return { route: job.route, output: outPath };
+}
+
+export async function runSSR(args) {
+	if (!args.manifest) {
+		process.stderr.write(
+			"svelterender-sidecar ssr: --manifest=<path> is required\n",
+		);
+		process.exit(2);
+	}
+	const manifestPath = resolve(args.manifest);
+	const raw = await readFile(manifestPath, "utf8");
+	const manifest = JSON.parse(raw);
+	if (!manifest || !Array.isArray(manifest.jobs)) {
+		throw new Error(
+			`ssr manifest at ${manifestPath} missing 'jobs' array`,
+		);
+	}
+	const root = resolve(manifest.root || args.root || process.cwd());
+	const outDir = resolve(manifest.outDir || args.out || join(root, ".gen", "svelte_js2go"));
+	const ctx = { root, outDir };
+	const results = [];
+	for (const job of manifest.jobs) {
+		if (!job || typeof job.route !== "string" || typeof job.source !== "string") {
+			throw new Error(
+				`ssr manifest job missing 'route' or 'source': ${JSON.stringify(job)}`,
+			);
+		}
+		results.push(await processJob(job, ctx));
+	}
+	process.stdout.write(stableStringify({ schema: SCHEMA_VERSION, results }));
+}

--- a/packages/sveltego/internal/codegen/svelterender/svelterender.go
+++ b/packages/sveltego/internal/codegen/svelterender/svelterender.go
@@ -134,7 +134,7 @@ func SidecarRoot() (string, error) {
 	dir := filepath.Join(filepath.Dir(thisFile), "sidecar")
 	entry := filepath.Join(dir, "index.mjs")
 	if _, err := os.Stat(entry); err != nil {
-		return "", fmt.Errorf("%w at %s: %v", errSidecarMissing, entry, err)
+		return "", fmt.Errorf("%w at %s: %w", errSidecarMissing, entry, err)
 	}
 	return dir, nil
 }

--- a/packages/sveltego/internal/codegen/svelterender/svelterender.go
+++ b/packages/sveltego/internal/codegen/svelterender/svelterender.go
@@ -1,36 +1,49 @@
 // Package svelterender drives the Phase 3 hybrid-SSG sidecar for
-// pure-Svelte routes (RFC #379, ADR 0008). When a route opts into
-// Templates: "svelte" AND Prerender: true, the build pipeline must
-// render the Svelte component to static HTML at build time so the
-// runtime stays JS-free.
+// pure-Svelte routes (RFC #379, ADR 0008) and the Phase 2 SSR-AST
+// extension (ADR 0009). When a route opts into Templates: "svelte" AND
+// Prerender: true, the build pipeline must render the Svelte component
+// to static HTML at build time so the runtime stays JS-free. When SSR
+// Option B is engaged, the same sidecar additionally compiles each
+// .svelte route via `svelte/compiler generate:'server'`, parses the
+// resulting JS via vendored Acorn, and writes ESTree JSON ASTs that the
+// Go-side pattern-match emitter (Phase 3, #425) consumes.
 //
-// The sidecar is a one-shot Node process invoking
-// `import { render } from 'svelte/server'`. This package owns:
+// The sidecar is a one-shot Node process. This package owns:
 //
 //   - Detecting whether any route in the manifest needs the sidecar.
 //   - Locating Node on $PATH and emitting a clear error when required
 //     but missing.
-//   - Generating the JS driver script that loops over routes, imports
-//     each .svelte component from Vite's SSR output, and writes HTML
-//     to static/_prerendered/<path>/index.html.
+//   - Locating the sidecar source tree (vendored alongside this Go
+//     package) and dispatching one of its modes.
+//   - Building the JSON manifest the sidecar reads on stdin/disk and
+//     parsing the JSON summary it writes to stdout.
 //
 // Runtime is unaffected; the deployed Go binary plus static/ is the
-// entire deployable. Phase 4 (#383) wires the sidecar into the
-// playgrounds and refines the JS driver. Phase 3 ships the
-// orchestration plus a smoke that invokes Node only when prerender
-// routes exist.
+// entire deployable.
 package svelterender
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 )
 
 // errNodeMissing is returned by EnsureNode when Phase-3 SSG would have
 // to invoke Node but the binary is not on $PATH. The build pipeline
 // surfaces it with a hint about Node 18+.
 var errNodeMissing = errors.New("svelterender: node binary not found on $PATH")
+
+// errSidecarMissing is returned when the vendored sidecar source tree
+// (package.json + index.mjs) cannot be located. Distinct from
+// errNodeMissing so callers can give the user a different remediation
+// hint (reinstall vs install Node).
+var errSidecarMissing = errors.New("svelterender: sidecar source tree not found")
 
 // EnsureNode reports whether `node` is callable. It is a thin wrapper
 // over exec.LookPath so callers can fail fast with a uniform message
@@ -72,4 +85,131 @@ func Plan(jobs []Job) []Job {
 		return nil
 	}
 	return out
+}
+
+// SSRJob describes one route the sidecar should compile to ESTree JSON
+// AST in SSR mode (ADR 0009). Route is the canonical request path used
+// for output slugging and diagnostics. Source is the .svelte path
+// relative to Root the sidecar will read.
+type SSRJob struct {
+	Route  string `json:"route"`
+	Source string `json:"source"`
+}
+
+// SSROptions configures BuildSSRAST. Root is the absolute project root
+// (paths in SSRJob.Source resolve relative to it). OutDir is the
+// directory the sidecar writes ast.json files into; when empty the
+// sidecar defaults it to <Root>/.gen/svelte_js2go.
+type SSROptions struct {
+	Root       string
+	OutDir     string
+	Jobs       []SSRJob
+	SidecarDir string // override for tests; resolves to vendored tree when empty
+	NodePath   string // override for tests; falls back to exec.LookPath("node")
+}
+
+// SSRResult captures one route emitted by the sidecar.
+type SSRResult struct {
+	Route  string `json:"route"`
+	Output string `json:"output"`
+}
+
+// ssrSummary mirrors the JSON summary the sidecar writes to stdout in
+// SSR mode. It is consumed only by BuildSSRAST.
+type ssrSummary struct {
+	Schema  string      `json:"schema"`
+	Results []SSRResult `json:"results"`
+}
+
+// SidecarRoot returns the absolute path to the vendored sidecar tree
+// (sidecar/index.mjs and friends). Locating the directory at runtime
+// depends on Go's runtime.Caller because the sidecar lives next to this
+// Go file and ships with the module checkout — there is no install
+// step. The returned path is empty when the tree cannot be found.
+func SidecarRoot() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("%w: runtime.Caller failed", errSidecarMissing)
+	}
+	dir := filepath.Join(filepath.Dir(thisFile), "sidecar")
+	entry := filepath.Join(dir, "index.mjs")
+	if _, err := os.Stat(entry); err != nil {
+		return "", fmt.Errorf("%w at %s: %v", errSidecarMissing, entry, err)
+	}
+	return dir, nil
+}
+
+// BuildSSRAST runs the sidecar in SSR mode for the configured jobs and
+// returns the per-route results. The sidecar is responsible for compile,
+// parse, and JSON write. This function only marshals the manifest, runs
+// the subprocess, and parses the result summary.
+func BuildSSRAST(ctx context.Context, opts SSROptions) ([]SSRResult, error) {
+	if opts.Root == "" {
+		return nil, errors.New("svelterender: SSROptions.Root is required")
+	}
+	if len(opts.Jobs) == 0 {
+		return nil, nil
+	}
+	nodePath := opts.NodePath
+	if nodePath == "" {
+		p, err := EnsureNode()
+		if err != nil {
+			return nil, err
+		}
+		nodePath = p
+	}
+	sidecarDir := opts.SidecarDir
+	if sidecarDir == "" {
+		p, err := SidecarRoot()
+		if err != nil {
+			return nil, err
+		}
+		sidecarDir = p
+	}
+	if _, err := os.Stat(filepath.Join(sidecarDir, "node_modules", "acorn")); err != nil {
+		return nil, fmt.Errorf("svelterender: sidecar deps not installed at %s: run `npm install` in the sidecar tree", sidecarDir)
+	}
+
+	manifest := struct {
+		Root   string   `json:"root"`
+		OutDir string   `json:"outDir,omitempty"`
+		Jobs   []SSRJob `json:"jobs"`
+	}{
+		Root:   opts.Root,
+		OutDir: opts.OutDir,
+		Jobs:   opts.Jobs,
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("svelterender: marshal manifest: %w", err)
+	}
+
+	tmp, err := os.CreateTemp("", "sveltego-ssr-manifest-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("svelterender: temp manifest: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(manifestBytes); err != nil {
+		tmp.Close()
+		return nil, fmt.Errorf("svelterender: write manifest: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, fmt.Errorf("svelterender: close manifest: %w", err)
+	}
+
+	entry := filepath.Join(sidecarDir, "index.mjs")
+	cmd := exec.CommandContext(ctx, nodePath, entry, "--mode=ssr", "--manifest="+tmpPath)
+	cmd.Dir = sidecarDir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("svelterender: sidecar ssr: %w; stderr: %s", err, stderr.String())
+	}
+	var summary ssrSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		return nil, fmt.Errorf("svelterender: parse sidecar summary: %w; stdout: %s", err, stdout.String())
+	}
+	return summary.Results, nil
 }

--- a/packages/sveltego/internal/codegen/svelterender/svelterender_test.go
+++ b/packages/sveltego/internal/codegen/svelterender/svelterender_test.go
@@ -1,9 +1,18 @@
 package svelterender
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 )
+
+var updateGolden = flag.Bool("update", false, "rewrite *.golden.json fixtures from sidecar output")
 
 func TestEnsureNode(t *testing.T) {
 	t.Parallel()
@@ -37,5 +46,167 @@ func TestPlan(t *testing.T) {
 	got := Plan(jobs)
 	if len(got) != 2 {
 		t.Fatalf("Plan(2 valid) length = %d, want 2", len(got))
+	}
+}
+
+func TestSidecarRoot(t *testing.T) {
+	t.Parallel()
+	dir, err := SidecarRoot()
+	if err != nil {
+		t.Fatalf("SidecarRoot: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "package.json")); err != nil {
+		t.Fatalf("sidecar package.json missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "index.mjs")); err != nil {
+		t.Fatalf("sidecar index.mjs missing: %v", err)
+	}
+}
+
+// requireSidecarReady skips the test when Node or the sidecar's
+// node_modules are unavailable. CI installs both before the gate; local
+// runs may skip if a developer has not installed sidecar deps yet.
+func requireSidecarReady(t *testing.T) (sidecarDir, nodePath string) {
+	t.Helper()
+	p, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH; skipping sidecar test")
+	}
+	dir, err := SidecarRoot()
+	if err != nil {
+		t.Skipf("sidecar tree not found: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node_modules", "acorn")); err != nil {
+		t.Skipf("sidecar node_modules missing; run `npm install` in %s", dir)
+	}
+	return dir, p
+}
+
+func TestBuildSSRAST_HelloWorld(t *testing.T) {
+	t.Parallel()
+	sidecarDir, nodePath := requireSidecarReady(t)
+	root := filepath.Join("testdata", "ssr-ast")
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	out := t.TempDir()
+	results, err := BuildSSRAST(context.Background(), SSROptions{
+		Root:       absRoot,
+		OutDir:     out,
+		SidecarDir: sidecarDir,
+		NodePath:   nodePath,
+		Jobs: []SSRJob{
+			{Route: "/hello-world", Source: "hello-world/_page.svelte"},
+			{Route: "/each-list", Source: "each-list/_page.svelte"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSSRAST: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+
+	for _, r := range results {
+		if _, err := os.Stat(r.Output); err != nil {
+			t.Fatalf("output missing for %s: %v", r.Route, err)
+		}
+	}
+
+	cases := []struct {
+		name   string
+		out    string
+		golden string
+	}{
+		{"hello-world", filepath.Join(out, "hello-world", "ast.json"), filepath.Join(absRoot, "hello-world", "ast.golden.json")},
+		{"each-list", filepath.Join(out, "each-list", "ast.json"), filepath.Join(absRoot, "each-list", "ast.golden.json")},
+	}
+	for _, tc := range cases {
+		got, err := os.ReadFile(tc.out)
+		if err != nil {
+			t.Fatalf("%s: read output: %v", tc.name, err)
+		}
+		if *updateGolden {
+			if err := os.WriteFile(tc.golden, got, 0o600); err != nil {
+				t.Fatalf("%s: update golden: %v", tc.name, err)
+			}
+			continue
+		}
+		want, err := os.ReadFile(tc.golden)
+		if err != nil {
+			t.Fatalf("%s: read golden: %v (run with -update to create)", tc.name, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s: ast.json drift; run with -update to refresh golden", tc.name)
+		}
+		// Sanity: the AST root must be a Program node and contain at
+		// least one ExportDefaultDeclaration so downstream emitter
+		// consumers have a stable entry point. This guards against an
+		// upstream Acorn or Svelte change silently emitting a different
+		// shape that the goldens then rubber-stamp.
+		var payload struct {
+			Schema string `json:"schema"`
+			AST    struct {
+				Type string `json:"type"`
+				Body []struct {
+					Type string `json:"type"`
+				} `json:"body"`
+			} `json:"ast"`
+		}
+		if err := json.Unmarshal(got, &payload); err != nil {
+			t.Fatalf("%s: payload unmarshal: %v", tc.name, err)
+		}
+		if payload.Schema == "" {
+			t.Fatalf("%s: schema field empty", tc.name)
+		}
+		if payload.AST.Type != "Program" {
+			t.Fatalf("%s: ast.type = %q, want Program", tc.name, payload.AST.Type)
+		}
+		var sawExport bool
+		for _, b := range payload.AST.Body {
+			if b.Type == "ExportDefaultDeclaration" {
+				sawExport = true
+				break
+			}
+		}
+		if !sawExport {
+			t.Fatalf("%s: no ExportDefaultDeclaration in Program body", tc.name)
+		}
+	}
+}
+
+func TestBuildSSRAST_Determinism(t *testing.T) {
+	t.Parallel()
+	sidecarDir, nodePath := requireSidecarReady(t)
+	root := filepath.Join("testdata", "ssr-ast")
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	jobs := []SSRJob{{Route: "/hello-world", Source: "hello-world/_page.svelte"}}
+
+	out1 := t.TempDir()
+	if _, err := BuildSSRAST(context.Background(), SSROptions{
+		Root: absRoot, OutDir: out1, SidecarDir: sidecarDir, NodePath: nodePath, Jobs: jobs,
+	}); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	out2 := t.TempDir()
+	if _, err := BuildSSRAST(context.Background(), SSROptions{
+		Root: absRoot, OutDir: out2, SidecarDir: sidecarDir, NodePath: nodePath, Jobs: jobs,
+	}); err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+	a, err := os.ReadFile(filepath.Join(out1, "hello-world", "ast.json"))
+	if err != nil {
+		t.Fatalf("read run 1: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(out2, "hello-world", "ast.json"))
+	if err != nil {
+		t.Fatalf("read run 2: %v", err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Fatalf("ast.json not byte-identical across runs (sidecar non-deterministic)")
 	}
 }

--- a/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/each-list/_page.svelte
+++ b/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/each-list/_page.svelte
@@ -1,0 +1,9 @@
+<script>
+	let { data } = $props();
+</script>
+
+<ul>
+	{#each data.items as item}
+		<li>{item.title}</li>
+	{/each}
+</ul>

--- a/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/each-list/ast.golden.json
+++ b/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/each-list/ast.golden.json
@@ -1,0 +1,590 @@
+{
+  "ast": {
+    "body": [
+      {
+        "attributes": [],
+        "end": 44,
+        "source": {
+          "end": 43,
+          "raw": "'svelte/internal/server'",
+          "start": 19,
+          "type": "Literal",
+          "value": "svelte/internal/server"
+        },
+        "specifiers": [
+          {
+            "end": 13,
+            "local": {
+              "end": 13,
+              "name": "$",
+              "start": 12,
+              "type": "Identifier"
+            },
+            "start": 7,
+            "type": "ImportNamespaceSpecifier"
+          }
+        ],
+        "start": 0,
+        "type": "ImportDeclaration"
+      },
+      {
+        "declaration": {
+          "async": false,
+          "body": {
+            "body": [
+              {
+                "end": 481,
+                "expression": {
+                  "arguments": [
+                    {
+                      "async": false,
+                      "body": {
+                        "body": [
+                          {
+                            "declarations": [
+                              {
+                                "end": 163,
+                                "id": {
+                                  "end": 153,
+                                  "properties": [
+                                    {
+                                      "computed": false,
+                                      "end": 151,
+                                      "key": {
+                                        "end": 151,
+                                        "name": "data",
+                                        "start": 147,
+                                        "type": "Identifier"
+                                      },
+                                      "kind": "init",
+                                      "method": false,
+                                      "shorthand": true,
+                                      "start": 147,
+                                      "type": "Property",
+                                      "value": {
+                                        "end": 151,
+                                        "name": "data",
+                                        "start": 147,
+                                        "type": "Identifier"
+                                      }
+                                    }
+                                  ],
+                                  "start": 145,
+                                  "type": "ObjectPattern"
+                                },
+                                "init": {
+                                  "end": 163,
+                                  "name": "$$props",
+                                  "start": 156,
+                                  "type": "Identifier"
+                                },
+                                "start": 145,
+                                "type": "VariableDeclarator"
+                              }
+                            ],
+                            "end": 164,
+                            "kind": "let",
+                            "start": 141,
+                            "type": "VariableDeclaration"
+                          },
+                          {
+                            "end": 200,
+                            "expression": {
+                              "arguments": [
+                                {
+                                  "end": 198,
+                                  "expressions": [],
+                                  "quasis": [
+                                    {
+                                      "end": 197,
+                                      "start": 185,
+                                      "tail": true,
+                                      "type": "TemplateElement",
+                                      "value": {
+                                        "cooked": "<ul><!--[-->",
+                                        "raw": "<ul><!--[-->"
+                                      }
+                                    }
+                                  ],
+                                  "start": 184,
+                                  "type": "TemplateLiteral"
+                                }
+                              ],
+                              "callee": {
+                                "computed": false,
+                                "end": 183,
+                                "object": {
+                                  "end": 178,
+                                  "name": "$$renderer",
+                                  "start": 168,
+                                  "type": "Identifier"
+                                },
+                                "optional": false,
+                                "property": {
+                                  "end": 183,
+                                  "name": "push",
+                                  "start": 179,
+                                  "type": "Identifier"
+                                },
+                                "start": 168,
+                                "type": "MemberExpression"
+                              },
+                              "end": 199,
+                              "optional": false,
+                              "start": 168,
+                              "type": "CallExpression"
+                            },
+                            "start": 168,
+                            "type": "ExpressionStatement"
+                          },
+                          {
+                            "declarations": [
+                              {
+                                "end": 254,
+                                "id": {
+                                  "end": 220,
+                                  "name": "each_array",
+                                  "start": 210,
+                                  "type": "Identifier"
+                                },
+                                "init": {
+                                  "arguments": [
+                                    {
+                                      "computed": false,
+                                      "end": 253,
+                                      "object": {
+                                        "end": 247,
+                                        "name": "data",
+                                        "start": 243,
+                                        "type": "Identifier"
+                                      },
+                                      "optional": false,
+                                      "property": {
+                                        "end": 253,
+                                        "name": "items",
+                                        "start": 248,
+                                        "type": "Identifier"
+                                      },
+                                      "start": 243,
+                                      "type": "MemberExpression"
+                                    }
+                                  ],
+                                  "callee": {
+                                    "computed": false,
+                                    "end": 242,
+                                    "object": {
+                                      "end": 224,
+                                      "name": "$",
+                                      "start": 223,
+                                      "type": "Identifier"
+                                    },
+                                    "optional": false,
+                                    "property": {
+                                      "end": 242,
+                                      "name": "ensure_array_like",
+                                      "start": 225,
+                                      "type": "Identifier"
+                                    },
+                                    "start": 223,
+                                    "type": "MemberExpression"
+                                  },
+                                  "end": 254,
+                                  "optional": false,
+                                  "start": 223,
+                                  "type": "CallExpression"
+                                },
+                                "start": 210,
+                                "type": "VariableDeclarator"
+                              }
+                            ],
+                            "end": 255,
+                            "kind": "const",
+                            "start": 204,
+                            "type": "VariableDeclaration"
+                          },
+                          {
+                            "body": {
+                              "body": [
+                                {
+                                  "declarations": [
+                                    {
+                                      "end": 377,
+                                      "id": {
+                                        "end": 355,
+                                        "name": "item",
+                                        "start": 351,
+                                        "type": "Identifier"
+                                      },
+                                      "init": {
+                                        "computed": true,
+                                        "end": 377,
+                                        "object": {
+                                          "end": 368,
+                                          "name": "each_array",
+                                          "start": 358,
+                                          "type": "Identifier"
+                                        },
+                                        "optional": false,
+                                        "property": {
+                                          "end": 376,
+                                          "name": "$$index",
+                                          "start": 369,
+                                          "type": "Identifier"
+                                        },
+                                        "start": 358,
+                                        "type": "MemberExpression"
+                                      },
+                                      "start": 351,
+                                      "type": "VariableDeclarator"
+                                    }
+                                  ],
+                                  "end": 378,
+                                  "kind": "let",
+                                  "start": 347,
+                                  "type": "VariableDeclaration"
+                                },
+                                {
+                                  "end": 435,
+                                  "expression": {
+                                    "arguments": [
+                                      {
+                                        "end": 433,
+                                        "expressions": [
+                                          {
+                                            "arguments": [
+                                              {
+                                                "computed": false,
+                                                "end": 425,
+                                                "object": {
+                                                  "end": 419,
+                                                  "name": "item",
+                                                  "start": 415,
+                                                  "type": "Identifier"
+                                                },
+                                                "optional": false,
+                                                "property": {
+                                                  "end": 425,
+                                                  "name": "title",
+                                                  "start": 420,
+                                                  "type": "Identifier"
+                                                },
+                                                "start": 415,
+                                                "type": "MemberExpression"
+                                              }
+                                            ],
+                                            "callee": {
+                                              "computed": false,
+                                              "end": 414,
+                                              "object": {
+                                                "end": 407,
+                                                "name": "$",
+                                                "start": 406,
+                                                "type": "Identifier"
+                                              },
+                                              "optional": false,
+                                              "property": {
+                                                "end": 414,
+                                                "name": "escape",
+                                                "start": 408,
+                                                "type": "Identifier"
+                                              },
+                                              "start": 406,
+                                              "type": "MemberExpression"
+                                            },
+                                            "end": 426,
+                                            "optional": false,
+                                            "start": 406,
+                                            "type": "CallExpression"
+                                          }
+                                        ],
+                                        "quasis": [
+                                          {
+                                            "end": 404,
+                                            "start": 400,
+                                            "tail": false,
+                                            "type": "TemplateElement",
+                                            "value": {
+                                              "cooked": "<li>",
+                                              "raw": "<li>"
+                                            }
+                                          },
+                                          {
+                                            "end": 432,
+                                            "start": 427,
+                                            "tail": true,
+                                            "type": "TemplateElement",
+                                            "value": {
+                                              "cooked": "</li>",
+                                              "raw": "</li>"
+                                            }
+                                          }
+                                        ],
+                                        "start": 399,
+                                        "type": "TemplateLiteral"
+                                      }
+                                    ],
+                                    "callee": {
+                                      "computed": false,
+                                      "end": 398,
+                                      "object": {
+                                        "end": 393,
+                                        "name": "$$renderer",
+                                        "start": 383,
+                                        "type": "Identifier"
+                                      },
+                                      "optional": false,
+                                      "property": {
+                                        "end": 398,
+                                        "name": "push",
+                                        "start": 394,
+                                        "type": "Identifier"
+                                      },
+                                      "start": 383,
+                                      "type": "MemberExpression"
+                                    },
+                                    "end": 434,
+                                    "optional": false,
+                                    "start": 383,
+                                    "type": "CallExpression"
+                                  },
+                                  "start": 383,
+                                  "type": "ExpressionStatement"
+                                }
+                              ],
+                              "end": 439,
+                              "start": 342,
+                              "type": "BlockStatement"
+                            },
+                            "end": 439,
+                            "init": {
+                              "declarations": [
+                                {
+                                  "end": 279,
+                                  "id": {
+                                    "end": 275,
+                                    "name": "$$index",
+                                    "start": 268,
+                                    "type": "Identifier"
+                                  },
+                                  "init": {
+                                    "end": 279,
+                                    "raw": "0",
+                                    "start": 278,
+                                    "type": "Literal",
+                                    "value": 0
+                                  },
+                                  "start": 268,
+                                  "type": "VariableDeclarator"
+                                },
+                                {
+                                  "end": 309,
+                                  "id": {
+                                    "end": 289,
+                                    "name": "$$length",
+                                    "start": 281,
+                                    "type": "Identifier"
+                                  },
+                                  "init": {
+                                    "computed": false,
+                                    "end": 309,
+                                    "object": {
+                                      "end": 302,
+                                      "name": "each_array",
+                                      "start": 292,
+                                      "type": "Identifier"
+                                    },
+                                    "optional": false,
+                                    "property": {
+                                      "end": 309,
+                                      "name": "length",
+                                      "start": 303,
+                                      "type": "Identifier"
+                                    },
+                                    "start": 292,
+                                    "type": "MemberExpression"
+                                  },
+                                  "start": 281,
+                                  "type": "VariableDeclarator"
+                                }
+                              ],
+                              "end": 309,
+                              "kind": "let",
+                              "start": 264,
+                              "type": "VariableDeclaration"
+                            },
+                            "start": 259,
+                            "test": {
+                              "end": 329,
+                              "left": {
+                                "end": 318,
+                                "name": "$$index",
+                                "start": 311,
+                                "type": "Identifier"
+                              },
+                              "operator": "<",
+                              "right": {
+                                "end": 329,
+                                "name": "$$length",
+                                "start": 321,
+                                "type": "Identifier"
+                              },
+                              "start": 311,
+                              "type": "BinaryExpression"
+                            },
+                            "type": "ForStatement",
+                            "update": {
+                              "argument": {
+                                "end": 338,
+                                "name": "$$index",
+                                "start": 331,
+                                "type": "Identifier"
+                              },
+                              "end": 340,
+                              "operator": "++",
+                              "prefix": false,
+                              "start": 331,
+                              "type": "UpdateExpression"
+                            }
+                          },
+                          {
+                            "end": 476,
+                            "expression": {
+                              "arguments": [
+                                {
+                                  "end": 474,
+                                  "expressions": [],
+                                  "quasis": [
+                                    {
+                                      "end": 473,
+                                      "start": 460,
+                                      "tail": true,
+                                      "type": "TemplateElement",
+                                      "value": {
+                                        "cooked": "<!--]--></ul>",
+                                        "raw": "<!--]--></ul>"
+                                      }
+                                    }
+                                  ],
+                                  "start": 459,
+                                  "type": "TemplateLiteral"
+                                }
+                              ],
+                              "callee": {
+                                "computed": false,
+                                "end": 458,
+                                "object": {
+                                  "end": 453,
+                                  "name": "$$renderer",
+                                  "start": 443,
+                                  "type": "Identifier"
+                                },
+                                "optional": false,
+                                "property": {
+                                  "end": 458,
+                                  "name": "push",
+                                  "start": 454,
+                                  "type": "Identifier"
+                                },
+                                "start": 443,
+                                "type": "MemberExpression"
+                              },
+                              "end": 475,
+                              "optional": false,
+                              "start": 443,
+                              "type": "CallExpression"
+                            },
+                            "start": 443,
+                            "type": "ExpressionStatement"
+                          }
+                        ],
+                        "end": 479,
+                        "start": 137,
+                        "type": "BlockStatement"
+                      },
+                      "end": 479,
+                      "expression": false,
+                      "generator": false,
+                      "id": null,
+                      "params": [
+                        {
+                          "end": 132,
+                          "name": "$$renderer",
+                          "start": 122,
+                          "type": "Identifier"
+                        }
+                      ],
+                      "start": 121,
+                      "type": "ArrowFunctionExpression"
+                    }
+                  ],
+                  "callee": {
+                    "computed": false,
+                    "end": 120,
+                    "object": {
+                      "end": 110,
+                      "name": "$$renderer",
+                      "start": 100,
+                      "type": "Identifier"
+                    },
+                    "optional": false,
+                    "property": {
+                      "end": 120,
+                      "name": "component",
+                      "start": 111,
+                      "type": "Identifier"
+                    },
+                    "start": 100,
+                    "type": "MemberExpression"
+                  },
+                  "end": 480,
+                  "optional": false,
+                  "start": 100,
+                  "type": "CallExpression"
+                },
+                "start": 100,
+                "type": "ExpressionStatement"
+              }
+            ],
+            "end": 483,
+            "start": 97,
+            "type": "BlockStatement"
+          },
+          "end": 483,
+          "expression": false,
+          "generator": false,
+          "id": {
+            "end": 75,
+            "name": "_page",
+            "start": 70,
+            "type": "Identifier"
+          },
+          "params": [
+            {
+              "end": 86,
+              "name": "$$renderer",
+              "start": 76,
+              "type": "Identifier"
+            },
+            {
+              "end": 95,
+              "name": "$$props",
+              "start": 88,
+              "type": "Identifier"
+            }
+          ],
+          "start": 61,
+          "type": "FunctionDeclaration"
+        },
+        "end": 483,
+        "start": 46,
+        "type": "ExportDefaultDeclaration"
+      }
+    ],
+    "end": 483,
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program"
+  },
+  "route": "/each-list",
+  "schema": "ssr-json-ast/v1"
+}

--- a/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/hello-world/_page.svelte
+++ b/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/hello-world/_page.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { data } = $props();
+</script>
+
+<h1>Hello {data.name}</h1>

--- a/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/hello-world/ast.golden.json
+++ b/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/hello-world/ast.golden.json
@@ -1,0 +1,288 @@
+{
+  "ast": {
+    "body": [
+      {
+        "attributes": [],
+        "end": 44,
+        "source": {
+          "end": 43,
+          "raw": "'svelte/internal/server'",
+          "start": 19,
+          "type": "Literal",
+          "value": "svelte/internal/server"
+        },
+        "specifiers": [
+          {
+            "end": 13,
+            "local": {
+              "end": 13,
+              "name": "$",
+              "start": 12,
+              "type": "Identifier"
+            },
+            "start": 7,
+            "type": "ImportNamespaceSpecifier"
+          }
+        ],
+        "start": 0,
+        "type": "ImportDeclaration"
+      },
+      {
+        "declaration": {
+          "async": false,
+          "body": {
+            "body": [
+              {
+                "end": 230,
+                "expression": {
+                  "arguments": [
+                    {
+                      "async": false,
+                      "body": {
+                        "body": [
+                          {
+                            "declarations": [
+                              {
+                                "end": 163,
+                                "id": {
+                                  "end": 153,
+                                  "properties": [
+                                    {
+                                      "computed": false,
+                                      "end": 151,
+                                      "key": {
+                                        "end": 151,
+                                        "name": "data",
+                                        "start": 147,
+                                        "type": "Identifier"
+                                      },
+                                      "kind": "init",
+                                      "method": false,
+                                      "shorthand": true,
+                                      "start": 147,
+                                      "type": "Property",
+                                      "value": {
+                                        "end": 151,
+                                        "name": "data",
+                                        "start": 147,
+                                        "type": "Identifier"
+                                      }
+                                    }
+                                  ],
+                                  "start": 145,
+                                  "type": "ObjectPattern"
+                                },
+                                "init": {
+                                  "end": 163,
+                                  "name": "$$props",
+                                  "start": 156,
+                                  "type": "Identifier"
+                                },
+                                "start": 145,
+                                "type": "VariableDeclarator"
+                              }
+                            ],
+                            "end": 164,
+                            "kind": "let",
+                            "start": 141,
+                            "type": "VariableDeclaration"
+                          },
+                          {
+                            "end": 225,
+                            "expression": {
+                              "arguments": [
+                                {
+                                  "end": 223,
+                                  "expressions": [
+                                    {
+                                      "arguments": [
+                                        {
+                                          "computed": false,
+                                          "end": 215,
+                                          "object": {
+                                            "end": 210,
+                                            "name": "data",
+                                            "start": 206,
+                                            "type": "Identifier"
+                                          },
+                                          "optional": false,
+                                          "property": {
+                                            "end": 215,
+                                            "name": "name",
+                                            "start": 211,
+                                            "type": "Identifier"
+                                          },
+                                          "start": 206,
+                                          "type": "MemberExpression"
+                                        }
+                                      ],
+                                      "callee": {
+                                        "computed": false,
+                                        "end": 205,
+                                        "object": {
+                                          "end": 198,
+                                          "name": "$",
+                                          "start": 197,
+                                          "type": "Identifier"
+                                        },
+                                        "optional": false,
+                                        "property": {
+                                          "end": 205,
+                                          "name": "escape",
+                                          "start": 199,
+                                          "type": "Identifier"
+                                        },
+                                        "start": 197,
+                                        "type": "MemberExpression"
+                                      },
+                                      "end": 216,
+                                      "optional": false,
+                                      "start": 197,
+                                      "type": "CallExpression"
+                                    }
+                                  ],
+                                  "quasis": [
+                                    {
+                                      "end": 195,
+                                      "start": 185,
+                                      "tail": false,
+                                      "type": "TemplateElement",
+                                      "value": {
+                                        "cooked": "<h1>Hello ",
+                                        "raw": "<h1>Hello "
+                                      }
+                                    },
+                                    {
+                                      "end": 222,
+                                      "start": 217,
+                                      "tail": true,
+                                      "type": "TemplateElement",
+                                      "value": {
+                                        "cooked": "</h1>",
+                                        "raw": "</h1>"
+                                      }
+                                    }
+                                  ],
+                                  "start": 184,
+                                  "type": "TemplateLiteral"
+                                }
+                              ],
+                              "callee": {
+                                "computed": false,
+                                "end": 183,
+                                "object": {
+                                  "end": 178,
+                                  "name": "$$renderer",
+                                  "start": 168,
+                                  "type": "Identifier"
+                                },
+                                "optional": false,
+                                "property": {
+                                  "end": 183,
+                                  "name": "push",
+                                  "start": 179,
+                                  "type": "Identifier"
+                                },
+                                "start": 168,
+                                "type": "MemberExpression"
+                              },
+                              "end": 224,
+                              "optional": false,
+                              "start": 168,
+                              "type": "CallExpression"
+                            },
+                            "start": 168,
+                            "type": "ExpressionStatement"
+                          }
+                        ],
+                        "end": 228,
+                        "start": 137,
+                        "type": "BlockStatement"
+                      },
+                      "end": 228,
+                      "expression": false,
+                      "generator": false,
+                      "id": null,
+                      "params": [
+                        {
+                          "end": 132,
+                          "name": "$$renderer",
+                          "start": 122,
+                          "type": "Identifier"
+                        }
+                      ],
+                      "start": 121,
+                      "type": "ArrowFunctionExpression"
+                    }
+                  ],
+                  "callee": {
+                    "computed": false,
+                    "end": 120,
+                    "object": {
+                      "end": 110,
+                      "name": "$$renderer",
+                      "start": 100,
+                      "type": "Identifier"
+                    },
+                    "optional": false,
+                    "property": {
+                      "end": 120,
+                      "name": "component",
+                      "start": 111,
+                      "type": "Identifier"
+                    },
+                    "start": 100,
+                    "type": "MemberExpression"
+                  },
+                  "end": 229,
+                  "optional": false,
+                  "start": 100,
+                  "type": "CallExpression"
+                },
+                "start": 100,
+                "type": "ExpressionStatement"
+              }
+            ],
+            "end": 232,
+            "start": 97,
+            "type": "BlockStatement"
+          },
+          "end": 232,
+          "expression": false,
+          "generator": false,
+          "id": {
+            "end": 75,
+            "name": "_page",
+            "start": 70,
+            "type": "Identifier"
+          },
+          "params": [
+            {
+              "end": 86,
+              "name": "$$renderer",
+              "start": 76,
+              "type": "Identifier"
+            },
+            {
+              "end": 95,
+              "name": "$$props",
+              "start": 88,
+              "type": "Identifier"
+            }
+          ],
+          "start": 61,
+          "type": "FunctionDeclaration"
+        },
+        "end": 232,
+        "start": 46,
+        "type": "ExportDefaultDeclaration"
+      }
+    ],
+    "end": 232,
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program"
+  },
+  "route": "/hello-world",
+  "schema": "ssr-json-ast/v1"
+}

--- a/tasks/specs/ssr-json-ast.md
+++ b/tasks/specs/ssr-json-ast.md
@@ -1,0 +1,168 @@
+# SSR JSON-AST schema (Phase 2 of SSR Option B)
+
+- **Status:** Locked for v1 (re-evaluate when Svelte minor pin moves).
+- **Owner:** `packages/sveltego/internal/codegen/svelterender/sidecar/`.
+- **Consumers:** Phase 3 emitter (`internal/codegen/svelte_js2go/`, [#425](https://github.com/binsarjr/sveltego/issues/425)).
+- **Related:** [ADR 0009](../decisions/0009-ssr-option-b.md), [issue #424](https://github.com/binsarjr/sveltego/issues/424).
+
+## Purpose
+
+The Node sidecar at `internal/codegen/svelterender/sidecar/` runs at
+`sveltego build` time and, in `--mode=ssr`, emits one JSON file per
+route describing the ESTree AST of Svelte's compiled server output.
+The Go-side pattern-match emitter consumes those files and writes
+`Render()` functions per route. No JS runtime ever touches the request
+path.
+
+This document fixes the schema so the producer (sidecar) and consumer
+(emitter) move independently.
+
+## Pipeline
+
+```
+.svelte source
+  -> svelte/compiler.compile(source, { generate: 'server', filename, dev: false })
+  -> result.js.code   (string of compiled server JS, ESM)
+  -> acorn.parse(result.js.code, { sourceType: 'module', ecmaVersion: 'latest' })
+  -> ESTree Program node
+  -> sorted-key JSON serialization
+  -> .gen/svelte_js2go/<route-slug>/ast.json
+```
+
+Acorn is pinned to `8.16.0`; Svelte to `5.55.5`. Both pins live in
+`packages/sveltego/internal/codegen/svelterender/sidecar/package.json`.
+Sub-decision 3 of ADR 0009 governs minor bumps.
+
+## Output path
+
+```
+<outDir>/<route-slug>/ast.json
+```
+
+`outDir` defaults to `<projectRoot>/.gen/svelte_js2go`. `route-slug` is
+derived from the canonical request path:
+
+- `/` → `_root`
+- `/about` → `about`
+- `/blog/post` → `blog__post`
+- `/[slug]` → `[slug]`
+
+The slug uses `__` as a separator to keep one-segment-per-directory
+filesystems happy and to leave bracketed parameters intact for
+Phase 5/6 lookup.
+
+## File envelope
+
+```jsonc
+{
+  "schema": "ssr-json-ast/v1",
+  "route":  "/hello-world",
+  "ast":    { /* ESTree Program node — see below */ }
+}
+```
+
+- `schema` — fixed string `ssr-json-ast/v1`. Bump on any
+  consumer-visible change (envelope shape, sort policy, helper
+  identifiers).
+- `route` — copied from the input job; lets a single-file consumer
+  identify its source without reparsing the path.
+- `ast` — Acorn output, untransformed. Keys serialized in sorted order
+  (see "Determinism rules").
+
+## ESTree node types the consumer must handle
+
+Svelte 5's `generate: 'server'` lowering produces a flat string-builder
+program. The Phase-3 emitter only needs to dispatch on a small set of
+ESTree node types in the `ast.body` array (and recursively under
+function bodies). The list below is the closed set targeted by v1; new
+shapes surface as `unknown shape: <name>` build failures (Sub-decision
+2 of ADR 0009).
+
+### Top-level
+
+| ESTree type                  | Origin                                       |
+|------------------------------|----------------------------------------------|
+| `Program`                    | Root.                                        |
+| `ImportDeclaration`          | `import * as $ from 'svelte/internal/server'`. Only one expected per file in v1; record the local namespace identifier. |
+| `ExportDefaultDeclaration`   | The render function. Body is a `FunctionDeclaration` or `ArrowFunctionExpression`. |
+
+### Inside the render function
+
+| ESTree type                  | Origin                                       |
+|------------------------------|----------------------------------------------|
+| `FunctionDeclaration` / `ArrowFunctionExpression` | The exported render function and helpers it nests for control flow. |
+| `BlockStatement`             | Function bodies and `if` / `each` arms.      |
+| `VariableDeclaration` (`let`/`const`) | `let { data } = $$props`, scratch counters. |
+| `ObjectPattern` / `Property` / `Identifier` | Destructuring of `$$props`.                |
+| `ExpressionStatement`        | Wraps every emit call.                        |
+| `AssignmentExpression` with `+=` | `$$payload.out += '<h1>'`. The dominant emit shape. |
+| `MemberExpression`           | Property access: `data.name`, `$$payload.out`, namespaced helpers (`$.escape_html`). |
+| `Identifier`                 | Local references (the namespace import, function names). |
+| `Literal` (string / number / boolean) | Static template chunks, attribute names, numeric counters. |
+| `TemplateLiteral` / `TemplateElement` | Multi-segment HTML strings with interpolated runtime calls. |
+| `CallExpression`             | Helper calls: `$.escape_html(x)`, `$.attr(...)`, `$.clsx(...)`, `$.stringify(...)`, `$.spread_attributes(...)`, `$.merge_styles(...)`, `$.head(...)`, `$.html(...)`, `$.each(...)`, control-flow helpers. |
+| `IfStatement` / `ConditionalExpression` | Lowered `{#if}` and ternaries in expressions. |
+| `ReturnStatement`            | Inside helper closures (mostly slot fragments). |
+| `LogicalExpression` / `BinaryExpression` | Coercion guards (`x ?? ''`), index math.    |
+| `UnaryExpression`            | `!cond`, `+n`. Rare but produced by Svelte for negation guards. |
+| `SpreadElement`              | `{...attrs}` lowered into `$.spread_attributes`. |
+
+### Helper identifiers (closed set, v1)
+
+The sidecar does not transform these. The Phase-3 emitter recognises
+them by namespace + member name. The Phase-4 helpers package
+([#426](https://github.com/binsarjr/sveltego/issues/426)) implements
+each as a Go function with the same semantics.
+
+```
+$.escape_html        $.attr               $.clsx
+$.stringify          $.spread_attributes  $.merge_styles
+$.head               $.html               $.each
+$.if                 $.element            $.bind_props
+```
+
+A helper not in this list inside a `CallExpression.callee` of shape
+`$.<name>` is treated by the Phase-3 emitter as `unknown shape:
+helper:<name>` and fails the build.
+
+## Determinism rules
+
+The sidecar guarantees **byte-identical** output for byte-identical
+inputs across runs and hosts. Three guard rails:
+
+1. **Sorted keys.** Every object key is emitted in lexicographic
+   order. Acorn does not promise key order across versions; pinning a
+   minor would not be sufficient on its own.
+2. **No timestamps, no absolute paths.** The envelope contains only
+   `schema`, `route`, `ast`. The `filename` passed to
+   `svelte/compiler` is the manifest-relative source path, never an
+   absolute one — so byte-positions inside the AST do not encode the
+   developer's home directory.
+3. **No `dev: true`.** Svelte's dev mode injects source-map metadata
+   and per-build random IDs. The sidecar always compiles with
+   `dev: false`.
+
+The Go test suite asserts this by running the sidecar twice into
+distinct output directories and `bytes.Equal`-comparing the result
+(`TestBuildSSRAST_Determinism`).
+
+## Stability contract
+
+- Schema field changes require bumping `schema` to
+  `ssr-json-ast/v2` (or higher) and updating the Phase-3 emitter in
+  the same release.
+- Helper identifier additions are non-breaking — the emitter must
+  treat unknown identifiers as a build error, not a panic, so the
+  next sidecar release can ship new helpers in lockstep with new
+  emitter dispatch entries.
+- Acorn / Svelte minor pins move only via a dedicated PR (Sub-decision
+  3 of ADR 0009). The corpus regenerates against the new pin; new
+  emit shapes either get a Phase-3 pattern entry or the route opts
+  into the sidecar fallback (Phase 8, [#430](https://github.com/binsarjr/sveltego/issues/430)).
+
+## Reference
+
+- Goldens: `packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/<fixture>/ast.golden.json`
+- Sidecar entry: `packages/sveltego/internal/codegen/svelterender/sidecar/index.mjs`
+- Go invoker: `BuildSSRAST` in `packages/sveltego/internal/codegen/svelterender/svelterender.go`
+- Spec for the Phase-3 emitter pattern matrix: tracked in [#425](https://github.com/binsarjr/sveltego/issues/425).


### PR DESCRIPTION
## Summary

- Extends `packages/sveltego/internal/codegen/svelterender/` with a Node sidecar that compiles each `.svelte` route via `svelte/compiler generate:'server'`, parses the result via vendored Acorn, and writes ESTree JSON ASTs the future Go-side pattern-match emitter (Phase 3) will consume.
- Build-time only — no JS runtime on the request path. ADR 0008 + ADR 0009 invariants preserved.
- Sidecar lives at `svelterender/sidecar/`; one entry point, two modes (`--mode=ssg|ssr`). SSG mode is a forward-compatible stub for the Phase 4 of RFC #379 wire-up.

## Decisions locked in this PR

- **Acorn 8.16.0, Svelte 5.55.5** pinned in `sidecar/package.json` + `package-lock.json`. Sub-decision 3 of ADR 0009 governs minor bumps via dedicated PR.
- **Output envelope**: `{ schema: "ssr-json-ast/v1", route, ast }` at `<outDir>/<route-slug>/ast.json`. Slug derives from route (`/` -> `_root`, `/blog/post` -> `blog__post`).
- **Determinism**: sorted JSON keys, no timestamps, no absolute paths, `dev: false`. Verified by `TestBuildSSRAST_Determinism` and the golden tests.

## What landed

- `sidecar/index.mjs`, `sidecar/ssr.mjs`, `sidecar/ssg.mjs` (stub) — Node entry + SSR pipeline (compile -> Acorn -> stable JSON).
- `svelterender.go` gains `BuildSSRAST(ctx, opts)` + `SidecarRoot()`. The existing `EnsureNode` / `Plan` / `Job` SSG path is untouched (regression check: 492 codegen tests pass).
- Goldens for `hello-world` and `each-list` fixtures under `testdata/ssr-ast/` exercise the dominant emit shapes (`escape_html`, `each_array`, template literals, `ExportDefaultDeclaration`).
- Spec doc `tasks/specs/ssr-json-ast.md` documents the ESTree node set + Svelte helper identifier set the Phase 3 emitter must dispatch on, plus the determinism contract and stability policy.

## Test plan

- [x] `gofumpt -l` clean
- [x] `goimports -l -local github.com/binsarjr/sveltego` clean
- [x] `go vet ./packages/sveltego/internal/codegen/svelterender/...` clean
- [x] `go test -race ./packages/sveltego/internal/codegen/svelterender/... -count=1` (5 tests pass)
- [x] `go test ./packages/sveltego/internal/codegen/... -count=1` (492 tests pass — existing SSG path untouched)
- [x] `go build ./...`
- [x] Determinism: sidecar run twice yields byte-identical `ast.json` (in-suite via `TestBuildSSRAST_Determinism`, plus manual `diff` check)
- [x] Golden hello-world AST has `Program` root + `ExportDefaultDeclaration` (asserted in `TestBuildSSRAST_HelloWorld`)

## Notes

- Tests skip cleanly when `node` is missing or sidecar `node_modules/` is empty. CI must `npm install` inside `packages/sveltego/internal/codegen/svelterender/sidecar/` before the gate (Phase 9 docs will spell this out).
- AST files are 10-30KB per fixture — acceptable build-time cost, never on request path.

Closes #424. Tracks #422. Refs ADR 0009 (#432).