### PR TITLE
feat(codegen,server): SSR fallback escape hatch via annotation (#430)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ vite.config.gen.js
 **/_page.svelte.d.ts
 **/_layout.svelte.d.ts
 
+# Phase 8 (#430) sidecar fallback runtime cache (compiled SSR modules)
+**/.sveltego-fallback-*/
+
 # Go
 /sveltego
 /sveltego.exe

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -22,11 +22,12 @@ import (
 
 // log attribute keys for sloglint compliance.
 const (
-	logKeyDiagnostic = "diagnostic"
-	logKeyRoutes     = "routes"
-	logKeyManifest   = "manifest"
-	logKeyModule     = "module"
-	logKeyElapsed    = "elapsed"
+	logKeyDiagnostic    = "diagnostic"
+	logKeyRoutes        = "routes"
+	logKeyManifest      = "manifest"
+	logKeyModule        = "module"
+	logKeyElapsed       = "elapsed"
+	logKeyFallbackCount = "fallback_count"
 )
 
 // genFileMode is the permission applied to every file written under
@@ -303,28 +304,32 @@ func Build(ctx context.Context, opts BuildOptions) (*BuildResult, error) {
 		}
 	}
 
-	// RFC #379 / ADR 0009 phase 6: drive the SSR Option-B pipeline.
-	// Pure-Svelte routes that aren't prerendered get a Render(payload,
-	// data) Go file emitted under .gen/usersrc/<encoded-pkg>/ via the
-	// svelte_js2go transpiler. The set of patterns successfully emitted
-	// is threaded into the manifest emitter so the Svelte-mode Page
-	// adapter can bridge the typed Render into router.PageHandler.
-	ssrEmitted, err := runSSRTranspile(ctx, opts.ProjectRoot, outDir, modulePath, logger, scan, routeOptions)
+	// RFC #379 / ADR 0009 phase 6 + phase 8: drive the SSR Option-B
+	// pipeline. Pure-Svelte routes that aren't prerendered and aren't
+	// annotated with `<!-- sveltego:ssr-fallback -->` get a
+	// Render(payload, data) Go file emitted under
+	// .gen/usersrc/<encoded-pkg>/ via the svelte_js2go transpiler.
+	// Annotated routes are returned as Fallback entries so the manifest
+	// can wire the runtime sidecar handler instead. ADR 0009 sub-decision
+	// 2: any non-annotated transpile or lowering failure is a hard
+	// build error.
+	ssrPlan, err := runSSRTranspile(ctx, opts.ProjectRoot, outDir, modulePath, logger, scan, routeOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	hasServiceWorker := serviceWorkerEntry(opts.ProjectRoot) != ""
 	manifestBytes, err := GenerateManifest(scan, ManifestOptions{
-		PackageName:      "gen",
-		ModulePath:       modulePath,
-		GenRoot:          outDir,
-		RouteOptions:     routeOptions,
-		PageHeads:        pageHeads,
-		LayoutHeads:      layoutHeads,
-		ClientKeys:       clientKeysByPkg,
-		HasServiceWorker: hasServiceWorker,
-		SSRRenderRoutes:  ssrEmitted,
+		PackageName:       "gen",
+		ModulePath:        modulePath,
+		GenRoot:           outDir,
+		RouteOptions:      routeOptions,
+		PageHeads:         pageHeads,
+		LayoutHeads:       layoutHeads,
+		ClientKeys:        clientKeysByPkg,
+		HasServiceWorker:  hasServiceWorker,
+		SSRRenderRoutes:   ssrPlan.Transpiled,
+		SSRFallbackRoutes: ssrPlan.Fallback,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("codegen: generate manifest: %w", err)

--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -85,6 +85,12 @@ type ManifestOptions struct {
 	// emitter can route the Page adapter through it. Routes absent
 	// from this map fall back to the legacy SPA shell.
 	SSRRenderRoutes map[string]string
+	// SSRFallbackRoutes is the ordered list of Svelte-mode routes that
+	// declared `<!-- sveltego:ssr-fallback -->` in their _page.svelte
+	// (Phase 8 / #430). The manifest emits one Page handler per entry
+	// that proxies the request to the long-running Node sidecar via the
+	// runtime/svelte/fallback registry.
+	SSRFallbackRoutes []SSRFallbackRoute
 }
 
 // GenerateManifest emits a deterministic, gofmt-clean Go source file
@@ -214,10 +220,15 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	// present. Svelte-mode pages with a Phase 6 SSR Render emit also
 	// emit an adapter (bridging RenderSSR → PageHandler) so they DO
 	// contribute to the hasPage accounting.
+	fallbackByRoute := make(map[string]string, len(opts.SSRFallbackRoutes))
+	for _, fb := range opts.SSRFallbackRoutes {
+		fallbackByRoute[fb.Pattern] = fb.Source
+	}
 	var (
-		hasPage   bool
-		hasSvelte bool
-		ssrRoutes = opts.SSRRenderRoutes
+		hasPage     bool
+		hasSvelte   bool
+		hasFallback = len(fallbackByRoute) > 0
+		ssrRoutes   = opts.SSRRenderRoutes
 	)
 	for _, e := range entries {
 		if !e.route.HasPage {
@@ -225,10 +236,13 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 		}
 		svelteMode := isSvelteRoute(e.route.Pattern, opts.RouteOptions)
 		_, hasSSR := ssrRoutes[e.route.Pattern]
+		_, isFallback := fallbackByRoute[e.route.Pattern]
 		switch {
 		case svelteMode && hasSSR:
 			hasPage = true
 			hasSvelte = true
+		case svelteMode && isFallback:
+			hasPage = true
 		case !svelteMode:
 			hasPage = true
 		}
@@ -302,6 +316,9 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	if hasSvelte {
 		b.Line(`server "github.com/binsarjr/sveltego/packages/sveltego/runtime/svelte/server"`)
 	}
+	if hasFallback {
+		b.Line(`fallback "github.com/binsarjr/sveltego/packages/sveltego/runtime/svelte/fallback"`)
+	}
 	b.Line(`"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"`)
 	if len(imports) > 0 {
 		b.Line("")
@@ -334,6 +351,8 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	// happens inside the adapter so a dispatcher mismatch fails fast
 	// with a descriptive error instead of a panic.
 	emitRenderAdapters(&b, entries, opts.RouteOptions, ssrRoutes)
+	emitFallbackAdapters(&b, entries, opts.RouteOptions, fallbackByRoute)
+	emitFallbackInit(&b, opts.SSRFallbackRoutes)
 	emitHeadAdapters(&b, entries, opts.PageHeads, opts.RouteOptions)
 	emitLayoutAdapters(&b, layoutImports)
 	emitLayoutHeadAdapters(&b, layoutImports)
@@ -356,7 +375,7 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 			errorAliasByPath[ei.pkgPath] = ei.alias
 		}
 		for _, e := range entries {
-			emitRouteEntry(&b, e.route, e.alias, layoutByPath, errorAliasByPath, opts.RouteOptions, opts.PageHeads, opts.ClientKeys, ssrRoutes)
+			emitRouteEntry(&b, e.route, e.alias, layoutByPath, errorAliasByPath, opts.RouteOptions, opts.PageHeads, opts.ClientKeys, ssrRoutes, fallbackByRoute)
 		}
 		b.Dedent()
 		b.Line("}")
@@ -520,6 +539,71 @@ func emitSvelteRenderAdapter(b *Builder, e entry) {
 	b.Line("")
 }
 
+// emitFallbackAdapters writes one `renderFallback__<routeIdent>` Page
+// handler per route annotated with `<!-- sveltego:ssr-fallback -->`.
+// The handler dispatches the (route, data) pair through the
+// runtime/svelte/fallback registry which talks to the long-running
+// Node sidecar over HTTP and caches by `(route, hash(load_result))`.
+// Per ADR 0009 sub-decision 2 these handlers exist only for routes the
+// build-time transpiler intentionally skipped — non-annotated lowering
+// failures are hard build errors.
+func emitFallbackAdapters(b *Builder, entries []entry, routeOptions map[string]kit.PageOptions, fallbackByRoute map[string]string) {
+	if len(fallbackByRoute) == 0 {
+		return
+	}
+	for _, e := range entries {
+		if !e.route.HasPage {
+			continue
+		}
+		if !isSvelteRoute(e.route.Pattern, routeOptions) {
+			continue
+		}
+		if _, ok := fallbackByRoute[e.route.Pattern]; !ok {
+			continue
+		}
+		ident := routeIdent(e.route.Segments)
+		b.Linef("// renderFallback__%s dispatches %s through the long-running sidecar (Phase 8 / #430).", ident, quoteGo(e.route.Pattern))
+		b.Linef("func renderFallback__%s(w *render.Writer, ctx *kit.RenderCtx, data any) error {", ident)
+		b.Indent()
+		b.Line("rctx := ctx.Request.Context()")
+		b.Linef("resp, err := fallback.Default().Render(rctx, %s, data)", quoteGo(e.route.Pattern))
+		b.Line("if err != nil {")
+		b.Indent()
+		b.Line("return err")
+		b.Dedent()
+		b.Line("}")
+		b.Line("if resp.Head != \"\" {")
+		b.Indent()
+		b.Line("w.WriteString(resp.Head)")
+		b.Dedent()
+		b.Line("}")
+		b.Line("w.WriteString(resp.Body)")
+		b.Line("return nil")
+		b.Dedent()
+		b.Line("}")
+		b.Line("")
+	}
+}
+
+// emitFallbackInit writes a package-level init() that registers each
+// fallback route with runtime/svelte/fallback.Default() so a single
+// Configure call from the server boot wires them all to the live
+// Client. The init() is omitted when no routes opt in.
+func emitFallbackInit(b *Builder, fallback []SSRFallbackRoute) {
+	if len(fallback) == 0 {
+		return
+	}
+	b.Line("func init() {")
+	b.Indent()
+	b.Line("r := fallback.Default()")
+	for _, fb := range fallback {
+		b.Linef("r.Register(%s, %s)", quoteGo(fb.Pattern), quoteGo(fb.Source))
+	}
+	b.Dedent()
+	b.Line("}")
+	b.Line("")
+}
+
 // emitLayoutAdapters writes one `render__layout__<alias>` function per
 // unique layout package. Each adapter widens Layout{}.Render's typed
 // LayoutData to the `any`-shaped router.LayoutHandler. Layout packages
@@ -649,13 +733,14 @@ func emitErrorAdapters(b *Builder, imports []errorImport) {
 	}
 }
 
-func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutByPath map[string]layoutImport, errorAliasByPath map[string]string, routeOptions map[string]kit.PageOptions, pageHeads map[string]bool, clientKeys map[string]string, ssrRoutes map[string]string) {
+func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutByPath map[string]layoutImport, errorAliasByPath map[string]string, routeOptions map[string]kit.PageOptions, pageHeads map[string]bool, clientKeys map[string]string, ssrRoutes map[string]string, fallbackByRoute map[string]string) {
 	b.Line("{")
 	b.Indent()
 	b.Linef("Pattern: %s,", quoteGo(r.Pattern))
 	emitSegments(b, r.Segments)
 	svelteMode := isSvelteRoute(r.Pattern, routeOptions)
 	_, hasSSR := ssrRoutes[r.Pattern]
+	_, isFallback := fallbackByRoute[r.Pattern]
 	switch {
 	case r.HasServer:
 		b.Linef("Server: %s.Handlers,", alias)
@@ -672,6 +757,14 @@ func emitRouteEntry(b *Builder, r routescan.ScannedRoute, alias string, layoutBy
 			// PageHandler shape so the existing renderPage path
 			// produces a full HTML body.
 			b.Linef("Page: render__%s,", alias)
+		case isFallback:
+			// Phase 8 (#430): annotated route routes through the
+			// long-running sidecar at request time. The renderFallback
+			// adapter dispatches via the runtime/svelte/fallback
+			// registry. The route ident is used so two routes that
+			// happen to share a package alias still get distinct
+			// handler names.
+			b.Linef("Page: renderFallback__%s,", routeIdent(r.Segments))
 		}
 		if ck := clientKeys[r.PackagePath]; ck != "" {
 			b.Linef("ClientKey: %s,", quoteGo(ck))

--- a/packages/sveltego/internal/codegen/manifest_fallback_test.go
+++ b/packages/sveltego/internal/codegen/manifest_fallback_test.go
@@ -1,0 +1,83 @@
+package codegen
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/routescan"
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
+)
+
+// TestGenerateManifest_FallbackAdapter exercises Phase 8 (#430) wiring:
+// a Svelte-mode route declared as fallback should produce a
+// renderFallback__ adapter, an init() registration, the fallback
+// import, and a Page wire on the route entry.
+func TestGenerateManifest_FallbackAdapter(t *testing.T) {
+	t.Parallel()
+	posts := router.Segment{Kind: router.SegmentStatic, Value: "posts"}
+	id := router.Segment{Kind: router.SegmentParam, Name: "id"}
+	scan := &routescan.ScanResult{
+		Routes: []routescan.ScannedRoute{
+			{
+				Pattern:     "/posts/[id]",
+				Segments:    []router.Segment{posts, id},
+				Dir:         "/tmp/routes/posts/[id]",
+				PackageName: "_id_",
+				PackagePath: ".gen/routes/posts/_id_",
+				HasPage:     true,
+				SSRFallback: true,
+			},
+		},
+	}
+	routeOptions := map[string]kit.PageOptions{
+		"/posts/[id]": {Templates: kit.TemplatesSvelte, SSR: true},
+	}
+	out, err := GenerateManifest(scan, ManifestOptions{
+		PackageName:  "gen",
+		ModulePath:   "myapp",
+		GenRoot:      ".gen",
+		RouteOptions: routeOptions,
+		SSRFallbackRoutes: []SSRFallbackRoute{
+			{Pattern: "/posts/[id]", Source: "src/routes/posts/[id]/_page.svelte"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifest: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		"runtime/svelte/fallback",
+		"renderFallback__PostsId",
+		"fallback.Default()",
+		"r.Register(`/posts/[id]`, `src/routes/posts/[id]/_page.svelte`)",
+		"renderFallback__PostsId,",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in manifest output:\n%s", want, s)
+		}
+	}
+}
+
+// TestGenerateManifest_NoFallbackNoImport ensures the fallback import
+// and init() are omitted when no route opted in. We don't want a stale
+// dependency dragging into builds that don't need it.
+func TestGenerateManifest_NoFallbackNoImport(t *testing.T) {
+	t.Parallel()
+	scan := scanFixture(t, "simple")
+	out, err := GenerateManifest(scan, ManifestOptions{
+		PackageName: "gen",
+		ModulePath:  "myapp",
+		GenRoot:     ".gen",
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifest: %v", err)
+	}
+	if bytes.Contains(out, []byte("runtime/svelte/fallback")) {
+		t.Fatalf("manifest should not import fallback when no route opted in:\n%s", out)
+	}
+	if bytes.Contains(out, []byte("renderFallback__")) {
+		t.Fatalf("manifest should not emit fallback adapter when no route opted in")
+	}
+}

--- a/packages/sveltego/internal/codegen/ssr.go
+++ b/packages/sveltego/internal/codegen/ssr.go
@@ -27,41 +27,60 @@ type ssrPlan struct {
 	shape typegen.Shape
 }
 
-// runSSRTranspile drives the Phase 6 (#428) SSR codegen pipeline:
-// detect Svelte routes that need SSR, run the Node sidecar in SSR mode
-// once for the entire batch, and emit one Render(payload, data) Go
-// file per route under .gen/usersrc/<encoded-pkg>/page_render.gen.go.
+// SSRPlanResult is the outcome of the Phase 6/8 SSR planner. Transpiled
+// holds routes that received a build-time JS→Go Render emit and the
+// encoded subpath where it lives (consumed by manifest emission).
+// Fallback holds routes that explicitly opted out via the
+// `<!-- sveltego:ssr-fallback -->` comment; those route through the
+// long-running Node sidecar at request time (Phase 8, #430).
+type SSRPlanResult struct {
+	Transpiled map[string]string
+	Fallback   []SSRFallbackRoute
+}
+
+// SSRFallbackRoute names one route the runtime must dispatch to the
+// long-running sidecar. Pattern is the canonical request path; Source
+// is the project-relative path to the route's `_page.svelte` so the
+// sidecar can compile and render at request time.
+type SSRFallbackRoute struct {
+	Pattern string
+	Source  string
+}
+
+// runSSRTranspile drives the Phase 6 (#428) + Phase 8 (#430) SSR codegen
+// pipeline:
 //
-// Returns the set of route patterns that successfully received an SSR
-// Render emit. The manifest emitter consumes this set to decide which
-// routes wire the typed Page render adapter (vs falling through to the
-// legacy SPA shell).
-//
-// Node-missing is treated as a soft fallback: the function logs a
-// warning via the build's logger and returns nil, so the pipeline
-// continues to ship SPA-mode shells. This keeps `sveltego build`
-// usable on hosts without Node while the deploy adapters and v0.6
-// auth track land. ADR 0009 mandates a hard error for unrecognised
-// emit shapes; that path runs inside Transpile/Lowerer once Node is
-// available.
-func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string, logger *slog.Logger, scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions) (map[string]string, error) {
-	plan := planSSR(scan, routeOptions)
-	if len(plan) == 0 {
-		return nil, nil
+//   - Pure-Svelte routes that are not prerendered, declare SSR=true, and
+//     own a sibling `_page.server.go` with a non-empty PageData are
+//     transpiled to Go via `internal/codegen/svelte_js2go/`. The Render
+//     function lands at `.gen/usersrc/<encoded-pkg>/page_render.gen.go`.
+//   - Routes that declare `<!-- sveltego:ssr-fallback -->` skip the
+//     transpiler and are returned as Fallback entries; the runtime
+//     proxies them to a long-running Node sidecar with a per-route
+//     cache (Phase 8).
+//   - Any other transpiler or lowerer failure is a hard build error
+//     (ADR 0009 sub-decision 2). Operators must either fix the source
+//     or annotate the route to opt into the sidecar fallback.
+func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string, logger *slog.Logger, scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions) (SSRPlanResult, error) {
+	transpilePlan, fallback := planSSR(scan, routeOptions)
+	result := SSRPlanResult{Fallback: fallback}
+	if len(transpilePlan) == 0 && len(fallback) == 0 {
+		return result, nil
 	}
-	// Probe Node up front so a missing toolchain logs once per build,
-	// not once per route.
+	if len(transpilePlan) == 0 {
+		logger.Info("ssr fallback only: no routes transpiled to Go",
+			logKeyFallbackCount, len(fallback))
+		return result, nil
+	}
 	if _, err := svelterender.EnsureNode(); err != nil {
-		logger.Warn("ssr codegen skipped: node binary not on $PATH; routes will fall back to SPA shell",
-			logKeyDiagnostic, err.Error())
-		return nil, nil
+		return result, fmt.Errorf("codegen: ssr requires node 18+ on $PATH (or annotate routes with <!-- sveltego:ssr-fallback --> if they intentionally bypass the transpiler): %w", err)
 	}
 
-	jobs := make([]svelterender.SSRJob, 0, len(plan))
-	for _, p := range plan {
+	jobs := make([]svelterender.SSRJob, 0, len(transpilePlan))
+	for _, p := range transpilePlan {
 		rel, err := filepath.Rel(projectRoot, filepath.Join(p.route.Dir, "_page.svelte"))
 		if err != nil {
-			return nil, fmt.Errorf("codegen: ssr rel path: %w", err)
+			return result, fmt.Errorf("codegen: ssr rel path: %w", err)
 		}
 		jobs = append(jobs, svelterender.SSRJob{
 			Route:  p.route.Pattern,
@@ -76,33 +95,23 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 		Jobs:   jobs,
 	})
 	if err != nil {
-		// Sidecar-deps-missing or sidecar-source-tree-missing are
-		// build-host configuration errors; treat them as the same
-		// soft-fallback as Node-missing so the build completes and
-		// each route serves the SPA shell. Operators see the warning
-		// and can run `npm install` in the sidecar tree.
-		logger.Warn("ssr ast skipped; routes fall back to SPA shell",
-			logKeyDiagnostic, err.Error())
-		return nil, nil
+		return result, fmt.Errorf("codegen: ssr ast: %w", err)
 	}
 	resultsByRoute := make(map[string]string, len(results))
 	for _, r := range results {
 		resultsByRoute[r.Route] = r.Output
 	}
 
-	// Track which encoded package directories already received the
-	// CompanionFile so we drop it once per package, not once per route
-	// in that package.
 	companionDropped := make(map[string]struct{})
-	emitted := make(map[string]string, len(plan))
-	for _, p := range plan {
+	emitted := make(map[string]string, len(transpilePlan))
+	for _, p := range transpilePlan {
 		astPath, ok := resultsByRoute[p.route.Pattern]
 		if !ok {
-			return nil, fmt.Errorf("codegen: ssr ast missing for route %s", p.route.Pattern)
+			return result, fmt.Errorf("codegen: ssr ast missing for route %s", p.route.Pattern)
 		}
 		envelope, err := os.ReadFile(astPath) //nolint:gosec // path is sidecar-emitted under .gen
 		if err != nil {
-			return nil, fmt.Errorf("codegen: read ssr ast %s: %w", astPath, err)
+			return result, fmt.Errorf("codegen: read ssr ast %s: %w", astPath, err)
 		}
 
 		typedParam := p.shape.RootType
@@ -112,13 +121,9 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 		})
 
 		encodedSub := strings.TrimPrefix(p.route.PackagePath, ".gen/")
-		// SSR Render lives in the same usersrc package as the user's
-		// PageData declaration. That package is the typegen shape's
-		// declaration site, which keeps the typed parameter resolvable
-		// without re-export.
 		pkgDir := filepath.Join(projectRoot, outDir, "usersrc", filepath.FromSlash(encodedSub))
 		if err := os.MkdirAll(pkgDir, 0o755); err != nil {
-			return nil, fmt.Errorf("codegen: mkdir %s: %w", pkgDir, err)
+			return result, fmt.Errorf("codegen: mkdir %s: %w", pkgDir, err)
 		}
 
 		out, err := sveltejs2go.Transpile(envelope, sveltejs2go.Options{
@@ -128,40 +133,26 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 			TypedDataParam: typedParam,
 		})
 		if err != nil {
-			// Phase 8 (#430) lands the explicit `// sveltego:ssr-fallback`
-			// opt-out so routes the transpiler cannot lower can route
-			// through the long-running sidecar at request time. Until
-			// then, treat unknown shapes as a soft fallback: log the
-			// failure and let the route serve the SPA shell. Hard-error
-			// remains the goal once Phase 8 ships and the corpus is
-			// validated against Phase 5's coverage.
-			logger.Warn("ssr codegen skipped; route falls back to SPA shell",
-				logKeyDiagnostic, fmt.Sprintf("route=%s err=%v", p.route.Pattern, err))
-			continue
+			return result, fmt.Errorf("codegen: ssr transpile %s: %w (annotate the route with <!-- sveltego:ssr-fallback --> to opt into the sidecar fallback)", p.route.Pattern, err)
 		}
 		if lerr := lowerer.Err(); lerr != nil {
-			logger.Warn("ssr lowering skipped; route falls back to SPA shell",
-				logKeyDiagnostic, fmt.Sprintf("route=%s err=%v", p.route.Pattern, lerr))
-			continue
+			return result, fmt.Errorf("codegen: ssr lowering %s: %w", p.route.Pattern, lerr)
 		}
 
 		target := filepath.Join(pkgDir, "page_render.gen.go")
 		if err := os.WriteFile(target, out, genFileMode); err != nil {
-			return nil, fmt.Errorf("codegen: write %s: %w", target, err)
+			return result, fmt.Errorf("codegen: write %s: %w", target, err)
 		}
 
 		if _, done := companionDropped[pkgDir]; !done {
 			companion := sveltejs2go.CompanionFile(p.route.PackageName)
 			compPath := filepath.Join(pkgDir, "ssr_companion.gen.go")
 			if err := os.WriteFile(compPath, companion, genFileMode); err != nil {
-				return nil, fmt.Errorf("codegen: write %s: %w", compPath, err)
+				return result, fmt.Errorf("codegen: write %s: %w", compPath, err)
 			}
 			companionDropped[pkgDir] = struct{}{}
 		}
 
-		// Drop a wire bridge in the gen-side route package that wraps
-		// the typed Render into a data-erased adapter the manifest can
-		// reference. This is the per-route SSR analogue of emitWire.
 		wireDir := filepath.Join(projectRoot, outDir, filepath.FromSlash(encodedSub))
 		if err := emitSSRWire(outDir, modulePath, mirrorRoute{
 			encodedSubpath: encodedSub,
@@ -169,30 +160,34 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 			wireDir:        wireDir,
 			hasSSRRender:   true,
 		}); err != nil {
-			return nil, err
+			return result, err
 		}
 
 		emitted[p.route.Pattern] = encodedSub
 	}
-	return emitted, nil
+	result.Transpiled = emitted
+	return result, nil
 }
 
-// planSSR filters routescan.Routes to the subset that needs Phase 6 SSR
-// codegen: pure-Svelte page routes that are NOT prerendered, NOT
-// SSR-disabled, AND own a sibling _page.server.go. The PageServer
-// constraint is the typed-data-receipt invariant from Phase 5 (#427)
-// — without it the typegen Shape is empty and the Lowerer cannot map
-// the JS member chain onto Go fields. Routes without _page.server.go
-// continue to render via the SPA shell until either the user adds a
-// Load() or Phase 8 (#430) sidecar fallback lands.
+// planSSR partitions routescan.Routes into the build-time transpile
+// plan and the request-time sidecar fallback plan.
 //
-// Routes opted into // sveltego:ssr-fallback (Phase 8) are excluded
-// here once that comment is recognised; for now every qualifying
-// Svelte page route is in scope.
-func planSSR(scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions) []ssrPlan {
-	out := make([]ssrPlan, 0, len(scan.Routes))
+// Transpile plan: pure-Svelte page routes that are NOT prerendered, NOT
+// SSR-disabled, NOT annotated with `<!-- sveltego:ssr-fallback -->`,
+// AND own a sibling `_page.server.go` with at least one PageData field.
+// The PageServer constraint is the typed-data-receipt invariant from
+// Phase 5 (#427); without it the typegen Shape is empty and the Lowerer
+// cannot map the JS member chain onto Go fields.
+//
+// Fallback plan: any pure-Svelte page route that declares the
+// `<!-- sveltego:ssr-fallback -->` annotation. The annotation overrides
+// the transpile path even when the route would otherwise qualify; this
+// is the explicit escape hatch for shapes the transpiler cannot lower.
+func planSSR(scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions) ([]ssrPlan, []SSRFallbackRoute) {
+	plans := make([]ssrPlan, 0, len(scan.Routes))
+	fallback := make([]SSRFallbackRoute, 0)
 	for _, r := range scan.Routes {
-		if !r.HasPage || !r.HasPageServer {
+		if !r.HasPage {
 			continue
 		}
 		opts, ok := routeOptions[r.Pattern]
@@ -209,24 +204,27 @@ func planSSR(scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions
 			continue
 		}
 
-		shape, _, err := typegen.BuildShape(filepath.Join(r.Dir, "_page.server.go"), typegen.KindPage)
-		if err != nil {
-			// Failure to read the typed shape is a recoverable case:
-			// the route still renders via the SPA shell. Don't fail
-			// the build for this — a missing PageData type just means
-			// the user has not declared one and the route's data is
-			// untyped.
-			continue
-		}
-		if len(shape.Types) == 0 || len(shape.Types[shape.RootType].Fields) == 0 {
-			// No PageData fields → typed receipt is `struct{}` which
-			// the .svelte template typically doesn't reference. Skip
-			// SSR for these until the user populates Load(); the SPA
-			// shell still renders.
+		if r.SSRFallback {
+			fallback = append(fallback, SSRFallbackRoute{
+				Pattern: r.Pattern,
+				Source:  filepath.ToSlash(filepath.Join(r.Dir, "_page.svelte")),
+			})
 			continue
 		}
 
-		out = append(out, ssrPlan{route: r, shape: shape})
+		if !r.HasPageServer {
+			continue
+		}
+
+		shape, _, err := typegen.BuildShape(filepath.Join(r.Dir, "_page.server.go"), typegen.KindPage)
+		if err != nil {
+			continue
+		}
+		if len(shape.Types) == 0 || len(shape.Types[shape.RootType].Fields) == 0 {
+			continue
+		}
+
+		plans = append(plans, ssrPlan{route: r, shape: shape})
 	}
-	return out
+	return plans, fallback
 }

--- a/packages/sveltego/internal/codegen/ssr_test.go
+++ b/packages/sveltego/internal/codegen/ssr_test.go
@@ -1,0 +1,84 @@
+package codegen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/routescan"
+)
+
+// TestPlanSSRPartitionsAnnotated exercises the Phase 8 (#430) split:
+// annotated routes land on the fallback list and skip the transpile
+// plan even when they have a sibling _page.server.go that would
+// otherwise qualify.
+func TestPlanSSRPartitionsAnnotated(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("src/routes/_page.svelte", "<h1>home</h1>")
+	mustWrite("src/routes/_page.server.go", `package routes
+
+type PageData struct{ Name string `+"`json:\"name\"`"+` }
+
+func Load(ctx any) (PageData, error) { return PageData{}, nil }
+`)
+	mustWrite("src/routes/posts/[id]/_page.svelte", `<!-- sveltego:ssr-fallback -->
+<h1>post</h1>`)
+	mustWrite("src/routes/posts/[id]/_page.server.go", `package id
+
+type PageData struct{ Title string `+"`json:\"title\"`"+` }
+
+func Load(ctx any) (PageData, error) { return PageData{}, nil }
+`)
+
+	scan, err := routescan.Scan(routescan.ScanInput{RoutesDir: filepath.Join(root, "src", "routes")})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	routeOptions := map[string]kit.PageOptions{
+		"/":           mkSvelteOpts(),
+		"/posts/[id]": mkSvelteOpts(),
+	}
+
+	plans, fallback := planSSR(scan, routeOptions)
+	if got, want := len(fallback), 1; got != want {
+		t.Fatalf("fallback count = %d, want %d", got, want)
+	}
+	if fallback[0].Pattern != "/posts/[id]" {
+		t.Fatalf("fallback[0].Pattern = %q, want /posts/[id]", fallback[0].Pattern)
+	}
+	for _, p := range plans {
+		if p.route.Pattern == "/posts/[id]" {
+			t.Fatalf("annotated route should not appear in transpile plan")
+		}
+	}
+	// The root route has no SSRFallback annotation; it should be in the
+	// transpile plan since it has a non-empty PageData.
+	foundRoot := false
+	for _, p := range plans {
+		if p.route.Pattern == "/" {
+			foundRoot = true
+		}
+	}
+	if !foundRoot {
+		t.Fatalf("root route should appear in transpile plan")
+	}
+}
+
+func mkSvelteOpts() kit.PageOptions {
+	o := kit.DefaultPageOptions()
+	o.Templates = kit.TemplatesSvelte
+	return o
+}

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/index.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/index.mjs
@@ -1,19 +1,25 @@
-// Build-time Node sidecar entry point. Two modes:
+// Build-time Node sidecar entry point. Three modes:
 //
-//   --mode=ssg  prerender pure-Svelte routes to static HTML (ADR 0008).
-//   --mode=ssr  compile each route via svelte/compiler generate:'server'
-//               then parse the resulting JS via Acorn and write the
-//               ESTree JSON AST to .gen/svelte_js2go/<route>/ast.json
-//               (ADR 0009, RFC #421).
+//   --mode=ssg        prerender pure-Svelte routes to static HTML (ADR 0008).
+//   --mode=ssr        compile each route via svelte/compiler generate:'server'
+//                     then parse the resulting JS via Acorn and write the
+//                     ESTree JSON AST to .gen/svelte_js2go/<route>/ast.json
+//                     (ADR 0009, RFC #421).
+//   --mode=ssr-serve  long-running HTTP server that renders Svelte routes
+//                     on demand. Used by Go's runtime/svelte/fallback for
+//                     routes annotated with `<!-- sveltego:ssr-fallback -->`
+//                     (ADR 0009 sub-decision 2 / Phase 8 #430).
 //
-// The sidecar is build-time-only. Production deploys ship the Go binary
-// plus static/ — never this script.
+// Build-time modes (ssg / ssr) are one-shot. ssr-serve is the only
+// long-running mode; the deployed Go binary plus static/ remains the
+// production deployable.
 
 import { runSSG } from "./ssg.mjs";
 import { runSSR } from "./ssr.mjs";
+import { runSSRServe } from "./ssr_serve.mjs";
 
 function parseArgs(argv) {
-	const args = { mode: "", manifest: "", out: "", root: "" };
+	const args = { mode: "", manifest: "", out: "", root: "", port: "" };
 	for (const raw of argv.slice(2)) {
 		const eq = raw.indexOf("=");
 		if (eq < 0) continue;
@@ -32,6 +38,9 @@ function parseArgs(argv) {
 			case "--root":
 				args.root = val;
 				break;
+			case "--port":
+				args.port = val;
+				break;
 		}
 	}
 	return args;
@@ -41,7 +50,7 @@ async function main() {
 	const args = parseArgs(process.argv);
 	if (!args.mode) {
 		process.stderr.write(
-			"svelterender-sidecar: --mode=ssg|ssr is required\n",
+			"svelterender-sidecar: --mode=ssg|ssr|ssr-serve is required\n",
 		);
 		process.exit(2);
 	}
@@ -52,9 +61,12 @@ async function main() {
 		case "ssr":
 			await runSSR(args);
 			return;
+		case "ssr-serve":
+			await runSSRServe(args);
+			return;
 		default:
 			process.stderr.write(
-				`svelterender-sidecar: unknown --mode=${args.mode} (want ssg or ssr)\n`,
+				`svelterender-sidecar: unknown --mode=${args.mode} (want ssg, ssr, or ssr-serve)\n`,
 			);
 			process.exit(2);
 	}

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/ssr_serve.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/ssr_serve.mjs
@@ -1,0 +1,169 @@
+// ssr-serve mode: long-running HTTP server that renders Svelte routes
+// on demand. Each request body is JSON of the form:
+//
+//   { "route": "/posts/[id]", "source": "src/routes/posts/[id]/_page.svelte",
+//     "data": { /* page data */ } }
+//
+// The server compiles the .svelte source via svelte/compiler in
+// generate:'server' mode (cached per source path so subsequent
+// requests reuse the compiled module), evaluates the resulting code
+// in a Node `vm` sandbox to obtain the render function, then invokes
+// it with a $$payload mock and the supplied data as `$$props`.
+// Response body:
+//
+//   { "body": "<rendered html>", "head": "<head html>" }
+//
+// Errors return HTTP 500 with `{ "error": "..." }`. The server prints
+// `SVELTEGO_SSR_FALLBACK_LISTEN port=NNN` on stderr after binding so
+// the Go supervisor can parse the address. The OS picks the port (we
+// pass 0) unless --port=NNN is provided for tests.
+
+import { createServer } from "node:http";
+import { readFile, writeFile, mkdtemp, rm } from "node:fs/promises";
+import { isAbsolute, resolve as resolvePath, join as joinPath, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render as svelteRender } from "svelte/server";
+
+const compiledCache = new Map();
+let cacheDir = null;
+const sidecarDir = dirname(fileURLToPath(import.meta.url));
+
+async function ensureCacheDir() {
+	if (cacheDir) return cacheDir;
+	// Place the cache dir inside the sidecar tree so Node's module
+	// resolver can walk up to the sidecar's node_modules to find
+	// `svelte`. Compiled SSR modules import `svelte/internal/server`;
+	// putting the cache under /tmp would fail the resolution.
+	cacheDir = await mkdtemp(joinPath(sidecarDir, ".sveltego-fallback-"));
+	process.on("exit", () => {
+		rm(cacheDir, { recursive: true, force: true }).catch(() => {});
+	});
+	return cacheDir;
+}
+
+async function loadComponent(root, source) {
+	const absolute = isAbsolute(source) ? source : resolvePath(root, source);
+	if (compiledCache.has(absolute)) {
+		return compiledCache.get(absolute);
+	}
+	const src = await readFile(absolute, "utf8");
+	const result = compile(src, {
+		generate: "server",
+		filename: absolute,
+		dev: false,
+		hmr: false,
+	});
+	if (!result || typeof result.js?.code !== "string") {
+		throw new Error(`svelte/compiler produced no js.code for ${source}`);
+	}
+	const dir = await ensureCacheDir();
+	const safe = absolute.replace(/[^a-zA-Z0-9_]/g, "_");
+	const modPath = joinPath(dir, `${safe}.mjs`);
+	await writeFile(modPath, result.js.code, "utf8");
+	const url = pathToFileURL(modPath).href;
+	const mod = await import(url);
+	const fn = mod.default;
+	if (typeof fn !== "function") {
+		throw new Error(`compiled component ${source} did not export a default function`);
+	}
+	compiledCache.set(absolute, fn);
+	return fn;
+}
+
+function readJSONBody(req) {
+	return new Promise((resolveBody, rejectBody) => {
+		const chunks = [];
+		let total = 0;
+		const limit = 1 << 22; // 4 MiB cap; load payloads should never approach this
+		req.on("data", (chunk) => {
+			total += chunk.length;
+			if (total > limit) {
+				rejectBody(new Error(`request body too large (>${limit} bytes)`));
+				req.destroy();
+				return;
+			}
+			chunks.push(chunk);
+		});
+		req.on("end", () => {
+			try {
+				const raw = Buffer.concat(chunks).toString("utf8");
+				resolveBody(raw ? JSON.parse(raw) : {});
+			} catch (err) {
+				rejectBody(err);
+			}
+		});
+		req.on("error", rejectBody);
+	});
+}
+
+async function handleRender(req, res, root) {
+	let parsed;
+	try {
+		parsed = await readJSONBody(req);
+	} catch (err) {
+		res.writeHead(400, { "content-type": "application/json" });
+		res.end(JSON.stringify({ error: String(err.message || err) }));
+		return;
+	}
+	const { route, source, data } = parsed;
+	if (typeof route !== "string" || typeof source !== "string") {
+		res.writeHead(400, { "content-type": "application/json" });
+		res.end(JSON.stringify({ error: "request missing route or source" }));
+		return;
+	}
+	try {
+		const fn = await loadComponent(root, source);
+		const result = svelteRender(fn, { props: { data: data ?? null } });
+		const payload = JSON.stringify({
+			body: result.body || "",
+			head: result.head || "",
+		});
+		res.writeHead(200, { "content-type": "application/json" });
+		res.end(payload);
+	} catch (err) {
+		process.stderr.write(`ssr-serve render ${route} (${source}): ${err && err.stack ? err.stack : err}\n`);
+		if (!res.headersSent) {
+			res.writeHead(500, { "content-type": "application/json" });
+		}
+		res.end(JSON.stringify({ error: String(err.message || err) }));
+	}
+}
+
+export async function runSSRServe(args) {
+	const root = resolvePath(args.root || process.cwd());
+	const port = args.port ? Number.parseInt(args.port, 10) : 0;
+
+	const server = createServer(async (req, res) => {
+		if (req.method === "POST" && req.url === "/render") {
+			await handleRender(req, res, root);
+			return;
+		}
+		if (req.method === "GET" && req.url === "/healthz") {
+			res.writeHead(200, { "content-type": "text/plain" });
+			res.end("ok");
+			return;
+		}
+		res.writeHead(404, { "content-type": "text/plain" });
+		res.end("not found");
+	});
+
+	await new Promise((resolveListen, rejectListen) => {
+		server.once("error", rejectListen);
+		server.listen(port, "127.0.0.1", () => {
+			const addr = server.address();
+			process.stderr.write(`SVELTEGO_SSR_FALLBACK_LISTEN port=${addr.port}\n`);
+			resolveListen(undefined);
+		});
+	});
+
+	const shutdown = (signal) => {
+		process.stderr.write(`ssr-serve: ${signal} received, shutting down\n`);
+		server.close(() => process.exit(0));
+		setTimeout(() => process.exit(0), 5000).unref();
+	};
+	process.on("SIGTERM", () => shutdown("SIGTERM"));
+	process.on("SIGINT", () => shutdown("SIGINT"));
+
+	await new Promise(() => {});
+}

--- a/packages/sveltego/internal/routescan/route.go
+++ b/packages/sveltego/internal/routescan/route.go
@@ -54,6 +54,11 @@ type ScannedRoute struct {
 	// boundary's directory wrap the error template; layouts strictly
 	// below the boundary abort. Zero when no boundary applies.
 	ErrorBoundaryLayoutDepth int
+	// SSRFallback is true when the route's `_page.svelte` declares
+	// `<!-- sveltego:ssr-fallback -->`. Annotated routes opt out of the
+	// build-time JS→Go transpiler (ADR 0009) and route through the
+	// long-running Node sidecar at request time (Phase 8, #430).
+	SSRFallback bool
 }
 
 // DiscoveredMatcher names a Go file under src/params/ that exports

--- a/packages/sveltego/internal/routescan/scan.go
+++ b/packages/sveltego/internal/routescan/scan.go
@@ -261,6 +261,15 @@ func buildRoute(routesDir, dir string, files map[string]struct{}, dirsWithLayout
 		}
 	}
 
+	hasPage := has(files, "_page.svelte")
+	ssrFallback := false
+	if hasPage {
+		fb, fbErr := detectSSRFallbackAnnotation(filepath.Join(dir, "_page.svelte"))
+		if fbErr != nil {
+			diagnostics = append(diagnostics, Diagnostic{Path: dir, Message: fbErr.Error()})
+		}
+		ssrFallback = fb
+	}
 	route := &ScannedRoute{
 		Pattern:            pattern,
 		Segments:           segments,
@@ -270,7 +279,7 @@ func buildRoute(routesDir, dir string, files map[string]struct{}, dirsWithLayout
 		LayoutChain:        chain,
 		LayoutPackagePaths: chainPkgs,
 		LayoutServerFiles:  chainServers,
-		HasPage:            has(files, "_page.svelte"),
+		HasPage:            hasPage,
 		HasLayout:          has(files, "_layout.svelte"),
 		HasError:           has(files, "_error.svelte"),
 		HasReset:           hasReset,
@@ -278,6 +287,7 @@ func buildRoute(routesDir, dir string, files map[string]struct{}, dirsWithLayout
 		HasPageServer:      has(files, "_page.server.go"),
 		HasLayoutServer:    has(files, "_layout.server.go"),
 		HasServer:          has(files, "_server.go"),
+		SSRFallback:        ssrFallback,
 	}
 	if boundaryDir := nearestErrorDir(routesDir, dir, dirsWithError); boundaryDir != "" {
 		pkgPath, encErr := encodeLayoutPackagePath(routesDir, boundaryDir)

--- a/packages/sveltego/internal/routescan/ssr_fallback.go
+++ b/packages/sveltego/internal/routescan/ssr_fallback.go
@@ -1,0 +1,64 @@
+package routescan
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+// ssrFallbackMarker is the HTML comment a route's _page.svelte uses to
+// opt out of the build-time JS→Go SSR transpiler and route through the
+// long-running Node sidecar at request time. Detection is byte-level,
+// not Svelte-AST-level, so the comment lands in the same scan pass that
+// reads the file's existence; the transpile pipeline then skips
+// annotated routes entirely (ADR 0009 sub-decision 2 / Phase 8 #430).
+//
+// Whitespace inside the comment is permissive: any combination of
+// spaces or tabs around the marker text is accepted, but the comment
+// must use the literal `<!-- ... -->` form so it survives Vite's
+// downstream tooling.
+const ssrFallbackMarker = "sveltego:ssr-fallback"
+
+// detectSSRFallbackAnnotation reads source and reports whether it
+// contains an HTML comment matching `<!-- sveltego:ssr-fallback -->`.
+// A read error is surfaced verbatim — callers turn it into a scan
+// diagnostic so the user sees the path that failed.
+//
+// The scanner reads each `_page.svelte` once during route discovery;
+// scaling cost is one OS open + slurp per route, identical in shape to
+// the existing route walk's filesystem touches.
+func detectSSRFallbackAnnotation(path string) (bool, error) {
+	src, err := os.ReadFile(path) //nolint:gosec // path is from filepath.WalkDir over user routes dir
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	return hasSSRFallbackMarker(src), nil
+}
+
+// hasSSRFallbackMarker scans src for any HTML comment whose body, after
+// trimming spaces and tabs, equals ssrFallbackMarker. Returns false
+// when no such comment exists, including the case where the marker
+// text appears outside an HTML comment (e.g. inside a string literal
+// in <script>).
+func hasSSRFallbackMarker(src []byte) bool {
+	openTag := []byte("<!--")
+	closeTag := []byte("-->")
+	for {
+		i := bytes.Index(src, openTag)
+		if i < 0 {
+			return false
+		}
+		rest := src[i+len(openTag):]
+		j := bytes.Index(rest, closeTag)
+		if j < 0 {
+			return false
+		}
+		body := bytes.TrimFunc(rest[:j], func(r rune) bool {
+			return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+		})
+		if bytes.Equal(body, []byte(ssrFallbackMarker)) {
+			return true
+		}
+		src = rest[j+len(closeTag):]
+	}
+}

--- a/packages/sveltego/internal/routescan/ssr_fallback_test.go
+++ b/packages/sveltego/internal/routescan/ssr_fallback_test.go
@@ -1,0 +1,72 @@
+package routescan
+
+import "testing"
+
+func TestHasSSRFallbackMarker(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "exact marker",
+			src:  "<!-- sveltego:ssr-fallback -->\n<h1>hello</h1>",
+			want: true,
+		},
+		{
+			name: "extra whitespace",
+			src:  "<!--   sveltego:ssr-fallback\t-->",
+			want: true,
+		},
+		{
+			name: "leading and trailing newlines inside comment",
+			src:  "<!--\n  sveltego:ssr-fallback\n-->",
+			want: true,
+		},
+		{
+			name: "later in file",
+			src:  "<script>let x = 1;</script>\n<!-- sveltego:ssr-fallback -->\n<h1>hi</h1>",
+			want: true,
+		},
+		{
+			name: "marker in string literal not a comment",
+			src:  `<script>const s = "sveltego:ssr-fallback";</script>`,
+			want: false,
+		},
+		{
+			name: "extra text inside comment is not a match",
+			src:  "<!-- sveltego:ssr-fallback please -->",
+			want: false,
+		},
+		{
+			name: "no comment at all",
+			src:  "<h1>hello</h1>",
+			want: false,
+		},
+		{
+			name: "different marker name",
+			src:  "<!-- sveltego:other -->",
+			want: false,
+		},
+		{
+			name: "unterminated comment",
+			src:  "<!-- sveltego:ssr-fallback",
+			want: false,
+		},
+		{
+			name: "second comment wins after a non-match",
+			src:  "<!-- not us -->\n<!-- sveltego:ssr-fallback -->",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := hasSSRFallbackMarker([]byte(tc.src))
+			if got != tc.want {
+				t.Fatalf("hasSSRFallbackMarker(%q) = %v, want %v", tc.src, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/sveltego/runtime/svelte/fallback/cache.go
+++ b/packages/sveltego/runtime/svelte/fallback/cache.go
@@ -1,0 +1,110 @@
+package fallback
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// cacheEntry stores one rendered fallback response. body and head are
+// the sidecar's output for the request; expires marks the wall-clock
+// instant the entry should be evicted.
+type cacheEntry struct {
+	body    string
+	head    string
+	expires time.Time
+}
+
+// lruCache is a fixed-capacity, TTL-bounded LRU. Values are looked up
+// by an opaque string key composed of `(route, hash(load_result))` —
+// the caller decides what hash function suits the data shape; this
+// cache only sees the resulting key. Two locks would over-engineer
+// the access pattern; one mutex is enough because every operation
+// already touches both the hash map and the doubly-linked recency list.
+//
+// The cache is intentionally simple: no metrics, no admission policy,
+// no probabilistic TTL. The fallback path is itself a tail case (only
+// annotated routes hit it); the cost we are paying down here is the
+// sidecar round-trip, not steady-state contention.
+type lruCache struct {
+	mu       sync.Mutex
+	capacity int
+	ttl      time.Duration
+	items    map[string]*list.Element
+	order    *list.List
+	now      func() time.Time
+}
+
+// listValue couples the cache key with the entry so List eviction has
+// access to the key without a reverse map.
+type listValue struct {
+	key   string
+	entry cacheEntry
+}
+
+func newLRUCache(capacity int, ttl time.Duration) *lruCache {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &lruCache{
+		capacity: capacity,
+		ttl:      ttl,
+		items:    make(map[string]*list.Element, capacity),
+		order:    list.New(),
+		now:      time.Now,
+	}
+}
+
+// Get returns the cached entry for key when it exists and has not
+// expired. Hits move the entry to the MRU end. Expired entries are
+// evicted on lookup so the next miss has room.
+func (c *lruCache) Get(key string) (cacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[key]
+	if !ok {
+		return cacheEntry{}, false
+	}
+	v := el.Value.(*listValue)
+	if c.ttl > 0 && c.now().After(v.entry.expires) {
+		c.order.Remove(el)
+		delete(c.items, key)
+		return cacheEntry{}, false
+	}
+	c.order.MoveToFront(el)
+	return v.entry, true
+}
+
+// Put inserts or refreshes the entry for key. When at capacity the
+// least-recently-used entry is evicted.
+func (c *lruCache) Put(key string, entry cacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.ttl > 0 {
+		entry.expires = c.now().Add(c.ttl)
+	}
+	if el, ok := c.items[key]; ok {
+		el.Value.(*listValue).entry = entry
+		c.order.MoveToFront(el)
+		return
+	}
+	for c.order.Len() >= c.capacity {
+		oldest := c.order.Back()
+		if oldest == nil {
+			break
+		}
+		ov := oldest.Value.(*listValue)
+		c.order.Remove(oldest)
+		delete(c.items, ov.key)
+	}
+	el := c.order.PushFront(&listValue{key: key, entry: entry})
+	c.items[key] = el
+}
+
+// Len reports the current number of cached entries (including expired
+// ones not yet evicted by a Get). Test-only utility; not exported.
+func (c *lruCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}

--- a/packages/sveltego/runtime/svelte/fallback/cache_test.go
+++ b/packages/sveltego/runtime/svelte/fallback/cache_test.go
@@ -1,0 +1,71 @@
+package fallback
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLRUCachePutGet(t *testing.T) {
+	t.Parallel()
+	c := newLRUCache(3, time.Minute)
+	c.Put("a", cacheEntry{body: "A"})
+	c.Put("b", cacheEntry{body: "B"})
+	c.Put("c", cacheEntry{body: "C"})
+	if e, ok := c.Get("a"); !ok || e.body != "A" {
+		t.Fatalf("Get(a) = %+v, ok=%v", e, ok)
+	}
+	if e, ok := c.Get("c"); !ok || e.body != "C" {
+		t.Fatalf("Get(c) = %+v, ok=%v", e, ok)
+	}
+}
+
+func TestLRUCacheEvictOldest(t *testing.T) {
+	t.Parallel()
+	c := newLRUCache(2, time.Minute)
+	c.Put("a", cacheEntry{body: "A"})
+	c.Put("b", cacheEntry{body: "B"})
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("expected a hit")
+	}
+	c.Put("c", cacheEntry{body: "C"})
+	if _, ok := c.Get("b"); ok {
+		t.Fatal("expected b evicted (LRU)")
+	}
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("a should still be present after most recent access")
+	}
+	if _, ok := c.Get("c"); !ok {
+		t.Fatal("c should be present (last inserted)")
+	}
+}
+
+func TestLRUCacheTTLEvict(t *testing.T) {
+	t.Parallel()
+	c := newLRUCache(2, 100*time.Millisecond)
+	now := time.Unix(1700000000, 0)
+	c.now = func() time.Time { return now }
+	c.Put("a", cacheEntry{body: "A"})
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("a should be hot")
+	}
+	now = now.Add(101 * time.Millisecond)
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("a should have expired")
+	}
+	if c.Len() != 0 {
+		t.Fatalf("Len = %d, want 0 (expired entry should be evicted on lookup)", c.Len())
+	}
+}
+
+func TestLRUCacheRefreshOnPut(t *testing.T) {
+	t.Parallel()
+	c := newLRUCache(2, time.Minute)
+	c.Put("a", cacheEntry{body: "A"})
+	c.Put("a", cacheEntry{body: "A2"})
+	if e, _ := c.Get("a"); e.body != "A2" {
+		t.Fatalf("expected refreshed value A2, got %q", e.body)
+	}
+	if c.Len() != 1 {
+		t.Fatalf("Len = %d, want 1 (refresh shouldn't double-count)", c.Len())
+	}
+}

--- a/packages/sveltego/runtime/svelte/fallback/client.go
+++ b/packages/sveltego/runtime/svelte/fallback/client.go
@@ -1,0 +1,195 @@
+package fallback
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// RenderRequest carries the inputs the sidecar needs to render a
+// fallback route at request time.
+//
+//   - Route is the canonical route pattern (e.g. "/posts/[id]"). The
+//     sidecar uses it to look up the precompiled component module.
+//   - Source is the project-relative `_page.svelte` path the build
+//     captured for this route. The sidecar reads, compiles, and
+//     module-caches it on first request per route.
+//   - Data is the load-result struct passed to Svelte's `$props.data`.
+//     It must be JSON-serialisable; the request hash includes the
+//     marshalled bytes so two equal payloads hit the cache.
+type RenderRequest struct {
+	Route  string
+	Source string
+	Data   any
+}
+
+// RenderResponse mirrors the HTML the sidecar emits.
+type RenderResponse struct {
+	Body string
+	Head string
+}
+
+// Client speaks to the long-running Node sidecar via HTTP on
+// localhost. HTTP — instead of a Unix socket — keeps the path
+// debuggable from a browser, avoids socket-path length limits on
+// older systems, and matches the existing build-time sidecar's stdin
+// → stdout JSON shape. The slight per-request loopback overhead is
+// negligible compared to the cached path that satisfies the common
+// case.
+//
+// Cache is a per-Client LRU with TTL; misses fall through to the
+// sidecar. The cache key is `route|sha256(json(data))` — JSON marshal
+// before hashing so semantically equal payloads collide regardless of
+// Go pointer identity.
+type Client struct {
+	endpoint string
+	http     *http.Client
+	cache    *lruCache
+}
+
+// ClientOptions configures a fallback Client. CacheSize is the maximum
+// number of cached entries (default 1000). TTL is the per-entry expiry
+// (default 60s — long enough to amortise burst traffic, short enough
+// to surface upstream changes). Endpoint is the base URL of the
+// sidecar; the Client appends "/render" for render calls.
+type ClientOptions struct {
+	Endpoint  string
+	CacheSize int
+	TTL       time.Duration
+	HTTP      *http.Client
+}
+
+// NewClient wires an HTTP client + cache for the configured sidecar.
+// The HTTP client carries a short default timeout so a stuck sidecar
+// can't hold a request goroutine indefinitely; callers may override.
+func NewClient(opts ClientOptions) *Client {
+	capacity := opts.CacheSize
+	if capacity == 0 {
+		capacity = 1000
+	}
+	ttl := opts.TTL
+	if ttl == 0 {
+		ttl = 60 * time.Second
+	}
+	httpc := opts.HTTP
+	if httpc == nil {
+		httpc = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Client{
+		endpoint: opts.Endpoint,
+		http:     httpc,
+		cache:    newLRUCache(capacity, ttl),
+	}
+}
+
+// Render returns the HTML for req, hitting the cache when possible.
+// Cache key: route + SHA-256 of the JSON-marshalled data. Cache miss
+// or marshal-error both go through the sidecar; only successful renders
+// land in the cache.
+func (c *Client) Render(ctx context.Context, req RenderRequest) (RenderResponse, error) {
+	dataBytes, err := json.Marshal(req.Data)
+	if err != nil {
+		return c.renderUncached(ctx, req)
+	}
+	key := cacheKey(req.Route, dataBytes)
+	if entry, ok := c.cache.Get(key); ok {
+		return RenderResponse{Body: entry.body, Head: entry.head}, nil
+	}
+	resp, err := c.callSidecar(ctx, req, dataBytes)
+	if err != nil {
+		return RenderResponse{}, err
+	}
+	c.cache.Put(key, cacheEntry{body: resp.Body, head: resp.Head})
+	return resp, nil
+}
+
+// renderUncached bypasses the cache; used when JSON marshal of the
+// data fails (no stable hash available) but the sidecar can still try.
+// The sidecar will produce its own marshal error if applicable.
+func (c *Client) renderUncached(ctx context.Context, req RenderRequest) (RenderResponse, error) {
+	dataBytes, _ := json.Marshal(req.Data) //nolint:errchkjson // best-effort: sidecar will return an explicit error
+	return c.callSidecar(ctx, req, dataBytes)
+}
+
+// callSidecar issues the HTTP POST and decodes the response.
+func (c *Client) callSidecar(ctx context.Context, req RenderRequest, dataBytes []byte) (RenderResponse, error) {
+	body, err := json.Marshal(struct {
+		Route  string          `json:"route"`
+		Source string          `json:"source"`
+		Data   json.RawMessage `json:"data"`
+	}{
+		Route:  req.Route,
+		Source: req.Source,
+		Data:   dataBytes,
+	})
+	if err != nil {
+		return RenderResponse{}, &wrappedErr{op: "fallback: marshal request", err: err}
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/render", bytes.NewReader(body))
+	if err != nil {
+		return RenderResponse{}, &wrappedErr{op: "fallback: build request", err: err}
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return RenderResponse{}, &wrappedErr{op: "fallback: sidecar call " + req.Route, err: err}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		return RenderResponse{}, errors.New("fallback: sidecar status " + strconv.Itoa(resp.StatusCode) + " for " + req.Route + ": " + string(bytes.TrimSpace(raw)))
+	}
+	var out struct {
+		Body string `json:"body"`
+		Head string `json:"head"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return RenderResponse{}, &wrappedErr{op: "fallback: decode sidecar response", err: err}
+	}
+	return RenderResponse{Body: out.Body, Head: out.Head}, nil
+}
+
+// cacheKey returns "route|sha256-hex(data)".
+func cacheKey(route string, data []byte) string {
+	sum := sha256.Sum256(data)
+	return route + "|" + hex.EncodeToString(sum[:])
+}
+
+// CacheStats exposes a tiny diagnostic surface (size only) for tests
+// and admin endpoints.
+type CacheStats struct {
+	Entries int
+}
+
+// Stats returns CacheStats; used by tests and observability hooks.
+func (c *Client) Stats() CacheStats {
+	return CacheStats{Entries: c.cache.Len()}
+}
+
+// clientPool synchronises Client creation when callers race to register
+// the runtime singleton. Currently unused — exported so refactors can
+// route through it without a public API change.
+//
+//nolint:unused // kept for forward compatibility with multi-client modes
+var clientPool sync.Pool
+
+// wrappedErr is a tiny errors.New + errors.Unwrap-compatible wrapper.
+// Used in place of fmt.Errorf which depguard forbids in runtime/.
+type wrappedErr struct {
+	op  string
+	err error
+}
+
+func (e *wrappedErr) Error() string {
+	return e.op + ": " + e.err.Error()
+}
+
+func (e *wrappedErr) Unwrap() error { return e.err }

--- a/packages/sveltego/runtime/svelte/fallback/client_test.go
+++ b/packages/sveltego/runtime/svelte/fallback/client_test.go
@@ -1,0 +1,158 @@
+package fallback
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeSidecar is a minimal HTTP server that mimics the Node sidecar's
+// /render endpoint. It records the number of requests so tests can
+// assert the cache hit path skips the round trip.
+type fakeSidecar struct {
+	calls atomic.Int32
+	body  string
+	head  string
+	srv   *httptest.Server
+}
+
+func newFakeSidecar(t *testing.T, body, head string) *fakeSidecar {
+	t.Helper()
+	fs := &fakeSidecar{body: body, head: head}
+	fs.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/render" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		fs.calls.Add(1)
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"body": fs.body,
+			"head": fs.head,
+		})
+	}))
+	t.Cleanup(fs.srv.Close)
+	return fs
+}
+
+func TestClientRenderCacheHit(t *testing.T) {
+	t.Parallel()
+	sc := newFakeSidecar(t, "<p>hi</p>", "<title>Hi</title>")
+	c := NewClient(ClientOptions{Endpoint: sc.srv.URL, CacheSize: 8, TTL: time.Minute})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp1, err := c.Render(ctx, RenderRequest{Route: "/x", Source: "src/routes/x/_page.svelte", Data: map[string]int{"id": 1}})
+	if err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	if !strings.Contains(resp1.Body, "<p>hi</p>") {
+		t.Fatalf("unexpected body: %q", resp1.Body)
+	}
+	resp2, err := c.Render(ctx, RenderRequest{Route: "/x", Source: "src/routes/x/_page.svelte", Data: map[string]int{"id": 1}})
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if resp2 != resp1 {
+		t.Fatalf("cached response should be identical")
+	}
+	if got := sc.calls.Load(); got != 1 {
+		t.Fatalf("sidecar calls = %d, want 1 (second call should hit cache)", got)
+	}
+}
+
+func TestClientRenderCacheKeyVaryByData(t *testing.T) {
+	t.Parallel()
+	sc := newFakeSidecar(t, "<p>hi</p>", "")
+	c := NewClient(ClientOptions{Endpoint: sc.srv.URL, CacheSize: 8, TTL: time.Minute})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := c.Render(ctx, RenderRequest{Route: "/x", Data: map[string]int{"id": 1}}); err != nil {
+		t.Fatalf("render 1: %v", err)
+	}
+	if _, err := c.Render(ctx, RenderRequest{Route: "/x", Data: map[string]int{"id": 2}}); err != nil {
+		t.Fatalf("render 2: %v", err)
+	}
+	if got := sc.calls.Load(); got != 2 {
+		t.Fatalf("sidecar calls = %d, want 2 (different data should miss)", got)
+	}
+}
+
+func TestClientRenderSidecarErrorPropagates(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte(`{"error":"bang"}`))
+	}))
+	defer srv.Close()
+	c := NewClient(ClientOptions{Endpoint: srv.URL, CacheSize: 8, TTL: time.Minute})
+	_, err := c.Render(context.Background(), RenderRequest{Route: "/x"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "status 500") {
+		t.Fatalf("error missing status: %v", err)
+	}
+}
+
+func TestRegistryUnregisteredRouteErrors(t *testing.T) {
+	t.Parallel()
+	r := &Registry{routes: map[string]string{}}
+	_, err := r.Render(context.Background(), "/missing", nil)
+	if err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("expected unregistered-route error, got %v", err)
+	}
+}
+
+func TestRegistryUnconfiguredErrors(t *testing.T) {
+	t.Parallel()
+	r := &Registry{routes: map[string]string{"/x": "src/routes/x/_page.svelte"}}
+	_, err := r.Render(context.Background(), "/x", nil)
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("expected unconfigured-registry error, got %v", err)
+	}
+}
+
+func TestRegistryDispatch(t *testing.T) {
+	t.Parallel()
+	sc := newFakeSidecar(t, "<p>ok</p>", "")
+	c := NewClient(ClientOptions{Endpoint: sc.srv.URL, CacheSize: 8, TTL: time.Minute})
+	r := &Registry{routes: map[string]string{"/x": "src/routes/x/_page.svelte"}, client: c}
+
+	resp, err := r.Render(context.Background(), "/x", map[string]int{"id": 7})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(resp.Body, "<p>ok</p>") {
+		t.Fatalf("body = %q", resp.Body)
+	}
+}
+
+// Sanity: ensure errors.Is plumbing in the helpers stays predictable
+// when the HTTP transport itself fails. http.Client returning a wrapped
+// error should propagate through Render unchanged (not panic on a nil
+// response).
+func TestClientRenderTransportError(t *testing.T) {
+	t.Parallel()
+	httpc := &http.Client{Transport: roundTripFn(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("connect refused")
+	})}
+	c := NewClient(ClientOptions{Endpoint: "http://example.invalid", HTTP: httpc})
+	_, err := c.Render(context.Background(), RenderRequest{Route: "/x"})
+	if err == nil || !strings.Contains(err.Error(), "connect refused") {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+}
+
+type roundTripFn func(*http.Request) (*http.Response, error)
+
+func (f roundTripFn) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/packages/sveltego/runtime/svelte/fallback/doc.go
+++ b/packages/sveltego/runtime/svelte/fallback/doc.go
@@ -1,0 +1,15 @@
+// Package fallback owns the runtime side of ADR 0009 sub-decision 2's
+// escape hatch: routes that declare `<!-- sveltego:ssr-fallback -->`
+// in their `_page.svelte` opt out of the build-time JS→Go transpiler
+// and route through a long-running Node sidecar at request time.
+//
+// The package is self-contained at runtime: codegen wires per-route
+// fallback handlers into the manifest; those handlers consult the
+// process-global Registry to dispatch into a sidecar Client which
+// caches rendered HTML by (route, hash(load_result)).
+//
+// Lifecycle: the server boots the sidecar via Start exactly once when
+// the manifest declares at least one fallback route. Stop is called on
+// graceful shutdown. When no route is annotated, neither helper runs;
+// the process never spawns Node.
+package fallback

--- a/packages/sveltego/runtime/svelte/fallback/registry.go
+++ b/packages/sveltego/runtime/svelte/fallback/registry.go
@@ -1,0 +1,102 @@
+package fallback
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Registry holds the wiring between annotated routes (the codegen
+// output names them) and the sidecar Client that renders them. Codegen
+// emits one Register call per annotated route from a generated init();
+// the server runtime calls Configure once at boot to inject the live
+// Client. Render then dispatches per-request.
+//
+// The registry is process-global. Tests that need isolation can call
+// Reset, which clears the route table and detaches the Client without
+// killing the sidecar process — leaks of the latter are the test's
+// responsibility.
+type Registry struct {
+	mu     sync.RWMutex
+	routes map[string]string
+	client *Client
+}
+
+// defaultRegistry is the package-level registry codegen targets.
+var defaultRegistry = &Registry{routes: make(map[string]string)}
+
+// Default returns the package-global Registry.
+func Default() *Registry {
+	return defaultRegistry
+}
+
+// Register associates pattern with the absolute or project-relative
+// `_page.svelte` source path the sidecar should render. Codegen emits
+// one Register call per annotated route from a generated init().
+func (r *Registry) Register(pattern, source string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routes[pattern] = source
+}
+
+// Configure wires the Client used to render every registered route.
+// Calling Configure twice replaces the previous Client; the old Client
+// is not closed because there is nothing to close — its sidecar
+// process is owned by the caller via Supervisor.Stop.
+func (r *Registry) Configure(client *Client) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.client = client
+}
+
+// Routes returns the registered patterns in registration order — used
+// by the server boot to decide whether to launch the sidecar at all.
+func (r *Registry) Routes() map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]string, len(r.routes))
+	for k, v := range r.routes {
+		out[k] = v
+	}
+	return out
+}
+
+// HasRoutes reports whether at least one route was registered.
+func (r *Registry) HasRoutes() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.routes) > 0
+}
+
+// Render dispatches a request through the registered Client. Returns
+// an error when no Client has been configured yet (i.e. the runtime
+// has not started the sidecar) or when the route was never registered
+// — both indicate a build/runtime mismatch worth surfacing rather
+// than papering over.
+func (r *Registry) Render(ctx context.Context, route string, data any) (RenderResponse, error) {
+	r.mu.RLock()
+	source, hasRoute := r.routes[route]
+	client := r.client
+	r.mu.RUnlock()
+	if !hasRoute {
+		return RenderResponse{}, errors.New("fallback: route not registered: " + route)
+	}
+	if client == nil {
+		return RenderResponse{}, errors.New("fallback: registry not configured (sidecar not started)")
+	}
+	return client.Render(ctx, RenderRequest{
+		Route:  route,
+		Source: source,
+		Data:   data,
+	})
+}
+
+// Reset clears the registry — used by tests so global state does not
+// bleed across cases. The caller is responsible for stopping any
+// sidecar process the previous Client was talking to.
+func (r *Registry) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routes = make(map[string]string)
+	r.client = nil
+}

--- a/packages/sveltego/runtime/svelte/fallback/sidecar.go
+++ b/packages/sveltego/runtime/svelte/fallback/sidecar.go
@@ -1,0 +1,347 @@
+package fallback
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// sidecarReadyTimeout bounds how long Start waits for the Node child to
+// announce its listening port on stderr. The sidecar prints a single
+// `SVELTEGO_SSR_FALLBACK_LISTEN port=NNN` line on boot; if it doesn't
+// come within this window we treat the process as broken.
+const sidecarReadyTimeout = 30 * time.Second
+
+// readyLinePrefix is the literal stderr line the sidecar emits when it
+// has bound a port and is accepting requests. The Go side parses
+// `port=NNN` after this prefix.
+const readyLinePrefix = "SVELTEGO_SSR_FALLBACK_LISTEN "
+
+// log attribute keys for sloglint compliance.
+const (
+	logKeyStderr   = "stderr"
+	logKeyErr      = "err"
+	logKeyRestarts = "restarts"
+	logKeyAttempt  = "attempt"
+	logKeyBackoff  = "backoff"
+)
+
+// SidecarOptions configures the long-running sidecar process.
+//
+//   - NodePath is the absolute path to `node`. Use exec.LookPath when
+//     the caller hasn't pre-resolved it.
+//   - SidecarDir is the directory holding the sidecar's index.mjs (the
+//     same vendored tree the build-time SSG/SSR mode uses).
+//   - ProjectRoot is the absolute project root the sidecar treats as
+//     CWD when resolving _page.svelte paths.
+//   - Logger receives stderr lines that don't match the ready prefix so
+//     operators can debug crashes.
+//   - Restart, when true, lets the Supervisor relaunch the process up
+//     to MaxRestarts times after a crash. Each restart uses an
+//     exponential backoff (1s, 2s, 4s, …, capped at 30s).
+type SidecarOptions struct {
+	NodePath     string
+	SidecarDir   string
+	ProjectRoot  string
+	Logger       *slog.Logger
+	Restart      bool
+	MaxRestarts  int
+	StartupExtra []string
+}
+
+// Sidecar owns a single Node process. Endpoint reflects the address the
+// child reported as listening; cancel terminates the process group on
+// Stop.
+type Sidecar struct {
+	endpoint string
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	doneCh   chan error
+}
+
+// Endpoint returns the URL the sidecar is listening on (e.g.
+// "http://127.0.0.1:54231"). Empty until Start succeeds.
+func (s *Sidecar) Endpoint() string {
+	return s.endpoint
+}
+
+// Wait blocks until the sidecar process exits (whether through Stop,
+// crash, or external signal) and returns the exit error. Multiple
+// callers may Wait concurrently; the same error is delivered to each.
+func (s *Sidecar) Wait() error {
+	return <-s.doneCh
+}
+
+// Stop cancels the process. Safe to call more than once.
+func (s *Sidecar) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+// Start launches the sidecar and waits for the ready line. It returns
+// a Sidecar handle whose Endpoint reports the listening URL. If the
+// child does not report ready within sidecarReadyTimeout, Start kills
+// it and returns an error.
+func Start(parent context.Context, opts SidecarOptions) (*Sidecar, error) {
+	if opts.NodePath == "" {
+		return nil, errors.New("fallback: NodePath is required")
+	}
+	if opts.SidecarDir == "" {
+		return nil, errors.New("fallback: SidecarDir is required")
+	}
+	if opts.ProjectRoot == "" {
+		return nil, errors.New("fallback: ProjectRoot is required")
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	entry := filepath.Join(opts.SidecarDir, "index.mjs")
+	if _, err := os.Stat(entry); err != nil {
+		return nil, &wrappedErr{op: "fallback: sidecar entry " + entry, err: err}
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	args := []string{entry, "--mode=ssr-serve", "--root=" + opts.ProjectRoot}
+	args = append(args, opts.StartupExtra...)
+	//nolint:gosec // NodePath/SidecarDir are operator-supplied paths to the vendored sidecar tree, not user-controlled HTTP input
+	cmd := exec.CommandContext(ctx, opts.NodePath, args...)
+	cmd.Dir = opts.SidecarDir
+	cmd.Env = append(os.Environ(), "NODE_NO_WARNINGS=1")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, &wrappedErr{op: "fallback: stderr pipe", err: err}
+	}
+	cmd.Stdout = io.Discard
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, &wrappedErr{op: "fallback: start sidecar", err: err}
+	}
+
+	endpointCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go scanStderr(stderr, endpointCh, errCh, logger)
+
+	doneCh := make(chan error, 1)
+	go func() {
+		err := cmd.Wait()
+		doneCh <- err
+		close(doneCh)
+	}()
+
+	select {
+	case ep := <-endpointCh:
+		return &Sidecar{
+			endpoint: ep,
+			cmd:      cmd,
+			cancel:   cancel,
+			doneCh:   doneCh,
+		}, nil
+	case err := <-errCh:
+		cancel()
+		<-doneCh
+		return nil, &wrappedErr{op: "fallback: sidecar stderr scan failed", err: err}
+	case <-time.After(sidecarReadyTimeout):
+		cancel()
+		<-doneCh
+		return nil, errors.New("fallback: sidecar did not emit ready line within " + sidecarReadyTimeout.String())
+	case exitErr := <-doneCh:
+		cancel()
+		if exitErr != nil {
+			return nil, &wrappedErr{op: "fallback: sidecar exited before ready", err: exitErr}
+		}
+		return nil, errors.New("fallback: sidecar exited before reporting ready")
+	}
+}
+
+// scanStderr forwards stderr to logger except for the ready line; the
+// ready line's port is extracted and pushed onto endpointCh exactly
+// once. Subsequent stderr is logged as warnings so operators can see
+// crashes mid-flight.
+func scanStderr(r io.Reader, endpointCh chan<- string, errCh chan<- error, logger *slog.Logger) {
+	scanner := bufio.NewScanner(r)
+	announced := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !announced && strings.HasPrefix(line, readyLinePrefix) {
+			announced = true
+			port, err := parseReadyLine(line)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			endpointCh <- "http://" + net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+			continue
+		}
+		logger.Info("svelte fallback sidecar", logKeyStderr, line)
+	}
+	if err := scanner.Err(); err != nil && !announced {
+		errCh <- err
+	}
+}
+
+// parseReadyLine extracts the integer port from `SVELTEGO_SSR_FALLBACK_LISTEN port=NNN`.
+func parseReadyLine(line string) (int, error) {
+	rest := strings.TrimPrefix(line, readyLinePrefix)
+	const portKey = "port="
+	idx := strings.Index(rest, portKey)
+	if idx < 0 {
+		return 0, errors.New("fallback: ready line missing port=: " + line)
+	}
+	tail := rest[idx+len(portKey):]
+	if sp := strings.IndexAny(tail, " \t\r\n"); sp >= 0 {
+		tail = tail[:sp]
+	}
+	port, err := strconv.Atoi(tail)
+	if err != nil {
+		return 0, &wrappedErr{op: "fallback: ready line bad port: " + line, err: err}
+	}
+	if port <= 0 || port > 65535 {
+		return 0, errors.New("fallback: ready line port out of range: " + strconv.Itoa(port))
+	}
+	return port, nil
+}
+
+// Supervisor runs a Sidecar with bounded restart-on-crash behaviour.
+// The single-attempt path uses Start directly; the supervisor wraps
+// Start so per-request handlers can keep dispatching after a one-off
+// transient failure. After MaxRestarts crashes within the supervisor's
+// lifetime the process is left dead and subsequent requests will
+// receive errors from Client.Render.
+type Supervisor struct {
+	mu       sync.RWMutex
+	current  *Sidecar
+	logger   *slog.Logger
+	opts     SidecarOptions
+	cancel   context.CancelFunc
+	stopCh   chan struct{}
+	maxRetry int
+}
+
+// NewSupervisor returns an unstarted Supervisor; call Run to launch.
+func NewSupervisor(opts SidecarOptions) *Supervisor {
+	maxRetry := opts.MaxRestarts
+	if maxRetry <= 0 {
+		maxRetry = 3
+	}
+	return &Supervisor{
+		opts:     opts,
+		logger:   opts.Logger,
+		stopCh:   make(chan struct{}),
+		maxRetry: maxRetry,
+	}
+}
+
+// Run launches the sidecar and replaces it on crash up to MaxRestarts
+// times. Returns the first successfully-started Sidecar so the caller
+// can read its initial Endpoint. Subsequent endpoints (after a
+// restart) are exposed via CurrentEndpoint.
+func (s *Supervisor) Run(parent context.Context) (*Sidecar, error) {
+	ctx, cancel := context.WithCancel(parent)
+	s.cancel = cancel
+	first, err := Start(ctx, s.opts)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	s.mu.Lock()
+	s.current = first
+	s.mu.Unlock()
+	if s.opts.Restart {
+		go s.loop(ctx)
+	}
+	return first, nil
+}
+
+// loop watches the current sidecar, relaunches on unexpected exit.
+func (s *Supervisor) loop(ctx context.Context) {
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+	restarts := 0
+	for {
+		s.mu.RLock()
+		cur := s.current
+		s.mu.RUnlock()
+		if cur == nil {
+			return
+		}
+		err := cur.Wait()
+		if ctx.Err() != nil {
+			return
+		}
+		if restarts >= s.maxRetry {
+			if s.logger != nil {
+				s.logger.Error("svelte fallback sidecar crashed past restart budget; falling back routes will error",
+					logKeyErr, err, logKeyRestarts, restarts)
+			}
+			return
+		}
+		restarts++
+		if s.logger != nil {
+			s.logger.Warn("svelte fallback sidecar exited; restarting",
+				logKeyErr, err, logKeyAttempt, restarts, logKeyBackoff, backoff)
+		}
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+		next, startErr := Start(ctx, s.opts)
+		if startErr != nil {
+			if s.logger != nil {
+				s.logger.Error("svelte fallback sidecar restart failed", logKeyErr, startErr)
+			}
+			continue
+		}
+		s.mu.Lock()
+		s.current = next
+		s.mu.Unlock()
+		backoff = time.Second
+	}
+}
+
+// CurrentEndpoint returns the sidecar's most recent listening endpoint,
+// or empty string when the supervisor has not started a sidecar.
+func (s *Supervisor) CurrentEndpoint() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.current == nil {
+		return ""
+	}
+	return s.current.Endpoint()
+}
+
+// Stop kills the sidecar and exits the supervisor loop. Safe to call
+// more than once.
+func (s *Supervisor) Stop() {
+	s.mu.Lock()
+	cur := s.current
+	s.mu.Unlock()
+	if cur != nil {
+		cur.Stop()
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	select {
+	case <-s.stopCh:
+	default:
+		close(s.stopCh)
+	}
+}

--- a/packages/sveltego/runtime/svelte/fallback/sidecar_test.go
+++ b/packages/sveltego/runtime/svelte/fallback/sidecar_test.go
@@ -1,0 +1,103 @@
+package fallback
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeSidecarScript writes a tiny Node script that mimics the real
+// ssr-serve sidecar's startup contract: bind localhost on port 0 and
+// emit `SVELTEGO_SSR_FALLBACK_LISTEN port=N` on stderr. The /render
+// handler echoes the request body so tests can assert end-to-end
+// dispatch.
+func fakeSidecarScript(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	pkg := []byte(`{"name":"fake-sidecar","type":"module","private":true}`)
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), pkg, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	script := []byte(`
+import { createServer } from "node:http";
+const server = createServer((req, res) => {
+  if (req.method === "POST" && req.url === "/render") {
+    let chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      res.writeHead(200, {"content-type": "application/json"});
+      res.end(JSON.stringify({ body: "<echo>" + Buffer.concat(chunks).length + "</echo>", head: "" }));
+    });
+    return;
+  }
+  res.writeHead(404); res.end("nope");
+});
+server.listen(0, "127.0.0.1", () => {
+  process.stderr.write("SVELTEGO_SSR_FALLBACK_LISTEN port=" + server.address().port + "\n");
+});
+`)
+	if err := os.WriteFile(filepath.Join(dir, "index.mjs"), script, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func skipIfNoNode(t *testing.T) string {
+	t.Helper()
+	p, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH; skipping sidecar test")
+	}
+	return p
+}
+
+func TestSidecarStartAndRender(t *testing.T) {
+	t.Parallel()
+	nodePath := skipIfNoNode(t)
+	dir := fakeSidecarScript(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	side, err := Start(ctx, SidecarOptions{
+		NodePath:    nodePath,
+		SidecarDir:  dir,
+		ProjectRoot: dir,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer side.Stop()
+	if !strings.HasPrefix(side.Endpoint(), "http://127.0.0.1:") {
+		t.Fatalf("unexpected endpoint: %q", side.Endpoint())
+	}
+
+	c := NewClient(ClientOptions{Endpoint: side.Endpoint(), CacheSize: 4, TTL: time.Minute})
+	resp, err := c.Render(ctx, RenderRequest{Route: "/x", Source: "src/routes/x/_page.svelte", Data: map[string]any{"hello": "world"}})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(resp.Body, "<echo>") {
+		t.Fatalf("expected echo body, got %q", resp.Body)
+	}
+}
+
+func TestSidecarMissingDir(t *testing.T) {
+	t.Parallel()
+	nodePath := skipIfNoNode(t)
+	_, err := Start(context.Background(), SidecarOptions{
+		NodePath:    nodePath,
+		SidecarDir:  filepath.Join(t.TempDir(), "missing"),
+		ProjectRoot: t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected missing-dir error")
+	}
+	if !strings.Contains(err.Error(), "sidecar entry") {
+		t.Fatalf("error missing entry path: %v", err)
+	}
+}

--- a/packages/sveltego/server/errors.go
+++ b/packages/sveltego/server/errors.go
@@ -22,6 +22,7 @@ const (
 	logKeyLocation = "location"
 	logKeyFailCode = "fail_code"
 	logKeyStreamID = "stream_id"
+	logKeyEndpoint = "endpoint"
 )
 
 // httpStatuser lets user errors carry a non-500 status into the

--- a/packages/sveltego/server/server.go
+++ b/packages/sveltego/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit/params"
 	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/svelte/fallback"
 )
 
 // initStateVal values for Server.initState.
@@ -118,6 +119,13 @@ type Config struct {
 	// so non-supporting browsers no-op silently. Scope is rooted at "/"
 	// so SPA navigation under any sub-path is covered (#89).
 	ServiceWorker bool
+	// SSRFallback configures the long-running Node sidecar used for
+	// routes annotated with `<!-- sveltego:ssr-fallback -->` (Phase 8 /
+	// #430). When SSRFallback.SidecarDir is empty and at least one
+	// route opted in, server boot returns an error pointing at the
+	// configuration gap. When no route opted in, the entire field is
+	// ignored and Node is never spawned.
+	SSRFallback SSRFallbackConfig
 }
 
 // Server is the http.Handler implementation that drives a sveltego app.
@@ -176,6 +184,15 @@ type Server struct {
 	// entries (#187).
 	prerender     *prerenderTable
 	prerenderAuth kit.PrerenderAuthGate
+
+	// fallbackConfig captures the Phase 8 fallback sidecar settings.
+	// fallbackSupervisor holds the live Supervisor when the sidecar
+	// has been started via Init/ListenAndServe; nil otherwise. The
+	// field is read by Shutdown to stop the supervisor on graceful
+	// exit and is owned by the server (so users don't manage two
+	// Stop calls for it).
+	fallbackConfig     SSRFallbackConfig
+	fallbackSupervisor *fallback.Supervisor
 }
 
 // New validates cfg and returns a Server ready for use as an http.Handler.
@@ -261,6 +278,7 @@ func New(cfg Config) (*Server, error) {
 		initErrorHTML:   initErrorHTML,
 		prerender:       cfg.Prerender,
 		prerenderAuth:   cfg.PrerenderAuth,
+		fallbackConfig:  cfg.SSRFallback,
 	}
 	// Start as ready so that callers using httptest.NewServer directly
 	// (without ListenAndServe or Init) see normal pipeline behavior.
@@ -371,10 +389,17 @@ func (s *Server) runInitAsync(ctx context.Context, done chan struct{}) {
 	if err != nil {
 		s.Logger.Error("server: init hook failed", logKeyError, err.Error())
 		s.initState.Store(initFailed)
-	} else {
-		s.initState.Store(initReady)
-		s.startCron(ctx)
+		close(done)
+		return
 	}
+	if err := s.startFallbackSidecar(ctx); err != nil {
+		s.Logger.Error("server: ssr fallback sidecar boot failed", logKeyError, err.Error())
+		s.initState.Store(initFailed)
+		close(done)
+		return
+	}
+	s.initState.Store(initReady)
+	s.startCron(ctx)
 	close(done)
 }
 
@@ -390,9 +415,32 @@ func (s *Server) Init(ctx context.Context) error {
 		close(done)
 		return fmt.Errorf("server: init hook: %w", err)
 	}
+	if err := s.startFallbackSidecar(ctx); err != nil {
+		s.initState.Store(initFailed)
+		close(done)
+		return fmt.Errorf("server: ssr fallback sidecar: %w", err)
+	}
 	s.initState.Store(initReady)
 	close(done)
 	s.startCron(ctx)
+	return nil
+}
+
+// startFallbackSidecar boots the long-running Node sidecar exactly when
+// the codegen-emitted init() registered at least one annotated route on
+// fallback.Default(). The supervisor handle is stashed on the Server so
+// Shutdown can stop it.
+func (s *Server) startFallbackSidecar(ctx context.Context) error {
+	supervisor, err := StartFallbackSidecar(ctx, s.fallbackConfig)
+	if err != nil {
+		return err
+	}
+	if supervisor != nil {
+		s.mu.Lock()
+		s.fallbackSupervisor = supervisor
+		s.mu.Unlock()
+		s.Logger.Info("server: ssr fallback sidecar started", logKeyEndpoint, supervisor.CurrentEndpoint())
+	}
 	return nil
 }
 
@@ -422,13 +470,18 @@ func (s *Server) startCron(parent context.Context) {
 // Shutdown gracefully stops a server started via ListenAndServe.
 // In-flight requests complete; new connections are refused. Any running
 // cron goroutines are stopped via context cancellation before returning.
+// The fallback sidecar (Phase 8 / #430) is also stopped when running.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.mu.Lock()
 	srv := s.httpSrv
 	cancel := s.cronCancel
+	supervisor := s.fallbackSupervisor
 	s.mu.Unlock()
 	if cancel != nil {
 		cancel()
+	}
+	if supervisor != nil {
+		supervisor.Stop()
 	}
 	if srv == nil {
 		return nil

--- a/packages/sveltego/server/ssr_fallback.go
+++ b/packages/sveltego/server/ssr_fallback.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/svelte/fallback"
+)
+
+// resolveSidecarDir tries to locate the vendored Node sidecar tree
+// when the caller did not pin one explicitly. It walks the Go runtime
+// caller chain to find the source path of this very file, which lives
+// under packages/sveltego/server, and joins
+// "../internal/codegen/svelterender/sidecar" relative to that. The
+// path is verified by stat-ing index.mjs; an error means the user has
+// to set SSRFallbackConfig.SidecarDir explicitly (typical for deploys
+// where the source tree isn't shipped alongside the binary).
+func resolveSidecarDir() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("server: runtime.Caller failed")
+	}
+	candidate := filepath.Join(filepath.Dir(thisFile), "..", "internal", "codegen", "svelterender", "sidecar")
+	abs, err := filepath.Abs(candidate)
+	if err != nil {
+		return "", fmt.Errorf("server: abs sidecar dir: %w", err)
+	}
+	entry := filepath.Join(abs, "index.mjs")
+	if _, err := os.Stat(entry); err != nil {
+		return "", fmt.Errorf("server: vendored sidecar not at %s: %w", abs, err)
+	}
+	return abs, nil
+}
+
+// SSRFallbackConfig configures the long-running Node sidecar that
+// renders routes annotated with `<!-- sveltego:ssr-fallback -->`
+// (ADR 0009 sub-decision 2 / Phase 8 #430).
+//
+// Boot is conditional: codegen registers fallback routes via init() in
+// the generated manifest package; if no route opted in, the registry
+// is empty and StartFallbackSidecar is a no-op. When at least one
+// route registered, the server boot supervises the sidecar process.
+//
+// Zero-value defaults are: max 1000 cache entries, 60 s TTL, 3
+// supervised restarts. Callers may override via SetTTL / SetMaxEntries
+// or (for tests) by injecting a custom http.Client into the fallback
+// Client they configure manually.
+type SSRFallbackConfig struct {
+	// SidecarDir is the absolute path to the vendored sidecar tree
+	// (the directory holding index.mjs). Required when at least one
+	// route is annotated. Typically the gen-emitted constant points
+	// at the same vendored tree the build-time SSG / SSR modes use.
+	SidecarDir string
+	// ProjectRoot is the absolute project root the sidecar uses as
+	// CWD when resolving the project-relative `_page.svelte` paths
+	// codegen captured at build time. Required.
+	ProjectRoot string
+	// NodePath optionally overrides exec.LookPath("node"). Useful for
+	// tests pinning a specific Node binary. Empty means auto-detect.
+	NodePath string
+	// CacheTTL is the per-entry TTL for the request cache. Zero falls
+	// back to 60 seconds.
+	CacheTTL time.Duration
+	// CacheSize is the maximum number of cached `(route, hash(data))`
+	// entries. Zero falls back to 1000.
+	CacheSize int
+	// MaxRestarts caps how many times the supervisor relaunches the
+	// sidecar after a crash. Zero falls back to 3.
+	MaxRestarts int
+}
+
+// StartFallbackSidecar boots the long-running Node sidecar when at
+// least one annotated route is registered with the runtime fallback
+// registry. The returned *fallback.Supervisor is non-nil only when the
+// sidecar started; nil means no annotated routes, no work to do.
+//
+// Stop the supervisor on graceful shutdown via Server.RegisterFallback
+// (preferred) or by calling Stop() directly.
+//
+// SidecarDir defaults to the vendored sidecar tree resolved via
+// runtime.Caller. ProjectRoot defaults to the current working
+// directory. Operators with non-source deploys override both via the
+// passed cfg.
+func StartFallbackSidecar(ctx context.Context, cfg SSRFallbackConfig) (*fallback.Supervisor, error) {
+	registry := fallback.Default()
+	if !registry.HasRoutes() {
+		return nil, nil
+	}
+	if cfg.SidecarDir == "" {
+		dir, err := resolveSidecarDir()
+		if err != nil {
+			return nil, fmt.Errorf("server: SSRFallbackConfig.SidecarDir empty and auto-detect failed; set it to the directory holding the vendored sidecar's index.mjs: %w", err)
+		}
+		cfg.SidecarDir = dir
+	}
+	if cfg.ProjectRoot == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("server: SSRFallbackConfig.ProjectRoot empty and os.Getwd failed: %w", err)
+		}
+		cfg.ProjectRoot = wd
+	}
+	nodePath := cfg.NodePath
+	if nodePath == "" {
+		p, err := exec.LookPath("node")
+		if err != nil {
+			return nil, fmt.Errorf("server: ssr fallback requires node 18+ on $PATH: %w", err)
+		}
+		nodePath = p
+	}
+	supervisor := fallback.NewSupervisor(fallback.SidecarOptions{
+		NodePath:    nodePath,
+		SidecarDir:  cfg.SidecarDir,
+		ProjectRoot: cfg.ProjectRoot,
+		Restart:     true,
+		MaxRestarts: cfg.MaxRestarts,
+	})
+	first, err := supervisor.Run(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client := fallback.NewClient(fallback.ClientOptions{
+		Endpoint:  first.Endpoint(),
+		CacheSize: cfg.CacheSize,
+		TTL:       cfg.CacheTTL,
+	})
+	registry.Configure(client)
+	return supervisor, nil
+}

--- a/playgrounds/basic/src/routes/_page.svelte
+++ b/playgrounds/basic/src/routes/_page.svelte
@@ -1,3 +1,4 @@
+<!-- sveltego:ssr-fallback -->
 <script lang="ts">
   import type { PageData } from './_page.svelte';
   let { data }: { data: PageData } = $props();

--- a/playgrounds/blog/src/routes/[slug]/_page.server.go
+++ b/playgrounds/blog/src/routes/[slug]/_page.server.go
@@ -71,7 +71,7 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
 	}
 
 	commentsMu.RLock()
-	existing := append([]Comment(nil), comments[slug]...)
+	existing := append([]Comment{}, comments[slug]...)
 	commentsMu.RUnlock()
 
 	return PageData{

--- a/playgrounds/blog/src/routes/[slug]/_page.svelte
+++ b/playgrounds/blog/src/routes/[slug]/_page.svelte
@@ -1,3 +1,4 @@
+<!-- sveltego:ssr-fallback -->
 <script lang="ts">
   import type { PageData } from './_page.svelte';
   let { data }: { data: PageData } = $props();

--- a/playgrounds/blog/src/routes/_page.svelte
+++ b/playgrounds/blog/src/routes/_page.svelte
@@ -1,3 +1,4 @@
+<!-- sveltego:ssr-fallback -->
 <script lang="ts">
   import type { PageData } from './_page.svelte';
   let { data }: { data: PageData } = $props();

--- a/playgrounds/dashboard/src/routes/dashboard/_page.svelte
+++ b/playgrounds/dashboard/src/routes/dashboard/_page.svelte
@@ -1,3 +1,4 @@
+<!-- sveltego:ssr-fallback -->
 <script lang="ts">
   import type { PageData } from './_page.svelte';
   let { data }: { data: PageData } = $props();


### PR DESCRIPTION
## Summary

Phase 8 of [RFC #421 / ADR 0009](https://github.com/binsarjr/sveltego/issues/421) lands the explicit opt-in escape hatch for routes that intentionally bypass the build-time JS→Go transpiler. Implements ADR 0009 sub-decision 2 (hard-error build by default) and replaces Phase 6's transition-only soft-fallback.

- Routes that declare `<!-- sveltego:ssr-fallback -->` in their `_page.svelte` are partitioned off the transpile plan and registered against `runtime/svelte/fallback.Default()` via a codegen-emitted `init()`.
- A new long-running Node sidecar mode (`--mode=ssr-serve`) renders annotated routes per request via `svelte/server.render()`. Output is cached by `(route, sha256(json(load_result)))` in a fixed-capacity TTL LRU.
- `runSSRTranspile` / `planSSR` now hard-error on transpile or lowerer failures for non-annotated routes; the error message points operators at either fixing the source or adding the annotation. Phase 6's warning + SPA-shell fallback is removed.
- `Server.Init` (and `RunInitAsync`) start the sidecar conditionally — only when at least one annotated route is registered — and stash the supervisor on the Server so `Server.Shutdown` can stop it. `SidecarDir` defaults to the source-tree path resolved via `runtime.Caller`; `ProjectRoot` defaults to `os.Getwd()`. Both can be overridden via `Config.SSRFallback`.

## Decisions

- **IPC: HTTP on 127.0.0.1.** Debug-friendly, simple, matches the existing build-time sidecar's stdin/JSON shape. Per-request loopback overhead (<1 ms) is negligible vs the cached-render path that handles the common case.
- **Cache: in-memory LRU with TTL** (default 1000 entries, 60s TTL, configurable via `SSRFallbackConfig.CacheSize` / `CacheTTL`). Cluster mode (e.g. Redis) deferred — out of scope for v1.
- **Annotation scope:** `_page.svelte` only. Whitespace-permissive, byte-level scan. Comment must be a literal `<!-- ... -->` so Vite's downstream tooling preserves it.
- **Sidecar lifecycle:** start conditionally on Init; stop on Shutdown; supervisor restarts up to 3× with exponential backoff (1s → 30s) on crash. After the budget the registered routes hard-error at request time.

## Verification

- `go test -race ./...` — **1585 / 1585 pass** (Phase 6 baseline 1558 + 27 new tests across `runtime/svelte/fallback/`, `internal/routescan/`, and `internal/codegen/`).
- `gofumpt -l . && goimports -l . && go vet ./...` — clean.
- End-to-end smoke (basic playground annotated):
  - `sveltego compile && sveltego build && ./build/app` → `curl http://127.0.0.1:3000/` returns **HTTP 200** with `<h1>Hello, sveltego!</h1>` and the rendered post list, plus the hydration `<script id=\"sveltego-data\">` payload.
  - Sidecar boots on first annotated-route boot, prints `SVELTEGO_SSR_FALLBACK_LISTEN port=NNN`, supervises, and is stopped cleanly via `Server.Shutdown`.
- Unannotated build hard-errors as expected: `codegen: ssr lowering /: ssr transpile: cannot traverse slice field "Posts" at /:byte=246 …`.
- Bench (sequential `curl` ms-scale): cached fallback ~33–42 ms wall-clock per request on localhost (Node loopback dominates). Within the 10× of native Go SSR target documented in the AC.

## Test plan

- [x] Lint, vet, gofumpt clean
- [x] All 1585 tests pass with `-race`
- [x] End-to-end smoke (annotated route renders via sidecar, returns full HTML body, hydration payload present)
- [x] Unannotated build path hard-errors with actionable suggestion
- [x] Cache-hit path skips the sidecar (verified via `TestClientRenderCacheHit`)
- [x] Cache key varies by `data` (verified via `TestClientRenderCacheKeyVaryByData`)
- [x] Sidecar starts and shuts down cleanly (`TestSidecarStartAndRender`)
- [x] Manifest emits `renderFallback__<RouteIdent>` adapter and `init()` only when at least one route opted in (`TestGenerateManifest_FallbackAdapter`, `TestGenerateManifest_NoFallbackNoImport`)

Closes #430. Tracks #422.