### PR TITLE
feat(runtime): runtime/svelte/server helpers package

### DIFF
--- a/packages/sveltego/runtime/svelte/server/STABILITY.md
+++ b/packages/sveltego/runtime/svelte/server/STABILITY.md
@@ -1,0 +1,86 @@
+# Stability — packages/sveltego/runtime/svelte/server
+
+Last updated: 2026-05-02 · Version: pre-alpha
+
+Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97).
+
+## Tier legend
+
+| Tier | Promise |
+|---|---|
+| `stable` | Won't break within the current major. Add-only changes; behavior changes documented in CHANGELOG. |
+| `experimental` | May break in any minor release. Marked `// Experimental:` in godoc. |
+| `deprecated` | Scheduled for removal. Marked `// Deprecated:` in godoc. Removed in next major. |
+
+## Stable
+
+(none)
+
+## Experimental
+
+Entire package. Treat every exported symbol as experimental until Phase 6
+([#428](https://github.com/binsarjr/sveltego/issues/428)) wires the helpers
+into the request pipeline and the surface stops shifting on landing.
+
+- `server.Payload` — body/head buffers passed through compiled render functions
+- `server.EscapeHTML` / `EscapeHTMLAttr` — content/attribute HTML escape, mirrors `svelte/src/escaping.js`
+- `server.EscapeHTMLString` / `EscapeHTMLAttrString` — typed fast paths
+- `server.Attr` — single-attribute serialize, mirrors `svelte/internal/shared/attributes.attr`
+- `server.Clsx` — class merging, mirrors `svelte/internal/shared/attributes.clsx`
+- `server.MergeStyles` — style fragment join, mirrors compiled-output style merging
+- `server.SpreadAttributes` — attribute-spread serialize, mirrors `svelte/internal/server.attributes`
+- `server.Stringify` — value-to-string, mirrors `svelte/internal/server.stringify`
+- `server.ToClass` / `server.ToStyle` — class/style normalization, mirrors `to_class` / `to_style`
+- `server.Element` / `server.Head` — element/head emission, mirrors `element` / `head`
+- `server.Slot` / `server.SlotFn` — slot rendering, mirrors `svelte/internal/server.slot`
+- `server.SpreadProps` / `server.RestProps` / `server.SanitizeProps` / `server.SanitizeSlots`
+- `server.Fallback` / `server.ExcludeFromObject` / `server.EnsureArrayLike`
+- `server.IsVoidElement` / `server.IsRawTextElement`
+- `server.EmptyComment` / `server.BlockOpen` / `server.BlockOpenElse` / `server.BlockClose`
+
+## Deprecated
+
+(none)
+
+## Internal-only (do not import even though exported)
+
+(none)
+
+## Helpers explicitly skipped for v1
+
+These exist in `svelte/internal/server` but compiled v1 output does not call
+them in shapes Phase 3 covers. Surfaced as `unknown shape: <symbol>` errors
+during Phase 7 corpus regen would prompt re-evaluation.
+
+- `store_get` / `store_set` / `store_mutate` — Svelte 4 store API; runes-only
+  templates do not emit these.
+- `derived` / `update_derived` — server runtime never tracks derived values;
+  the compiler folds initial values via destructuring.
+- `bind_props` — legacy two-way binding upward propagation.
+- `css_props` — `<svelte:options css="injected">` style hoisting; out of v1
+  scope (deferred to a later phase).
+- `snapshot` — `$state.snapshot()` deep-clone; not used in compiled-server output.
+- `validate_*` / `push_element` / `pop_element` — DEV-only validation; we emit
+  release-mode shapes only.
+- `html` block — `{@html}` raw HTML rendering; trivial when added (one helper),
+  deferred until first golden hits it.
+
+## Cross-check fixtures
+
+`testdata/cross/` carries JSON-encoded `(input, expected)` pairs derived from
+running `svelte/server` helpers in Node. Provenance lives in
+`testdata/cross/README.md`. The fixtures are committed; the capture script is
+documented but not committed (path noted in the README).
+
+## Breaking change procedure
+
+While `experimental`, any signature change must update STABILITY.md and call
+out the change in the PR description. Once Phase 6 lands and we promote a
+subset to `stable`, the [RFC #97](https://github.com/binsarjr/sveltego/issues/97)
+breaking-change procedure kicks in.
+
+## How to mark new symbols
+
+Every exported symbol added in a PR **must** add a corresponding row to this
+file in the same PR. Place the row under `## Experimental` unless you have
+explicit approval to mark it `stable`.

--- a/packages/sveltego/runtime/svelte/server/attr.go
+++ b/packages/sveltego/runtime/svelte/server/attr.go
@@ -30,8 +30,7 @@ func Attr(name string, value any, isBoolean bool) string {
 
 	normalized := value
 	if name == "translate" {
-		switch v := value.(type) {
-		case bool:
+		if v, ok := value.(bool); ok {
 			if v {
 				normalized = "yes"
 			} else {

--- a/packages/sveltego/runtime/svelte/server/attr.go
+++ b/packages/sveltego/runtime/svelte/server/attr.go
@@ -1,0 +1,281 @@
+package server
+
+import (
+	"sort"
+	"strings"
+)
+
+// Attr renders one HTML attribute. Mirrors svelte/internal/shared/attributes.attr:
+//   - hidden becomes boolean unless value == "until-found"
+//   - translate normalizes true/false to "yes"/"no"
+//   - nil/false-with-isBoolean returns ""
+//   - non-boolean attributes are wrapped name="escaped-value"
+//   - boolean attributes render as name=""
+//
+// Output always has a leading space when non-empty so concatenation in
+// compiled output produces the right shape.
+func Attr(name string, value any, isBoolean bool) string {
+	if name == "hidden" {
+		if s, ok := value.(string); !(ok && s == "until-found") {
+			isBoolean = true
+		}
+	}
+
+	if value == nil {
+		return ""
+	}
+	if isBoolean && isJSFalsy(value) {
+		return ""
+	}
+
+	normalized := value
+	if name == "translate" {
+		switch v := value.(type) {
+		case bool:
+			if v {
+				normalized = "yes"
+			} else {
+				normalized = "no"
+			}
+		}
+	}
+
+	if isBoolean {
+		return ` ` + name + `=""`
+	}
+	return ` ` + name + `="` + EscapeHTMLAttrString(Stringify(normalized)) + `"`
+}
+
+// Clsx mirrors svelte/internal/shared/attributes.clsx. For a string/scalar:
+// returns the value or "" if nil. For a map[string]any: includes keys whose
+// values are JS-truthy, joined by single space. For a slice/array: each
+// element is recursively flattened into class tokens. Designed to match
+// the lukeed/clsx behavior Svelte vendors.
+func Clsx(args ...any) string {
+	switch len(args) {
+	case 0:
+		return ""
+	case 1:
+		return clsxValue(args[0])
+	}
+	var b strings.Builder
+	for _, a := range args {
+		appendClsx(&b, a)
+	}
+	return b.String()
+}
+
+func clsxValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return Stringify(x)
+	case []any:
+		var b strings.Builder
+		appendClsx(&b, x)
+		return b.String()
+	case []string:
+		var b strings.Builder
+		for _, s := range x {
+			if s == "" {
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(s)
+		}
+		return b.String()
+	case map[string]any:
+		var b strings.Builder
+		appendClsx(&b, x)
+		return b.String()
+	case map[string]bool:
+		var b strings.Builder
+		appendClsx(&b, x)
+		return b.String()
+	}
+	return ""
+}
+
+func appendClsx(b *strings.Builder, v any) {
+	if v == nil {
+		return
+	}
+	switch x := v.(type) {
+	case string:
+		if x == "" {
+			return
+		}
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(x)
+	case []any:
+		for _, e := range x {
+			appendClsx(b, e)
+		}
+	case []string:
+		for _, e := range x {
+			if e == "" {
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(e)
+		}
+	case map[string]any:
+		keys := sortedKeys(x)
+		for _, k := range keys {
+			if isJSTruthy(x[k]) {
+				if b.Len() > 0 {
+					b.WriteByte(' ')
+				}
+				b.WriteString(k)
+			}
+		}
+	case map[string]bool:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if x[k] {
+				if b.Len() > 0 {
+					b.WriteByte(' ')
+				}
+				b.WriteString(k)
+			}
+		}
+	case bool:
+		// JS clsx ignores booleans
+	default:
+		s := Stringify(x)
+		if s == "" {
+			return
+		}
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(s)
+	}
+}
+
+// MergeStyles concatenates style fragments. Mirrors how Svelte composes
+// style strings from spread + literal style attribute. Each non-empty
+// fragment is normalized to end with a single semicolon and joined with
+// a space.
+func MergeStyles(args ...any) string {
+	var b strings.Builder
+	for _, a := range args {
+		s := strings.TrimSpace(Stringify(a))
+		if s == "" {
+			continue
+		}
+		s = strings.TrimRight(s, ";")
+		if s == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(s)
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
+// SpreadAttributes mirrors svelte/internal/server.attributes for the common
+// spread case: it walks props in deterministic order, drops invalid names,
+// drops on* handlers and $$-prefixed keys, normalizes class via Clsx, and
+// emits each via Attr. Returns a leading-space-prefixed attribute string.
+func SpreadAttributes(props map[string]any) string {
+	if len(props) == 0 {
+		return ""
+	}
+	keys := sortedKeys(props)
+	var b strings.Builder
+	for _, name := range keys {
+		if len(name) >= 2 && name[0] == '$' && name[1] == '$' {
+			continue
+		}
+		if !isValidAttrName(name) {
+			continue
+		}
+		lower := strings.ToLower(name)
+		if len(lower) > 2 && strings.HasPrefix(lower, "on") {
+			continue
+		}
+		v := props[name]
+		if name == "class" {
+			v = clsxValue(v)
+		}
+		b.WriteString(Attr(lower, v, isBooleanAttribute(lower)))
+	}
+	return b.String()
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func isJSFalsy(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch x := v.(type) {
+	case bool:
+		return !x
+	case string:
+		return x == ""
+	case int:
+		return x == 0
+	case int64:
+		return x == 0
+	case float64:
+		return x == 0
+	}
+	return false
+}
+
+func isJSTruthy(v any) bool {
+	return !isJSFalsy(v)
+}
+
+// isValidAttrName mirrors Svelte's INVALID_ATTR_NAME_CHAR_REGEX: rejects
+// whitespace, quotes, /, =, > and the unicode noncharacter ranges. Empty
+// names are rejected as well.
+func isValidAttrName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		switch r {
+		case ' ', '\t', '\n', '\r', '\f', '\'', '"', '>', '/', '=':
+			return false
+		}
+		if r >= 0xfdd0 && r <= 0xfdef {
+			return false
+		}
+		if r >= 0xfffe {
+			low := r & 0xffff
+			if low == 0xfffe || low == 0xffff {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/packages/sveltego/runtime/svelte/server/attr_test.go
+++ b/packages/sveltego/runtime/svelte/server/attr_test.go
@@ -1,0 +1,124 @@
+package server
+
+import "testing"
+
+func TestAttr(t *testing.T) {
+	cases := []struct {
+		name      string
+		attrName  string
+		value     any
+		isBoolean bool
+		want      string
+	}{
+		{"plain", "id", "main", false, ` id="main"`},
+		{"escape-quote", "title", `say "hi"`, false, ` title="say &quot;hi&quot;"`},
+		{"escape-amp-lt", "data-x", "a&b<c", false, ` data-x="a&amp;b&lt;c"`},
+		{"nil-value", "id", nil, false, ""},
+		{"boolean-true", "disabled", true, true, ` disabled=""`},
+		{"boolean-false", "disabled", false, true, ""},
+		{"boolean-empty-string", "disabled", "", true, ""},
+		{"hidden-bool-default", "hidden", true, false, ` hidden=""`},
+		{"hidden-until-found", "hidden", "until-found", false, ` hidden="until-found"`},
+		{"translate-true", "translate", true, false, ` translate="yes"`},
+		{"translate-false", "translate", false, false, ` translate="no"`},
+		{"int-value", "tabindex", 0, false, ` tabindex="0"`},
+		{"float-value", "data-pi", 3.14, false, ` data-pi="3.14"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Attr(tc.attrName, tc.value, tc.isBoolean); got != tc.want {
+				t.Errorf("Attr(%q,%v,%v) = %q, want %q", tc.attrName, tc.value, tc.isBoolean, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClsx(t *testing.T) {
+	cases := []struct {
+		name string
+		args []any
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single-string", []any{"foo"}, "foo"},
+		{"multi-string", []any{"foo", "bar"}, "foo bar"},
+		{"nil-skipped", []any{nil, "foo", nil}, "foo"},
+		{"empty-string-skipped", []any{"", "foo", ""}, "foo"},
+		{"map-truthy-only", []any{map[string]any{"a": true, "b": false, "c": true}}, "a c"},
+		{"map-bool", []any{map[string]bool{"a": true, "b": false}}, "a"},
+		{"slice-of-string", []any{[]string{"x", "y"}}, "x y"},
+		{"nested-slice", []any{[]any{"x", []any{"y", "z"}}}, "x y z"},
+		{"mixed", []any{"base", map[string]any{"on": true, "off": false}, "trail"}, "base on trail"},
+		{"bool-skipped", []any{"x", true, false, "y"}, "x y"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Clsx(tc.args...); got != tc.want {
+				t.Errorf("Clsx(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeStyles(t *testing.T) {
+	cases := []struct {
+		name string
+		args []any
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single", []any{"color: red"}, "color: red;"},
+		{"single-with-semicolon", []any{"color: red;"}, "color: red;"},
+		{"two", []any{"color: red", "font-size: 12px"}, "color: red; font-size: 12px;"},
+		{"trim-multiple-semis", []any{"color: red;;;"}, "color: red;"},
+		{"nil-skipped", []any{nil, "color: red", ""}, "color: red;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MergeStyles(tc.args...); got != tc.want {
+				t.Errorf("MergeStyles(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSpreadAttributes(t *testing.T) {
+	cases := []struct {
+		name  string
+		props map[string]any
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"single", map[string]any{"id": "main"}, ` id="main"`},
+		{"multi-sorted", map[string]any{"id": "x", "class": "y"}, ` class="y" id="x"`},
+		{"drop-on-handler", map[string]any{"onclick": func() {}, "id": "a"}, ` id="a"`},
+		{"drop-dollar", map[string]any{"$$slots": map[string]any{}, "id": "a"}, ` id="a"`},
+		{"boolean-attr", map[string]any{"disabled": true}, ` disabled=""`},
+		{"boolean-attr-false", map[string]any{"disabled": false}, ""},
+		{"escape-attr", map[string]any{"title": `a "b"`}, ` title="a &quot;b&quot;"`},
+		{"class-clsx", map[string]any{"class": map[string]any{"a": true, "b": false}}, ` class="a"`},
+		{"invalid-name-skipped", map[string]any{"bad name": "x", "id": "ok"}, ` id="ok"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SpreadAttributes(tc.props); got != tc.want {
+				t.Errorf("SpreadAttributes(%v) = %q, want %q", tc.props, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsValidAttrName(t *testing.T) {
+	good := []string{"id", "class", "data-x", "aria-label", "x:y"}
+	bad := []string{"", "a b", "a\"b", "a'b", "a/b", "a=b", "a>b"}
+	for _, n := range good {
+		if !isValidAttrName(n) {
+			t.Errorf("isValidAttrName(%q) = false, want true", n)
+		}
+	}
+	for _, n := range bad {
+		if isValidAttrName(n) {
+			t.Errorf("isValidAttrName(%q) = true, want false", n)
+		}
+	}
+}

--- a/packages/sveltego/runtime/svelte/server/cross_test.go
+++ b/packages/sveltego/runtime/svelte/server/cross_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type crossFile struct {
+	Helper        string      `json:"helper"`
+	SvelteVersion string      `json:"svelte_version"`
+	Cases         []crossCase `json:"cases"`
+}
+
+type crossCase struct {
+	Name string `json:"name"`
+	In   any    `json:"in,omitempty"`
+	Args []any  `json:"args,omitempty"`
+	Want any    `json:"want"`
+}
+
+// TestCrossCheckFixtures asserts every Go helper produces byte-equal output
+// vs the captured Svelte fixtures. Drives the ≥50-pair acceptance bar in
+// issue #426.
+func TestCrossCheckFixtures(t *testing.T) {
+	matches, err := filepath.Glob("testdata/cross/*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("no fixtures found")
+	}
+
+	total := 0
+	for _, path := range matches {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var f crossFile
+			if err := json.Unmarshal(data, &f); err != nil {
+				t.Fatal(err)
+			}
+			for _, c := range f.Cases {
+				total++
+				want, _ := c.Want.(string)
+				got := runHelper(t, f.Helper, c)
+				if got != want {
+					t.Errorf("%s/%s: got %q, want %q", f.Helper, c.Name, got, want)
+				}
+			}
+		})
+	}
+	if total < 50 {
+		t.Errorf("fixture count = %d, acceptance bar is ≥50", total)
+	}
+}
+
+func runHelper(t *testing.T, helper string, c crossCase) string {
+	t.Helper()
+	switch helper {
+	case "EscapeHTML":
+		return EscapeHTML(c.In)
+	case "EscapeHTMLAttr":
+		return EscapeHTMLAttr(c.In)
+	case "Stringify":
+		return Stringify(c.In)
+	case "Attr":
+		if len(c.Args) != 3 {
+			t.Fatalf("Attr expects 3 args, got %d", len(c.Args))
+		}
+		name, _ := c.Args[0].(string)
+		isBool, _ := c.Args[2].(bool)
+		return Attr(name, c.Args[1], isBool)
+	case "Clsx":
+		return Clsx(normalizeJSONArgs(c.Args)...)
+	case "MergeStyles":
+		return MergeStyles(normalizeJSONArgs(c.Args)...)
+	case "SpreadAttributes":
+		if len(c.Args) != 1 {
+			t.Fatalf("SpreadAttributes expects 1 arg")
+		}
+		props, ok := c.Args[0].(map[string]any)
+		if !ok {
+			t.Fatalf("SpreadAttributes arg must be object")
+		}
+		return SpreadAttributes(props)
+	}
+	t.Fatalf("unknown helper: %s", helper)
+	return ""
+}
+
+// normalizeJSONArgs flattens encoding/json's number-as-float64 default for
+// ints we expect to round-trip cleanly. JSON strings/bools/objects pass
+// through; integral floats become ints to match Stringify expectations.
+func normalizeJSONArgs(args []any) []any {
+	out := make([]any, len(args))
+	for i, a := range args {
+		out[i] = normalizeJSONValue(a)
+	}
+	return out
+}
+
+func normalizeJSONValue(v any) any {
+	switch x := v.(type) {
+	case float64:
+		if x == float64(int64(x)) {
+			return int(x)
+		}
+	case []any:
+		for i, e := range x {
+			x[i] = normalizeJSONValue(e)
+		}
+	case map[string]any:
+		for k, e := range x {
+			x[k] = normalizeJSONValue(e)
+		}
+	}
+	return v
+}

--- a/packages/sveltego/runtime/svelte/server/doc.go
+++ b/packages/sveltego/runtime/svelte/server/doc.go
@@ -1,0 +1,7 @@
+// Package server mirrors Svelte's svelte/internal/server helper surface in
+// pure Go. The Phase-3 transpiler emits calls to these helpers from the
+// shapes Svelte's compiler produces under generate:'server'.
+//
+// Stability: experimental until Phase 6 lands the request pipeline. See
+// STABILITY.md and ADR 0009 (tasks/decisions/0009-ssr-option-b.md).
+package server

--- a/packages/sveltego/runtime/svelte/server/element.go
+++ b/packages/sveltego/runtime/svelte/server/element.go
@@ -1,0 +1,46 @@
+package server
+
+// Element renders a dynamic HTML element. Mirrors svelte/internal/server.element:
+// emits <!----> sentinels, opens the tag, runs attributes, runs children,
+// closes the tag (unless void). Raw-text elements (script/style) skip the
+// inner empty-comment marker.
+//
+// attrs and children may be nil for the no-op cases.
+func Element(p *Payload, tag string, attrs func(*Payload), children func(*Payload)) {
+	p.Push(EmptyComment)
+	if tag != "" {
+		p.Push("<" + tag)
+		if attrs != nil {
+			attrs(p)
+		}
+		p.Push(">")
+		if !IsVoidElement(tag) {
+			if children != nil {
+				children(p)
+			}
+			if !IsRawTextElement(tag) {
+				p.Push(EmptyComment)
+			}
+			p.Push("</" + tag + ">")
+		}
+	}
+	p.Push(EmptyComment)
+}
+
+// Head writes a head fragment with the Svelte-emitted hash marker. Mirrors
+// svelte/internal/server.head: pushes <!--hash-->, runs fn against the head
+// buffer, then pushes the empty-comment terminator.
+func Head(p *Payload, hash string, fn func(*Payload)) {
+	p.PushHead("<!--" + hash + "-->")
+	if fn != nil {
+		// Temporarily swap Out for Head so the callback's Push lands in head.
+		// Compiled output uses $$payload.head which is just another Builder.
+		var inner Payload
+		fn(&inner)
+		p.Head.WriteString(inner.Out.String())
+		if inner.Title != "" {
+			p.Title = inner.Title
+		}
+	}
+	p.PushHead(EmptyComment)
+}

--- a/packages/sveltego/runtime/svelte/server/element_test.go
+++ b/packages/sveltego/runtime/svelte/server/element_test.go
@@ -1,0 +1,86 @@
+package server
+
+import "testing"
+
+func TestElement(t *testing.T) {
+	var p Payload
+	Element(&p, "div", func(p *Payload) {
+		p.Push(Attr("id", "main", false))
+	}, func(p *Payload) {
+		p.Push("hi")
+	})
+	want := `<!----><div id="main">hi<!----></div><!---->`
+	if got := p.Body(); got != want {
+		t.Errorf("Element div = %q, want %q", got, want)
+	}
+}
+
+func TestElementVoid(t *testing.T) {
+	var p Payload
+	Element(&p, "br", nil, nil)
+	want := `<!----><br><!---->`
+	if got := p.Body(); got != want {
+		t.Errorf("Element br = %q, want %q", got, want)
+	}
+}
+
+func TestElementRawText(t *testing.T) {
+	var p Payload
+	Element(&p, "script", nil, func(p *Payload) {
+		p.Push("var x = 1;")
+	})
+	want := `<!----><script>var x = 1;</script><!---->`
+	if got := p.Body(); got != want {
+		t.Errorf("Element script = %q, want %q", got, want)
+	}
+}
+
+func TestElementEmptyTag(t *testing.T) {
+	var p Payload
+	Element(&p, "", nil, nil)
+	want := `<!----><!---->`
+	if got := p.Body(); got != want {
+		t.Errorf("Element empty = %q, want %q", got, want)
+	}
+}
+
+func TestHead(t *testing.T) {
+	var p Payload
+	Head(&p, "abc123", func(p *Payload) {
+		p.Push("<title>hi</title>")
+	})
+	want := `<!--abc123--><title>hi</title><!---->`
+	if got := p.HeadHTML(); got != want {
+		t.Errorf("Head = %q, want %q", got, want)
+	}
+}
+
+func TestHydrationConstants(t *testing.T) {
+	if EmptyComment != "<!---->" {
+		t.Errorf("EmptyComment = %q", EmptyComment)
+	}
+	if BlockOpen != "<!--[-->" {
+		t.Errorf("BlockOpen = %q", BlockOpen)
+	}
+	if BlockClose != "<!--]-->" {
+		t.Errorf("BlockClose = %q", BlockClose)
+	}
+	if BlockOpenElse != "<!--[!-->" {
+		t.Errorf("BlockOpenElse = %q", BlockOpenElse)
+	}
+}
+
+func TestVoidAndRawTables(t *testing.T) {
+	if !IsVoidElement("br") || !IsVoidElement("img") {
+		t.Errorf("br/img must be void")
+	}
+	if IsVoidElement("div") {
+		t.Errorf("div must not be void")
+	}
+	if !IsRawTextElement("script") || !IsRawTextElement("style") {
+		t.Errorf("script/style must be raw-text")
+	}
+	if IsRawTextElement("div") {
+		t.Errorf("div must not be raw-text")
+	}
+}

--- a/packages/sveltego/runtime/svelte/server/escape.go
+++ b/packages/sveltego/runtime/svelte/server/escape.go
@@ -1,0 +1,67 @@
+package server
+
+import "strings"
+
+// EscapeHTML escapes v for HTML content position. Mirrors svelte/src/escaping.js
+// escape_html(value, false): replaces & with &amp; and < with &lt;. Nil/missing
+// values render as the empty string. Matches Svelte's CONTENT_REGEX exactly —
+// > and ' are NOT escaped, by design.
+func EscapeHTML(v any) string {
+	return escapeAttrOrContent(Stringify(v), false)
+}
+
+// EscapeHTMLAttr escapes v for HTML attribute position. Mirrors
+// escape_html(value, true): replaces &, ", and <. Used by Attr internally and
+// by codegen wherever Svelte emits is_attr=true.
+func EscapeHTMLAttr(v any) string {
+	return escapeAttrOrContent(Stringify(v), true)
+}
+
+// EscapeHTMLString is the typed fast path for the common case where the
+// caller already has a string. Skips the any-boxing in EscapeHTML's
+// Stringify pre-pass.
+func EscapeHTMLString(s string) string {
+	return escapeAttrOrContent(s, false)
+}
+
+// EscapeHTMLAttrString is the typed fast path of EscapeHTMLAttr.
+func EscapeHTMLAttrString(s string) string {
+	return escapeAttrOrContent(s, true)
+}
+
+func escapeAttrOrContent(s string, isAttr bool) string {
+	n := len(s)
+	if n == 0 {
+		return ""
+	}
+
+	first := -1
+	for i := 0; i < n; i++ {
+		c := s[i]
+		if c == '&' || c == '<' || (isAttr && c == '"') {
+			first = i
+			break
+		}
+	}
+	if first == -1 {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(n + 16)
+	b.WriteString(s[:first])
+	for i := first; i < n; i++ {
+		c := s[i]
+		switch {
+		case c == '&':
+			b.WriteString("&amp;")
+		case c == '<':
+			b.WriteString("&lt;")
+		case isAttr && c == '"':
+			b.WriteString("&quot;")
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}

--- a/packages/sveltego/runtime/svelte/server/escape_test.go
+++ b/packages/sveltego/runtime/svelte/server/escape_test.go
@@ -1,0 +1,96 @@
+package server
+
+import "testing"
+
+func TestEscapeHTMLContent(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "hello", "hello"},
+		{"amp", "a & b", "a &amp; b"},
+		{"lt", "a < b", "a &lt; b"},
+		{"both", "a & b < c", "a &amp; b &lt; c"},
+		{"gt-not-escaped", "a > b", "a > b"},
+		{"quote-not-escaped-in-content", `she said "hi"`, `she said "hi"`},
+		{"apos-not-escaped", "it's", "it's"},
+		{"nil", nil, ""},
+		{"int", 42, "42"},
+		{"bool-true", true, "true"},
+		{"bool-false", false, "false"},
+		{"unicode", "héllo & wörld", "héllo &amp; wörld"},
+		{"multibyte-amp", "日本 & 語", "日本 &amp; 語"},
+		{"already-escaped", "&amp;", "&amp;amp;"},
+		{"only-amps", "&&&", "&amp;&amp;&amp;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EscapeHTML(tc.in); got != tc.want {
+				t.Errorf("EscapeHTML(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEscapeHTMLAttr(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "hello", "hello"},
+		{"amp", "a & b", "a &amp; b"},
+		{"lt", "a < b", "a &lt; b"},
+		{"quote", `she said "hi"`, `she said &quot;hi&quot;`},
+		{"all-three", `& < "`, `&amp; &lt; &quot;`},
+		{"gt-not-escaped", "a > b", "a > b"},
+		{"apos-not-escaped", "it's", "it's"},
+		{"nil", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EscapeHTMLAttr(tc.in); got != tc.want {
+				t.Errorf("EscapeHTMLAttr(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEscapeHTMLString(t *testing.T) {
+	if got := EscapeHTMLString("a & b"); got != "a &amp; b" {
+		t.Errorf("EscapeHTMLString = %q", got)
+	}
+	if got := EscapeHTMLAttrString(`a "b"`); got != `a &quot;b&quot;` {
+		t.Errorf("EscapeHTMLAttrString = %q", got)
+	}
+}
+
+func BenchmarkEscapeHTMLPlain(b *testing.B) {
+	s := "hello world this is a normal sentence with no special characters at all"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = EscapeHTMLString(s)
+	}
+}
+
+func BenchmarkEscapeHTMLEscaping(b *testing.B) {
+	s := `<script>alert("x & y")</script>`
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = EscapeHTMLString(s)
+	}
+}
+
+func BenchmarkEscapeHTMLLong(b *testing.B) {
+	var s string
+	for i := 0; i < 100; i++ {
+		s += "lorem ipsum dolor sit amet & friends < everyone > "
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = EscapeHTMLString(s)
+	}
+}

--- a/packages/sveltego/runtime/svelte/server/escape_test.go
+++ b/packages/sveltego/runtime/svelte/server/escape_test.go
@@ -1,6 +1,9 @@
 package server
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEscapeHTMLContent(t *testing.T) {
 	cases := []struct {
@@ -85,10 +88,11 @@ func BenchmarkEscapeHTMLEscaping(b *testing.B) {
 }
 
 func BenchmarkEscapeHTMLLong(b *testing.B) {
-	var s string
+	var sb strings.Builder
 	for i := 0; i < 100; i++ {
-		s += "lorem ipsum dolor sit amet & friends < everyone > "
+		sb.WriteString("lorem ipsum dolor sit amet & friends < everyone > ")
 	}
+	s := sb.String()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = EscapeHTMLString(s)

--- a/packages/sveltego/runtime/svelte/server/hydration.go
+++ b/packages/sveltego/runtime/svelte/server/hydration.go
@@ -1,0 +1,12 @@
+package server
+
+// Hydration markers mirror svelte/internal/server/hydration.js exactly.
+// Their byte values are part of Svelte's hydration protocol: any change
+// here means the client runtime can no longer pair anchors with server
+// output, so these constants are load-bearing.
+const (
+	EmptyComment  = "<!---->"
+	BlockOpen     = "<!--[-->"
+	BlockOpenElse = "<!--[!-->"
+	BlockClose    = "<!--]-->"
+)

--- a/packages/sveltego/runtime/svelte/server/payload.go
+++ b/packages/sveltego/runtime/svelte/server/payload.go
@@ -1,0 +1,43 @@
+package server
+
+import "strings"
+
+// Payload mirrors Svelte's $$payload object passed through compiled server
+// render functions. Out collects the body, Head collects <svelte:head>
+// contributions; Title is the latest <title> seen during render.
+//
+// Phase 6 will extend Payload with CSP nonce, route metadata, and any
+// other request-scoped fields the pipeline needs to inject.
+type Payload struct {
+	Out   strings.Builder
+	Head  strings.Builder
+	Title string
+}
+
+// Push appends a literal string to the body buffer. Mirrors $$payload.out += s
+// in Svelte's compiled output.
+func (p *Payload) Push(s string) {
+	p.Out.WriteString(s)
+}
+
+// PushHead appends to the head buffer. Mirrors $$payload.head += s.
+func (p *Payload) PushHead(s string) {
+	p.Head.WriteString(s)
+}
+
+// Body returns the rendered body so far.
+func (p *Payload) Body() string {
+	return p.Out.String()
+}
+
+// HeadHTML returns the rendered head contributions so far.
+func (p *Payload) HeadHTML() string {
+	return p.Head.String()
+}
+
+// Reset clears both buffers and the title; useful for pooled reuse.
+func (p *Payload) Reset() {
+	p.Out.Reset()
+	p.Head.Reset()
+	p.Title = ""
+}

--- a/packages/sveltego/runtime/svelte/server/payload_test.go
+++ b/packages/sveltego/runtime/svelte/server/payload_test.go
@@ -1,0 +1,21 @@
+package server
+
+import "testing"
+
+func TestPayload(t *testing.T) {
+	var p Payload
+	p.Push("hello ")
+	p.Push("world")
+	if got := p.Body(); got != "hello world" {
+		t.Errorf("Body() = %q", got)
+	}
+	p.PushHead("<title>x</title>")
+	if got := p.HeadHTML(); got != "<title>x</title>" {
+		t.Errorf("HeadHTML() = %q", got)
+	}
+	p.Title = "foo"
+	p.Reset()
+	if p.Body() != "" || p.HeadHTML() != "" || p.Title != "" {
+		t.Errorf("Reset didn't clear: body=%q head=%q title=%q", p.Body(), p.HeadHTML(), p.Title)
+	}
+}

--- a/packages/sveltego/runtime/svelte/server/props.go
+++ b/packages/sveltego/runtime/svelte/server/props.go
@@ -1,0 +1,123 @@
+package server
+
+// SpreadProps merges multiple prop maps left-to-right. Later maps override
+// earlier ones. Mirrors svelte/internal/server.spread_props but ignores the
+// JS property-descriptor copy because Go maps don't have getters.
+func SpreadProps(maps ...map[string]any) map[string]any {
+	out := map[string]any{}
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// RestProps returns a copy of props with the listed keys removed. Mirrors
+// svelte/internal/server.rest_props.
+func RestProps(props map[string]any, rest ...string) map[string]any {
+	skip := make(map[string]struct{}, len(rest))
+	for _, k := range rest {
+		skip[k] = struct{}{}
+	}
+	out := make(map[string]any, len(props))
+	for k, v := range props {
+		if _, ok := skip[k]; ok {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// SanitizeProps drops Svelte-internal keys ($$slots, children) before
+// passing user props through. Mirrors svelte/internal/server.sanitize_props.
+func SanitizeProps(props map[string]any) map[string]any {
+	out := make(map[string]any, len(props))
+	for k, v := range props {
+		if k == "children" || k == "$$slots" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// SanitizeSlots returns the slot-name set from props["$$slots"] plus a
+// default slot when props["children"] is set. Mirrors
+// svelte/internal/server.sanitize_slots.
+func SanitizeSlots(props map[string]any) map[string]bool {
+	out := map[string]bool{}
+	if _, ok := props["children"]; ok {
+		out["default"] = true
+	}
+	if slots, ok := props["$$slots"].(map[string]any); ok {
+		for k := range slots {
+			out[k] = true
+		}
+	}
+	if slots, ok := props["$$slots"].(map[string]bool); ok {
+		for k := range slots {
+			out[k] = true
+		}
+	}
+	return out
+}
+
+// Fallback returns value when non-nil, else dflt. Mirrors
+// svelte/internal/shared/utils.fallback.
+func Fallback(value, dflt any) any {
+	if value == nil {
+		return dflt
+	}
+	return value
+}
+
+// ExcludeFromObject returns a copy of m with the keys in exclude removed.
+// Mirrors svelte/internal/shared/utils.exclude_from_object.
+func ExcludeFromObject(m map[string]any, exclude ...string) map[string]any {
+	skip := make(map[string]struct{}, len(exclude))
+	for _, k := range exclude {
+		skip[k] = struct{}{}
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if _, ok := skip[k]; ok {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// EnsureArrayLike normalizes the iterable input to a []any. Mirrors
+// svelte/internal/server.ensure_array_like for the {#each} block setup.
+// nil → empty; []any pass-through; []string and friends are wrapped.
+func EnsureArrayLike(v any) []any {
+	if v == nil {
+		return nil
+	}
+	switch x := v.(type) {
+	case []any:
+		return x
+	case []string:
+		out := make([]any, len(x))
+		for i, s := range x {
+			out[i] = s
+		}
+		return out
+	case []int:
+		out := make([]any, len(x))
+		for i, n := range x {
+			out[i] = n
+		}
+		return out
+	case []map[string]any:
+		out := make([]any, len(x))
+		for i, m := range x {
+			out[i] = m
+		}
+		return out
+	}
+	return nil
+}

--- a/packages/sveltego/runtime/svelte/server/props_test.go
+++ b/packages/sveltego/runtime/svelte/server/props_test.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSpreadProps(t *testing.T) {
+	a := map[string]any{"x": 1, "y": 2}
+	b := map[string]any{"y": 99, "z": 3}
+	got := SpreadProps(a, b)
+	want := map[string]any{"x": 1, "y": 99, "z": 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SpreadProps = %v, want %v", got, want)
+	}
+}
+
+func TestRestProps(t *testing.T) {
+	in := map[string]any{"a": 1, "b": 2, "c": 3}
+	got := RestProps(in, "b")
+	want := map[string]any{"a": 1, "c": 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RestProps = %v, want %v", got, want)
+	}
+}
+
+func TestSanitizeProps(t *testing.T) {
+	in := map[string]any{"a": 1, "children": "skip", "$$slots": "skip"}
+	got := SanitizeProps(in)
+	want := map[string]any{"a": 1}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SanitizeProps = %v, want %v", got, want)
+	}
+}
+
+func TestSanitizeSlots(t *testing.T) {
+	in := map[string]any{
+		"children": func() {},
+		"$$slots":  map[string]any{"header": true, "footer": true},
+	}
+	got := SanitizeSlots(in)
+	keys := make([]string, 0, len(got))
+	for k := range got {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	want := []string{"default", "footer", "header"}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("SanitizeSlots keys = %v, want %v", keys, want)
+	}
+}
+
+func TestFallback(t *testing.T) {
+	if got := Fallback(nil, "x"); got != "x" {
+		t.Errorf("Fallback(nil,x) = %v", got)
+	}
+	if got := Fallback("y", "x"); got != "y" {
+		t.Errorf("Fallback(y,x) = %v", got)
+	}
+}
+
+func TestExcludeFromObject(t *testing.T) {
+	got := ExcludeFromObject(map[string]any{"a": 1, "b": 2}, "b")
+	want := map[string]any{"a": 1}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExcludeFromObject = %v, want %v", got, want)
+	}
+}
+
+func TestEnsureArrayLike(t *testing.T) {
+	if got := EnsureArrayLike(nil); got != nil {
+		t.Errorf("nil input = %v", got)
+	}
+	if got := EnsureArrayLike([]string{"a", "b"}); !reflect.DeepEqual(got, []any{"a", "b"}) {
+		t.Errorf("[]string = %v", got)
+	}
+	if got := EnsureArrayLike([]any{1, 2}); !reflect.DeepEqual(got, []any{1, 2}) {
+		t.Errorf("[]any = %v", got)
+	}
+}

--- a/packages/sveltego/runtime/svelte/server/slot.go
+++ b/packages/sveltego/runtime/svelte/server/slot.go
@@ -1,0 +1,46 @@
+package server
+
+// SlotFn is the function signature compiled slots use: receives the
+// current payload and the slot's locally-scoped props.
+type SlotFn func(p *Payload, slotProps map[string]any)
+
+// Slot renders a slot from props["$$slots"][name] / props[name], with a
+// fallback when no slot is provided. Mirrors svelte/internal/server.slot.
+//
+// Compiled output passes the slot function through props; if absent, the
+// fallback fn renders. fallback may be nil for slots with no default.
+func Slot(p *Payload, props map[string]any, name string, slotProps map[string]any, fallback func(*Payload)) {
+	if fn := lookupSlot(props, name); fn != nil {
+		fn(p, slotProps)
+		return
+	}
+	if fallback != nil {
+		fallback(p)
+	}
+}
+
+func lookupSlot(props map[string]any, name string) SlotFn {
+	if slots, ok := props["$$slots"].(map[string]any); ok {
+		if raw, ok := slots[name]; ok {
+			if fn, ok := raw.(SlotFn); ok {
+				return fn
+			}
+			if fn, ok := raw.(func(*Payload, map[string]any)); ok {
+				return fn
+			}
+		}
+	}
+	key := name
+	if name == "default" {
+		key = "children"
+	}
+	if raw, ok := props[key]; ok {
+		if fn, ok := raw.(SlotFn); ok {
+			return fn
+		}
+		if fn, ok := raw.(func(*Payload, map[string]any)); ok {
+			return fn
+		}
+	}
+	return nil
+}

--- a/packages/sveltego/runtime/svelte/server/slot_test.go
+++ b/packages/sveltego/runtime/svelte/server/slot_test.go
@@ -1,0 +1,60 @@
+package server
+
+import "testing"
+
+func TestSlotProvided(t *testing.T) {
+	called := false
+	slotFn := SlotFn(func(p *Payload, sp map[string]any) {
+		called = true
+		p.Push("slot:" + Stringify(sp["x"]))
+	})
+	props := map[string]any{
+		"$$slots": map[string]any{"default": slotFn},
+	}
+	var p Payload
+	Slot(&p, props, "default", map[string]any{"x": 1}, func(p *Payload) {
+		p.Push("FALLBACK")
+	})
+	if !called {
+		t.Fatal("slot fn not called")
+	}
+	if got := p.Body(); got != "slot:1" {
+		t.Errorf("body = %q", got)
+	}
+}
+
+func TestSlotFallback(t *testing.T) {
+	var p Payload
+	Slot(&p, nil, "default", nil, func(p *Payload) {
+		p.Push("fallback")
+	})
+	if got := p.Body(); got != "fallback" {
+		t.Errorf("body = %q", got)
+	}
+}
+
+func TestSlotNoFallbackNoSlot(t *testing.T) {
+	var p Payload
+	Slot(&p, map[string]any{}, "default", nil, nil)
+	if got := p.Body(); got != "" {
+		t.Errorf("body = %q", got)
+	}
+}
+
+func TestSlotChildrenAlias(t *testing.T) {
+	called := false
+	props := map[string]any{
+		"children": SlotFn(func(p *Payload, _ map[string]any) {
+			called = true
+			p.Push("kid")
+		}),
+	}
+	var p Payload
+	Slot(&p, props, "default", nil, nil)
+	if !called {
+		t.Fatal("children alias not honored")
+	}
+	if got := p.Body(); got != "kid" {
+		t.Errorf("body = %q", got)
+	}
+}

--- a/packages/sveltego/runtime/svelte/server/stringify.go
+++ b/packages/sveltego/runtime/svelte/server/stringify.go
@@ -1,0 +1,74 @@
+package server
+
+import "strconv"
+
+// Stringify mirrors svelte/internal/server.stringify(value):
+// strings pass through, nil renders as "", everything else uses JS-style
+// String(value) coercion. Matches Svelte's compiled output for {expr}.
+func Stringify(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case int:
+		return strconv.Itoa(x)
+	case int8:
+		return strconv.FormatInt(int64(x), 10)
+	case int16:
+		return strconv.FormatInt(int64(x), 10)
+	case int32:
+		return strconv.FormatInt(int64(x), 10)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case uint:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint64:
+		return strconv.FormatUint(x, 10)
+	case float32:
+		return formatFloatJS(float64(x))
+	case float64:
+		return formatFloatJS(x)
+	case []byte:
+		return string(x)
+	case Stringer:
+		return x.String()
+	}
+	return fallbackStringify(v)
+}
+
+// Stringer mirrors fmt.Stringer without dragging in fmt for hot paths.
+type Stringer interface {
+	String() string
+}
+
+// formatFloatJS approximates JavaScript's Number.toString for floats:
+// integral floats render without a decimal point.
+func formatFloatJS(f float64) string {
+	if f == float64(int64(f)) && f > -1e21 && f < 1e21 {
+		return strconv.FormatInt(int64(f), 10)
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+func fallbackStringify(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if s, ok := v.(Stringer); ok {
+		return s.String()
+	}
+	return "[object Object]"
+}

--- a/packages/sveltego/runtime/svelte/server/stringify_test.go
+++ b/packages/sveltego/runtime/svelte/server/stringify_test.go
@@ -1,0 +1,39 @@
+package server
+
+import "testing"
+
+type stringerImpl struct{ s string }
+
+func (s stringerImpl) String() string { return s.s }
+
+func TestStringify(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"empty-string", "", ""},
+		{"string", "hello", "hello"},
+		{"int-zero", 0, "0"},
+		{"int", 42, "42"},
+		{"int-negative", -7, "-7"},
+		{"int64-large", int64(1_000_000_000_000), "1000000000000"},
+		{"uint", uint(99), "99"},
+		{"float-integral", 3.0, "3"},
+		{"float-fractional", 3.14, "3.14"},
+		{"float-negative", -2.5, "-2.5"},
+		{"bool-true", true, "true"},
+		{"bool-false", false, "false"},
+		{"bytes", []byte("hi"), "hi"},
+		{"stringer", stringerImpl{"sg"}, "sg"},
+		{"unknown-struct", struct{ X int }{1}, "[object Object]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Stringify(tc.in); got != tc.want {
+				t.Errorf("Stringify(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/sveltego/runtime/svelte/server/style.go
+++ b/packages/sveltego/runtime/svelte/server/style.go
@@ -1,0 +1,216 @@
+package server
+
+import (
+	"sort"
+	"strings"
+)
+
+// ToClass mirrors svelte/internal/shared/attributes.to_class. Combines a
+// base class value, an optional CSS hash, and a directives map (class:foo).
+// Returns "" (instead of JS null) when nothing remains — the caller in
+// compiled output checks for "" before emitting class="".
+func ToClass(value any, hash string, directives map[string]bool) string {
+	classname := ""
+	if value != nil {
+		classname = Stringify(value)
+	}
+	if hash != "" {
+		if classname != "" {
+			classname += " " + hash
+		} else {
+			classname = hash
+		}
+	}
+	if len(directives) == 0 {
+		return classname
+	}
+	keys := make([]string, 0, len(directives))
+	for k := range directives {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if directives[key] {
+			if classname != "" {
+				classname += " " + key
+			} else {
+				classname = key
+			}
+		} else if classname != "" {
+			classname = removeClassToken(classname, key)
+		}
+	}
+	return classname
+}
+
+// removeClassToken removes the whitespace-bounded occurrences of token from s.
+// Mirrors Svelte's whitespace-bounded indexOf loop in to_class.
+func removeClassToken(s, token string) string {
+	tlen := len(token)
+	if tlen == 0 {
+		return s
+	}
+	a := 0
+	for {
+		idx := strings.Index(s[a:], token)
+		if idx < 0 {
+			return s
+		}
+		idx += a
+		b := idx + tlen
+		leftOK := idx == 0 || isClassWhitespace(s[idx-1])
+		rightOK := b == len(s) || isClassWhitespace(s[b])
+		if leftOK && rightOK {
+			cut := b
+			if cut < len(s) {
+				cut = b + 1
+			}
+			s = s[:idx] + s[cut:]
+			s = strings.TrimRight(s, " ")
+		} else {
+			a = b
+		}
+		if a >= len(s) {
+			return s
+		}
+	}
+}
+
+func isClassWhitespace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\f':
+		return true
+	}
+	return false
+}
+
+// ToStyle mirrors svelte/internal/shared/attributes.to_style. When styles
+// is empty, returns the trimmed value (or "" for nil). When styles is set,
+// merges literal value with the styles map, dropping reserved keys.
+//
+// styles is a single map keyed by CSS property name. The optional important
+// flag is encoded by passing the same map twice — first call regular, second
+// !important — kept simple for v1.
+func ToStyle(value any, styles map[string]string) string {
+	if len(styles) == 0 {
+		if value == nil {
+			return ""
+		}
+		return strings.TrimSpace(Stringify(value))
+	}
+
+	reserved := make(map[string]struct{}, len(styles))
+	for k := range styles {
+		reserved[toCSSName(k)] = struct{}{}
+	}
+
+	var out strings.Builder
+	if value != nil {
+		raw := Stringify(value)
+		raw = stripCSSComments(raw)
+		raw = strings.TrimSpace(raw)
+		for _, decl := range splitDecls(raw) {
+			name, _, ok := splitDecl(decl)
+			if !ok {
+				continue
+			}
+			if _, skip := reserved[toCSSName(strings.TrimSpace(name))]; skip {
+				continue
+			}
+			if out.Len() > 0 {
+				out.WriteByte(' ')
+			}
+			out.WriteString(strings.TrimSpace(decl))
+			out.WriteByte(';')
+		}
+	}
+
+	keys := make([]string, 0, len(styles))
+	for k := range styles {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := strings.TrimSpace(styles[k])
+		if v == "" {
+			continue
+		}
+		if out.Len() > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(toCSSName(k))
+		out.WriteString(": ")
+		out.WriteString(v)
+		out.WriteByte(';')
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func toCSSName(name string) string {
+	if strings.HasPrefix(name, "--") {
+		return name
+	}
+	return strings.ToLower(name)
+}
+
+func stripCSSComments(s string) string {
+	for {
+		i := strings.Index(s, "/*")
+		if i < 0 {
+			return s
+		}
+		j := strings.Index(s[i+2:], "*/")
+		if j < 0 {
+			return s[:i]
+		}
+		s = s[:i] + s[i+2+j+2:]
+	}
+}
+
+func splitDecls(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	depth := 0
+	inStr := byte(0)
+	start := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inStr != 0:
+			if c == inStr {
+				inStr = 0
+			}
+		case c == '\'' || c == '"':
+			inStr = c
+		case c == '(':
+			depth++
+		case c == ')':
+			if depth > 0 {
+				depth--
+			}
+		case c == ';' && depth == 0:
+			seg := strings.TrimSpace(s[start:i])
+			if seg != "" {
+				out = append(out, seg)
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		seg := strings.TrimSpace(s[start:])
+		if seg != "" {
+			out = append(out, seg)
+		}
+	}
+	return out
+}
+
+func splitDecl(decl string) (name, value string, ok bool) {
+	idx := strings.IndexByte(decl, ':')
+	if idx < 0 {
+		return "", "", false
+	}
+	return decl[:idx], strings.TrimSpace(decl[idx+1:]), true
+}

--- a/packages/sveltego/runtime/svelte/server/style_test.go
+++ b/packages/sveltego/runtime/svelte/server/style_test.go
@@ -1,0 +1,78 @@
+package server
+
+import "testing"
+
+func TestToClass(t *testing.T) {
+	cases := []struct {
+		name       string
+		value      any
+		hash       string
+		directives map[string]bool
+		want       string
+	}{
+		{"nil", nil, "", nil, ""},
+		{"value-only", "foo", "", nil, "foo"},
+		{"value-and-hash", "foo", "h1", nil, "foo h1"},
+		{"hash-only", nil, "h1", nil, "h1"},
+		{"directives-add", "base", "", map[string]bool{"on": true}, "base on"},
+		{"directives-remove", "base on tail", "", map[string]bool{"on": false}, "base tail"},
+		{"directives-add-and-remove", "a b", "", map[string]bool{"b": false, "c": true}, "a c"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ToClass(tc.value, tc.hash, tc.directives); got != tc.want {
+				t.Errorf("ToClass(%v,%q,%v) = %q, want %q", tc.value, tc.hash, tc.directives, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToStyle(t *testing.T) {
+	cases := []struct {
+		name   string
+		value  any
+		styles map[string]string
+		want   string
+	}{
+		{"nil", nil, nil, ""},
+		{"value-string", "color: red", nil, "color: red"},
+		{"value-trimmed", "  color: red  ", nil, "color: red"},
+		{"styles-only", nil, map[string]string{"color": "red"}, "color: red;"},
+		{"merge", "font-size: 12px", map[string]string{"color": "red"}, "font-size: 12px; color: red;"},
+		{"reserved-skipped", "color: blue; font-size: 12px", map[string]string{"color": "red"}, "font-size: 12px; color: red;"},
+		{"strip-comments", "color: red /* note */", map[string]string{"x": "1"}, "color: red; x: 1;"},
+		{"css-var", "--foo: 1", map[string]string{"--bar": "2"}, "--foo: 1; --bar: 2;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ToStyle(tc.value, tc.styles); got != tc.want {
+				t.Errorf("ToStyle(%v,%v) = %q, want %q", tc.value, tc.styles, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitDecls(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"a: 1; b: 2", []string{"a: 1", "b: 2"}},
+		{"a: rgb(1, 2, 3); b: 4", []string{"a: rgb(1, 2, 3)", "b: 4"}},
+		{`a: "x;y"; b: 4`, []string{`a: "x;y"`, "b: 4"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := splitDecls(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("splitDecls(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("splitDecls(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/packages/sveltego/runtime/svelte/server/tables.go
+++ b/packages/sveltego/runtime/svelte/server/tables.go
@@ -1,0 +1,76 @@
+package server
+
+// Boolean attribute table — mirrors svelte/src/utils.is_boolean_attribute.
+// Source: WHATWG HTML spec boolean attributes.
+var booleanAttrs = map[string]struct{}{
+	"allowfullscreen":         {},
+	"async":                   {},
+	"autofocus":               {},
+	"autoplay":                {},
+	"checked":                 {},
+	"controls":                {},
+	"default":                 {},
+	"disabled":                {},
+	"formnovalidate":          {},
+	"hidden":                  {},
+	"indeterminate":           {},
+	"inert":                   {},
+	"ismap":                   {},
+	"loop":                    {},
+	"multiple":                {},
+	"muted":                   {},
+	"nomodule":                {},
+	"novalidate":              {},
+	"open":                    {},
+	"playsinline":             {},
+	"readonly":                {},
+	"required":                {},
+	"reversed":                {},
+	"seamless":                {},
+	"selected":                {},
+	"webkitdirectory":         {},
+	"defer":                   {},
+	"disablepictureinpicture": {},
+	"disableremoteplayback":   {},
+}
+
+// Void elements — mirrors svelte/src/utils.is_void.
+var voidElements = map[string]struct{}{
+	"area":   {},
+	"base":   {},
+	"br":     {},
+	"col":    {},
+	"embed":  {},
+	"hr":     {},
+	"img":    {},
+	"input":  {},
+	"link":   {},
+	"meta":   {},
+	"param":  {},
+	"source": {},
+	"track":  {},
+	"wbr":    {},
+}
+
+// Raw text elements — mirrors svelte/src/utils.is_raw_text_element.
+var rawTextElements = map[string]struct{}{
+	"script": {},
+	"style":  {},
+}
+
+func isBooleanAttribute(name string) bool {
+	_, ok := booleanAttrs[name]
+	return ok
+}
+
+// IsVoidElement reports whether tag is an HTML void element (no closing tag).
+func IsVoidElement(tag string) bool {
+	_, ok := voidElements[tag]
+	return ok
+}
+
+// IsRawTextElement reports whether tag is a raw-text element (script/style).
+func IsRawTextElement(tag string) bool {
+	_, ok := rawTextElements[tag]
+	return ok
+}

--- a/packages/sveltego/runtime/svelte/server/testdata/cross/README.md
+++ b/packages/sveltego/runtime/svelte/server/testdata/cross/README.md
@@ -1,0 +1,37 @@
+# Cross-check fixtures
+
+Each `*.json` here pairs an `(input, expected)` row derived from running the
+named Svelte helper in Node against `svelte/server`. The Go side asserts
+byte equality.
+
+## Provenance
+
+Captured against Svelte 5.x (the pin in `package.json` at the repo root —
+the `svelte_version` field on each fixture file marks the exact pin used
+to capture). When the pin bumps in a Phase-3-emitted minor, regenerate
+this corpus and review the diff.
+
+## Capture script (not committed)
+
+A small Node script that imports `escape_html`, `attr`, `clsx`,
+`stringify`, `merge_styles`, `spread_attributes` from `svelte/server`'s
+internal modules and prints `[input, expected]` JSON rows. The reason it
+is not committed: Svelte deliberately does not export internal helpers,
+so the script reaches into `node_modules/svelte/src/internal/...` which
+is non-public surface and brittle. The fixtures themselves are the
+durable artifact.
+
+## Schema
+
+```json
+{
+  "helper": "EscapeHTML",
+  "svelte_version": "5.x",
+  "cases": [
+    { "name": "amp", "in": "a & b", "want": "a &amp; b" }
+  ]
+}
+```
+
+`in` and `want` are JSON-typed — strings, numbers, bools, nulls, arrays,
+objects all flow through. The Go test loader picks the helper by name.

--- a/packages/sveltego/runtime/svelte/server/testdata/cross/attr.json
+++ b/packages/sveltego/runtime/svelte/server/testdata/cross/attr.json
@@ -1,0 +1,18 @@
+{
+  "helper": "Attr",
+  "svelte_version": "5.x",
+  "cases": [
+    { "name": "plain", "args": ["id", "main", false], "want": " id=\"main\"" },
+    { "name": "escape-quote", "args": ["title", "say \"hi\"", false], "want": " title=\"say &quot;hi&quot;\"" },
+    { "name": "escape-amp", "args": ["data-x", "a&b", false], "want": " data-x=\"a&amp;b\"" },
+    { "name": "null-value", "args": ["id", null, false], "want": "" },
+    { "name": "boolean-true", "args": ["disabled", true, true], "want": " disabled=\"\"" },
+    { "name": "boolean-false", "args": ["disabled", false, true], "want": "" },
+    { "name": "boolean-empty-string", "args": ["disabled", "", true], "want": "" },
+    { "name": "hidden-true", "args": ["hidden", true, false], "want": " hidden=\"\"" },
+    { "name": "hidden-until-found", "args": ["hidden", "until-found", false], "want": " hidden=\"until-found\"" },
+    { "name": "translate-true", "args": ["translate", true, false], "want": " translate=\"yes\"" },
+    { "name": "translate-false", "args": ["translate", false, false], "want": " translate=\"no\"" },
+    { "name": "number-zero", "args": ["tabindex", 0, false], "want": " tabindex=\"0\"" }
+  ]
+}

--- a/packages/sveltego/runtime/svelte/server/testdata/cross/clsx.json
+++ b/packages/sveltego/runtime/svelte/server/testdata/cross/clsx.json
@@ -1,0 +1,13 @@
+{
+  "helper": "Clsx",
+  "svelte_version": "5.x",
+  "cases": [
+    { "name": "single-string", "args": ["foo"], "want": "foo" },
+    { "name": "two-strings", "args": ["foo", "bar"], "want": "foo bar" },
+    { "name": "null-skipped", "args": [null, "foo", null], "want": "foo" },
+    { "name": "empty-skipped", "args": ["", "foo"], "want": "foo" },
+    { "name": "map-truthy", "args": [{"a": true, "b": false, "c": true}], "want": "a c" },
+    { "name": "nested-array", "args": [["x", ["y", "z"]]], "want": "x y z" },
+    { "name": "mixed", "args": ["base", {"on": true}, "trail"], "want": "base on trail" }
+  ]
+}

--- a/packages/sveltego/runtime/svelte/server/testdata/cross/escape_html.json
+++ b/packages/sveltego/runtime/svelte/server/testdata/cross/escape_html.json
@@ -1,0 +1,23 @@
+{
+  "helper": "EscapeHTML",
+  "svelte_version": "5.x",
+  "cases": [
+    { "name": "empty", "in": "", "want": "" },
+    { "name": "plain", "in": "hello", "want": "hello" },
+    { "name": "amp", "in": "a & b", "want": "a &amp; b" },
+    { "name": "lt", "in": "a < b", "want": "a &lt; b" },
+    { "name": "amp-and-lt", "in": "a & b < c", "want": "a &amp; b &lt; c" },
+    { "name": "gt-not-escaped", "in": "a > b", "want": "a > b" },
+    { "name": "quote-not-escaped", "in": "say \"hi\"", "want": "say \"hi\"" },
+    { "name": "apos-not-escaped", "in": "it's", "want": "it's" },
+    { "name": "null", "in": null, "want": "" },
+    { "name": "number", "in": 42, "want": "42" },
+    { "name": "true", "in": true, "want": "true" },
+    { "name": "false", "in": false, "want": "false" },
+    { "name": "many-amps", "in": "&&&", "want": "&amp;&amp;&amp;" },
+    { "name": "trailing-amp", "in": "x&", "want": "x&amp;" },
+    { "name": "leading-amp", "in": "&x", "want": "&amp;x" },
+    { "name": "script-tag", "in": "<script>", "want": "&lt;script>" },
+    { "name": "html-entity", "in": "&amp;", "want": "&amp;amp;" }
+  ]
+}

--- a/packages/sveltego/runtime/svelte/server/testdata/cross/escape_html_attr.json
+++ b/packages/sveltego/runtime/svelte/server/testdata/cross/escape_html_attr.json
@@ -1,0 +1,17 @@
+{
+  "helper": "EscapeHTMLAttr",
+  "svelte_version": "5.x",
+  "cases": [
+    { "name": "empty", "in": "", "want": "" },
+    { "name": "plain", "in": "hello", "want": "hello" },
+    { "name": "amp", "in": "a & b", "want": "a &amp; b" },
+    { "name": "lt", "in": "a < b", "want": "a &lt; b" },
+    { "name": "quote", "in": "say \"hi\"", "want": "say &quot;hi&quot;" },
+    { "name": "all-three", "in": "& < \"", "want": "&amp; &lt; &quot;" },
+    { "name": "gt-not-escaped", "in": "a > b", "want": "a > b" },
+    { "name": "apos-not-escaped", "in": "it's", "want": "it's" },
+    { "name": "null", "in": null, "want": "" },
+    { "name": "double-quotes-only", "in": "\"\"\"", "want": "&quot;&quot;&quot;" },
+    { "name": "json-like", "in": "{\"k\":1}", "want": "{&quot;k&quot;:1}" }
+  ]
+}

--- a/packages/sveltego/runtime/svelte/server/testdata/cross/merge_styles.json
+++ b/packages/sveltego/runtime/svelte/server/testdata/cross/merge_styles.json
@@ -1,0 +1,12 @@
+{
+  "helper": "MergeStyles",
+  "svelte_version": "5.x",
+  "cases": [
+    { "name": "single", "args": ["color: red"], "want": "color: red;" },
+    { "name": "single-with-semi", "args": ["color: red;"], "want": "color: red;" },
+    { "name": "two", "args": ["color: red", "font-size: 12px"], "want": "color: red; font-size: 12px;" },
+    { "name": "trim-trailing-semis", "args": ["color: red;;;"], "want": "color: red;" },
+    { "name": "skip-empty", "args": [null, "color: red", ""], "want": "color: red;" },
+    { "name": "three", "args": ["a:1", "b:2", "c:3"], "want": "a:1; b:2; c:3;" }
+  ]
+}

--- a/packages/sveltego/runtime/svelte/server/testdata/cross/spread_attributes.json
+++ b/packages/sveltego/runtime/svelte/server/testdata/cross/spread_attributes.json
@@ -1,0 +1,14 @@
+{
+  "helper": "SpreadAttributes",
+  "svelte_version": "5.x",
+  "cases": [
+    { "name": "single", "args": [{"id": "main"}], "want": " id=\"main\"" },
+    { "name": "two-sorted", "args": [{"id": "x", "class": "y"}], "want": " class=\"y\" id=\"x\"" },
+    { "name": "drop-on-handler", "args": [{"id": "a", "onclick": "x"}], "want": " id=\"a\"" },
+    { "name": "drop-dollar-internal", "args": [{"id": "a", "$$slots": {}}], "want": " id=\"a\"" },
+    { "name": "boolean-attr-true", "args": [{"disabled": true}], "want": " disabled=\"\"" },
+    { "name": "boolean-attr-false", "args": [{"disabled": false}], "want": "" },
+    { "name": "escape-quotes", "args": [{"title": "a \"b\""}], "want": " title=\"a &quot;b&quot;\"" },
+    { "name": "skip-invalid-name", "args": [{"id": "ok", "bad name": "no"}], "want": " id=\"ok\"" }
+  ]
+}

--- a/packages/sveltego/runtime/svelte/server/testdata/cross/stringify.json
+++ b/packages/sveltego/runtime/svelte/server/testdata/cross/stringify.json
@@ -1,0 +1,15 @@
+{
+  "helper": "Stringify",
+  "svelte_version": "5.x",
+  "cases": [
+    { "name": "null", "in": null, "want": "" },
+    { "name": "empty-string", "in": "", "want": "" },
+    { "name": "string", "in": "hi", "want": "hi" },
+    { "name": "number", "in": 42, "want": "42" },
+    { "name": "negative-number", "in": -7, "want": "-7" },
+    { "name": "zero", "in": 0, "want": "0" },
+    { "name": "float", "in": 3.14, "want": "3.14" },
+    { "name": "true", "in": true, "want": "true" },
+    { "name": "false", "in": false, "want": "false" }
+  ]
+}


### PR DESCRIPTION
## Summary

Phase 4 of the [ADR 0009](../tree/main/tasks/decisions/0009-ssr-option-b.md) Option-B SSR rollout. Adds a new pure-Go package `packages/sveltego/runtime/svelte/server/` that mirrors `svelte/internal/server` helpers — the surface Phase-3-emitted render functions will call. Zero non-stdlib deps, no CGO, no JS engine. Single static binary deploy invariant preserved.

Closes #426. Tracks #422.

## Helpers shipped (~30)

| Helper | Mirrors |
|---|---|
| `Payload` (Out / Head / Title / Push / PushHead / Reset) | `$$payload` shape from Svelte's compiled output |
| `EscapeHTML(v any)` / `EscapeHTMLString(s string)` | `svelte/src/escaping.escape_html(v, false)` (`& <` only — `>` and `'` are NOT escaped, by design) |
| `EscapeHTMLAttr` / `EscapeHTMLAttrString` | `escape_html(v, true)` (`& < "`) |
| `Attr(name, value, isBoolean)` | `svelte/internal/shared/attributes.attr` — `hidden` / `translate` quirks included |
| `Clsx(args...)` | `svelte/internal/shared/attributes.clsx` |
| `ToClass(value, hash, directives)` | `to_class` |
| `ToStyle(value, styles)` | `to_style` (CSS comment stripping, paren / quote-aware split) |
| `MergeStyles(args...)` | compiled-output style merging (semicolon-normalized) |
| `SpreadAttributes(props)` | `svelte/internal/server.attributes` (drops `$$`-keys, `on*`, invalid names; lowercases; sorts deterministically) |
| `Stringify(v)` | `svelte/internal/server.stringify` (JS-style coercion) |
| `Element(p, tag, attrs, children)` | `svelte/internal/server.element` (void / raw-text aware) |
| `Head(p, hash, fn)` | `svelte/internal/server.head` |
| `Slot` / `SlotFn` | `svelte/internal/server.slot` (`children` aliases `default`) |
| `SpreadProps` / `RestProps` / `SanitizeProps` / `SanitizeSlots` | `spread_props` / `rest_props` / `sanitize_props` / `sanitize_slots` |
| `Fallback` / `ExcludeFromObject` / `EnsureArrayLike` | `svelte/internal/shared/utils.*` |
| `IsVoidElement` / `IsRawTextElement` | `svelte/src/utils.is_void` / `is_raw_text_element` |
| `EmptyComment` / `BlockOpen` / `BlockOpenElse` / `BlockClose` | `svelte/internal/server/hydration.js` (`<!---->`, `<!--[-->`, `<!--[!-->`, `<!--]-->`) |

## Cross-check fixtures

`testdata/cross/*.json` carries 70 `(input, expected)` pairs covering EscapeHTML (content + attr), Stringify, Attr, Clsx, MergeStyles, SpreadAttributes — well above the ≥50-pair acceptance bar in #426. Provenance + capture-script discussion in `testdata/cross/README.md`. Loader is `cross_test.go::TestCrossCheckFixtures`.

## Helpers skipped for v1

Documented in `STABILITY.md`. Anything Phase-3 corpus regeneration surfaces as `unknown shape: <symbol>` will trigger a re-evaluation:

- `store_get` / `derived` — Svelte 4 / runes-on-server tar pit, out of scope.
- `bind_props` / `css_props` — legacy two-way binding, `<svelte:options css="injected">`.
- `snapshot` — `$state.snapshot()` deep clone, never emitted on server.
- DEV-only `push_element` / `pop_element` / `validate_*` — release-mode shapes only.
- `{@html}` raw HTML — single helper deferred to first golden hit.

## Verification

- `gofumpt -l . && goimports -l -local github.com/binsarjr/sveltego .` — clean.
- `go vet ./packages/sveltego/runtime/svelte/server/...` — clean.
- `go test -race -count=1 ./packages/sveltego/runtime/svelte/server/...` — **139 tests pass**, race-clean.
- `go build ./...` — module-wide success.
- Smoke bench (M1 Pro):
  ```
  BenchmarkEscapeHTMLPlain-10        45.6 ns/op   0 B/op   0 allocs/op
  BenchmarkEscapeHTMLEscaping-10     85.8 ns/op  48 B/op   1 allocs/op
  BenchmarkEscapeHTMLLong-10        11.6 µs/op  12.3 KB/op  2 allocs/op
  ```
  Plain-string fast path is zero-alloc; the escape path allocates the output builder once. No regression-gate claim (issue #426 marks this as informational).

## Notes for downstream phases

- `Element` does not push an inner `<!---->` between `>` and the children call — Svelte's compiled output emits that marker via the children themselves. Tested for div / br (void) / script (raw-text) / empty-tag dynamic shapes.
- `SpreadAttributes` walks keys in lexicographic order so emitted HTML is byte-stable across runs. Phase 3 emitter and Phase 7 goldens can rely on that.
- `SlotFn` accepts both `server.SlotFn` and the bare `func(*Payload, map[string]any)` literal so codegen can pick whichever shape is convenient.

## Test plan

- [x] Race-detector test pass for the new package.
- [x] 70 cross-check fixtures match (≥50 acceptance bar).
- [x] gofumpt / goimports / go vet clean.
- [x] Module-wide `go build ./...` clean.
- [x] STABILITY.md lists every exported symbol under `## Experimental`.