### PR TITLE
docs: cover all four render modes (SSR/SSG/SPA/Static) (closes #449)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -29,6 +29,7 @@ Hard invariants (post-ADR 0008 + 0009; do not reopen without new evidence — se
 - **Codegen, not interpretation.** Static decisions at build time. Codegen emits `.svelte.d.ts` declarations (Go AST → TypeScript), prerendered HTML for SSG routes, and per-route Go `Render()` functions transpiled from `svelte/server` JS output for SSR routes.
 - **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Skip Svelte 4 legacy reactivity.
 - **Performance target:** 20–40k rps for SSG (zero per-request work) and JSON-payload responses; ≥10k rps p50 for transpiled SSR routes (RFC #421 acceptance criterion). If a proposal cannot reach that, surface the gap before writing code.
+- **Four render modes per route.** `kit.PageOptions` selects per route; `kit.DefaultPageOptions()` returns `SSR: true`, so **SSR is the default** (matches SvelteKit). The four modes: **SSR** (default; Go `Render()` emits HTML, client hydrates), **SSG** (`Prerender: true`; build-time HTML, static handler), **SPA** (`SSR: false`; app shell + JSON payload, client renders), **Static** (no `_page.server.go`; pure `.svelte`, client renders against `{}`). Layouts cascade per-field; page-level overrides win. Full reference: [`docs/render-modes.md`](./docs/render-modes.md).
 
 For high-level project context, read [`README.md`](./README.md) first, then [`CLAUDE.md`](./CLAUDE.md).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ Hard invariants (post-ADR 0008 + 0009; do not reopen without new evidence — se
 - **Codegen, not interpretation.** Static decisions at build time. Codegen emits `.svelte.d.ts` declarations (Go AST → TypeScript), prerendered HTML for SSG routes, and per-route Go `Render()` functions transpiled from `svelte/server` JS output for SSR routes.
 - **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Skip Svelte 4 legacy reactivity.
 - **Performance target:** 20–40k rps for SSG (zero per-request work) and JSON-payload responses; ≥10k rps p50 for transpiled SSR routes (RFC #421 acceptance criterion). If a proposal cannot reach that, surface the gap before writing code.
+- **Four render modes per route.** `kit.PageOptions` selects per route; `kit.DefaultPageOptions()` returns `SSR: true`, so **SSR is the default** (matches SvelteKit). The four modes: **SSR** (default; Go `Render()` emits HTML, client hydrates), **SSG** (`Prerender: true`; build-time HTML, static handler), **SPA** (`SSR: false`; app shell + JSON payload, client renders), **Static** (no `_page.server.go`; pure `.svelte`, client renders against `{}`). Layouts cascade per-field; page-level overrides win. Full reference: [`docs/render-modes.md`](./docs/render-modes.md).
 
 For high-level project context, read [`README.md`](./README.md) first, then [`CLAUDE.md`](./CLAUDE.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Hard invariants (post-ADR 0008 + 0009; do not reopen without new evidence — se
 - **Codegen, not interpretation.** Static decisions at build time. Codegen emits `.svelte.d.ts` declarations (Go AST → TypeScript), prerendered HTML for SSG routes, and per-route Go `Render()` functions transpiled from `svelte/server` JS output for SSR routes.
 - **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Skip Svelte 4 legacy reactivity.
 - **Performance target:** 20–40k rps for SSG (zero per-request work) and JSON-payload responses; ≥10k rps p50 for transpiled SSR routes (RFC #421 acceptance criterion). If a proposal cannot reach that, surface the gap before writing code.
+- **Four render modes per route.** `kit.PageOptions` selects per route; `kit.DefaultPageOptions()` returns `SSR: true`, so **SSR is the default** (matches SvelteKit). The four modes: **SSR** (default; Go `Render()` emits HTML, client hydrates), **SSG** (`Prerender: true`; build-time HTML, static handler), **SPA** (`SSR: false`; app shell + JSON payload, client renders), **Static** (no `_page.server.go`; pure `.svelte`, client renders against `{}`). Layouts cascade per-field; page-level overrides win. Full reference: [`docs/render-modes.md`](./docs/render-modes.md).
 
 For high-level project context, read [`README.md`](./README.md) first, then [`CLAUDE.md`](./CLAUDE.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Key invariants (post-ADR 0008 + 0009):
 - **Codegen, not interpretation.** Static decisions at build time. Codegen emits `.svelte.d.ts` declarations (Go AST → TypeScript), prerendered HTML for SSG routes, and per-route Go `Render()` functions transpiled from `svelte/server` JS output for SSR routes. No per-request template walking.
 - **Svelte 5 only.** Runes (`$props`, `$state`, `$derived`, `$effect`, `$bindable`). Skip Svelte 4 legacy reactivity.
 - **Performance target:** 20–40k rps for SSG (zero per-request work) and JSON-payload responses; ≥10k rps p50 for transpiled SSR routes (RFC #421 acceptance criterion). If a proposal can't reach that, surface it before writing code.
+- **Four render modes per route.** `kit.PageOptions` selects per route; `kit.DefaultPageOptions()` returns `SSR: true`, so **SSR is the default** (matches SvelteKit). The four modes: **SSR** (default; Go `Render()` emits HTML, client hydrates), **SSG** (`Prerender: true`; build-time HTML, static handler), **SPA** (`SSR: false`; app shell + JSON payload, client renders), **Static** (no `_page.server.go`; pure `.svelte`, client renders against `{}`). Layouts cascade per-field; page-level overrides win. Full reference: [`docs/render-modes.md`](docs/render-modes.md).
 
 ## Working rules (do not skip)
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,58 @@ hooks.server.go                  ──→ Handle, HandleError, HandleFetch
 
 Routes opting into `kit.PageOptions{Prerender: true}` ship as static HTML rendered at build time via `svelte/server`. Routes without prerender are transpiled to Go `Render()` functions at build time and rendered server-side from the Go binary at request time — no JS engine on the request path. Routes whose JS the transpiler cannot lower opt out explicitly via the `<!-- sveltego:ssr-fallback -->` HTML comment in `_page.svelte`; those route through a long-running Node sidecar with HTML cached by `(route, hash(load_result))`. **Node runs only at build time, plus as a build-time companion for opted-in fallback routes.** The deployed Go binary plus `static/` is the entire deployable.
 
+## Four render modes
+
+sveltego supports four render modes per route. **SSR is the default** — `kit.DefaultPageOptions()` returns `SSR: true`, matching SvelteKit's convention. Pick a mode per route by setting fields on `kit.PageOptions` in `_page.server.go` (or `_layout.server.go`; layouts cascade, page-level overrides win). Full reference + decision tree: [docs/render-modes.md](docs/render-modes.md).
+
+| Mode    | When to use                       | Page-options recipe                                | Runtime path                                |
+|---------|-----------------------------------|----------------------------------------------------|---------------------------------------------|
+| **SSR** (default) | Dynamic, fresh data per request   | Default — no opt-in needed (`SSR: true` is default)  | Go `Render()` emits HTML; client hydrates    |
+| **SSG** | Marketing, docs, blog             | `kit.PageOptions{Prerender: true}`                 | Build-time HTML; static handler at runtime  |
+| **SPA** | Authenticated dashboards, console | `kit.PageOptions{SSR: false}`                      | App shell + JSON payload; client renders    |
+| **Static** | No per-page data                  | No `_page.server.go`; pure `.svelte` only          | App shell + empty payload; client renders   |
+
+Quick examples:
+
+```go
+// SSR (default) — _page.server.go
+//go:build sveltego
+
+func Load(ctx kit.LoadCtx) (PageData, error) {
+    return PageData{Posts: fetchPosts(ctx)}, nil
+}
+```
+
+```go
+// SSG — _page.server.go
+//go:build sveltego
+
+const Prerender = true
+
+func Load(ctx kit.LoadCtx) (PageData, error) {
+    return PageData{Title: "About"}, nil
+}
+```
+
+```go
+// SPA — _page.server.go
+//go:build sveltego
+
+const SSR = false
+
+func Load(ctx kit.LoadCtx) (PageData, error) {
+    return PageData{User: currentUser(ctx)}, nil
+}
+```
+
+```svelte
+<!-- Static — _page.svelte only, no _page.server.go -->
+<h1>About sveltego</h1>
+<p>Static content, no server-side data.</p>
+```
+
+The `playgrounds/basic` app runs SSR by default; switch any route by editing the constants above.
+
 ## Quickstart
 
 Pre-alpha — expect rough edges. One Go command from any terminal, no clone, no global install:

--- a/docs/render-modes.md
+++ b/docs/render-modes.md
@@ -1,0 +1,179 @@
+# Render modes
+
+sveltego supports four render modes. Pick per route via [`kit.PageOptions`](../packages/sveltego/exports/kit/page_options.go) declared as exported constants in `_page.server.go` (or `_layout.server.go` — layouts cascade, page-level overrides win).
+
+**SSR is the default.** `kit.DefaultPageOptions()` returns `SSR: true`, matching SvelteKit's convention. New users get fast first paint and SEO-friendly HTML out of the box; opt out per route only when the page genuinely benefits from a different mode.
+
+| Mode    | When to use                          | Page-options recipe                                | Runtime path                                | Hydration |
+|---------|--------------------------------------|----------------------------------------------------|---------------------------------------------|-----------|
+| **SSR** (default)  | Dynamic, fresh data per request | Default — no opt-in needed (`SSR: true` is default)  | Go `Render()` emits HTML; client hydrates    | yes       |
+| **SSG** | Marketing, docs, blog                | `kit.PageOptions{Prerender: true}`                 | Build-time HTML; static handler at runtime  | yes       |
+| **SPA** | Authenticated dashboards, consoles   | `kit.PageOptions{SSR: false}`                      | App shell + JSON payload; client renders    | yes       |
+| **Static** | No per-page data                  | No `_page.server.go`; pure `.svelte` only          | App shell + empty payload; client renders   | no        |
+
+## Decision tree
+
+```
+Need per-request data from Go?
+├── No → does the page have any server data at all?
+│        ├── No → Static (just .svelte, no _page.server.go)
+│        └── Yes, but it never changes → SSG (Prerender: true)
+└── Yes → can the page be rendered ahead of time?
+         ├── Yes (content site, blog, docs)        → SSG (Prerender: true)
+         ├── No, needs SEO + LCP                   → SSR (default)
+         └── No, behind login + zero SEO concern   → SPA (SSR: false)
+```
+
+If you cannot decide, leave the defaults alone. SSR is the default for a reason: it serves dynamic data at the lowest first-paint cost without forcing a client boot before render.
+
+## Per-mode walkthrough
+
+### SSR (default)
+
+Use when each request needs fresh data and the page is publicly indexable (homepage, product page, search results). Go renders HTML at request time; the client hydrates after.
+
+**File layout:**
+
+```
+src/routes/posts/[id]/
+├── _page.svelte
+└── _page.server.go
+```
+
+**`_page.server.go`:**
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+
+type PageData struct {
+    Post Post `json:"post"`
+}
+
+func Load(ctx kit.LoadCtx) (PageData, error) {
+    id := ctx.Params["id"]
+    return PageData{Post: fetchPost(ctx, id)}, nil
+}
+```
+
+**`_page.svelte`:**
+
+```svelte
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<article>
+  <h1>{data.post.title}</h1>
+  <p>{data.post.body}</p>
+</article>
+```
+
+**Runtime:** the pipeline runs `Load`, the build-time-generated `Render(payload, props)` (transpiled from `svelte/server` JS via [ADR 0009](../tasks/decisions/0009-ssr-option-b.md) Option B) emits the HTML, and the client hydrates from the inlined payload.
+
+**Trade-off:** best LCP and SEO; pays Go CPU per request. Performance target is ≥10k rps p50 on mid-complexity pages (RFC #421 acceptance criterion).
+
+### SSG (Prerender)
+
+Use when the page rarely changes (marketing, docs, blog, changelog). The build emits static HTML once; the runtime serves it through a static handler at zero per-request CPU.
+
+**`_page.server.go`:**
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+
+const Prerender = true
+
+type PageData struct {
+    Title string `json:"title"`
+    Body  string `json:"body"`
+}
+
+func Load(ctx kit.LoadCtx) (PageData, error) {
+    return PageData{Title: "About", Body: loadAboutBody()}, nil
+}
+```
+
+**Runtime:** at `sveltego build`, a Node sidecar invokes `svelte/server` once per route with the data returned by `Load`, writes the HTML to `static/`, and the deployed binary serves the file directly. No Go template work at request time.
+
+**Trade-off:** zero per-request cost; data is frozen at build time. Performance target: 20–40k rps for the static handler.
+
+`PrerenderAuto: true` keeps `Prerender` opportunistic — the build prerenders only when the route has no dynamic params and no server `Load`, otherwise the route falls through to SSR. `PrerenderProtected: true` (#187) emits the static HTML but gates it behind the configured `PrerenderAuthGate` at request time.
+
+### SPA (SSR: false)
+
+Use when SEO is irrelevant (authenticated dashboards, internal consoles), the page benefits from rich client-side state, and the user is already past a login wall.
+
+**`_page.server.go`:**
+
+```go
+//go:build sveltego
+
+package routes
+
+import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+
+const SSR = false
+
+type PageData struct {
+    User User `json:"user"`
+}
+
+func Load(ctx kit.LoadCtx) (PageData, error) {
+    return PageData{User: currentUser(ctx)}, nil
+}
+```
+
+**Runtime:** the server returns the app shell (`app.html`) plus the JSON hydration payload from `Load`. The client mounts and renders. No HTML is generated server-side.
+
+**Trade-off:** server CPU per request is minimal — JSON encoding only — but first paint waits on the client bundle.
+
+### Static (no `_page.server.go`)
+
+Use when the page has no server data at all (a true static page: about, terms of service, simple landing). Drop the `_page.server.go` file entirely; only `_page.svelte` is needed.
+
+**File layout:**
+
+```
+src/routes/about/
+└── _page.svelte
+```
+
+**`_page.svelte`:**
+
+```svelte
+<h1>About sveltego</h1>
+<p>SvelteKit-shape framework for Go.</p>
+```
+
+**Runtime:** the server returns the app shell with an empty payload; the client mounts and renders the template against `data = {}`. No Go-side `Load`, no Render, no hydration data.
+
+**Trade-off:** simplest possible route; the page is still client-rendered, so first paint waits on the client bundle. For a true zero-JS page, combine with `Prerender: true` and a `_page.server.go` that returns an empty struct from `Load`.
+
+## Common pitfalls
+
+- **Layout cascade silently downgrades.** A `_layout.server.go` declaring `const SSR = false` makes every page underneath SPA-mode unless they explicitly set `const SSR = true`. The cascade is per-field. When in doubt, run `sveltego compile` and inspect the manifest.
+- **`Prerender` skips Handle hooks.** Build-time prerender does not run `hooks.server.go`'s `Handle`, so `Locals` is empty during `Load`. Codegen warns when a prerendered route's `Load` reads `ctx.Locals`. Move the read to a non-prerendered route or seed the data into the build script.
+- **`SSROnly: true` disables hydration.** The page renders HTML on the server but ships no client bundle. Use only for pages that need zero interactivity (printable receipts, RSS-rendered HTML mirrors).
+- **`<!-- sveltego:ssr-fallback -->` requires Node at request time.** This opt-in escape hatch routes the page through the long-running Node sidecar instead of the Go transpiler. Use only when the page's compiled JS shape genuinely cannot be lowered to Go (rare). The deploy still ships the Go binary; the sidecar is supervised separately. See [`packages/sveltego/runtime/svelte/fallback/STABILITY.md`](../packages/sveltego/runtime/svelte/fallback/STABILITY.md).
+- **Mixing modes in a layout chain.** A layout's data flows into every child page regardless of mode. SSG children that read SSR-only layout fields fail at build time with a clear error.
+- **Authoring SPA + Static together.** Both result in the client doing the rendering work. Pick Static when the page has no server data (no `_page.server.go`); pick SPA (`SSR: false`) when the page has server data that should not be SSR'd.
+
+## adapter-static
+
+`packages/adapter-static` is currently a stub tracked by [#65](https://github.com/binsarjr/sveltego/issues/65). Until it lands, a static-output deploy ships the entire `Prerender: true` route set by running `sveltego build` and uploading the contents of the build's `static/` directory; the SSR Go binary is not needed if every route is `Prerender: true`. This is awkward but accurate — the prerender engine is live; the adapter wrapper is the missing piece.
+
+## See also
+
+- [`packages/sveltego/exports/kit/page_options.go`](../packages/sveltego/exports/kit/page_options.go) — full `PageOptions` surface and field-by-field godoc.
+- [ADR 0008 — Pure-Svelte pivot](../tasks/decisions/0008-pure-svelte-pivot.md) — template invariant.
+- [ADR 0009 — SSR Option B](../tasks/decisions/0009-ssr-option-b.md) — build-time JS-to-Go transpile that powers the SSR mode.
+- [`playgrounds/basic/README.md`](../playgrounds/basic/README.md) — minimal SSR walkthrough.
+- [RFC #421](https://github.com/binsarjr/sveltego/issues/421) — Option A/B/C analysis.

--- a/packages/sveltego/STABILITY.md
+++ b/packages/sveltego/STABILITY.md
@@ -1,12 +1,29 @@
 # Stability — sveltego
 
-Last updated: 2026-04-29 · Version: pre-alpha
+Last updated: 2026-05-02 · Version: pre-alpha
 
 Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97). Pre-`v0.1` every export is implicitly experimental; this file populates as APIs land.
 
 ## Stable
 
-(none yet)
+### `kit.PageOptions` — per-route render-mode selector
+
+The mode-selecting fields are **stable** within the pre-alpha window. Behavioral defaults match SvelteKit:
+
+- `kit.DefaultPageOptions()` returns `SSR: true, CSR: true, CSRF: true, TrailingSlash: TrailingSlashNever, Templates: "svelte"`. **SSR is the framework default** for any route that omits the relevant constant.
+- `Prerender bool` — opt into SSG. Build-time HTML written to `static/`; runtime serves the file directly.
+- `SSR bool` — opt out of server-side rendering by setting `false`. Server returns the app shell + JSON payload; client renders.
+- `SSROnly bool` — render server-side and ship no client bundle. Page is non-interactive.
+- `CSR bool` — disable client hydration entirely. Server renders; client receives static markup only.
+- `PrerenderAuto bool` — opportunistic SSG: prerender only when the route has no dynamic params and no `Load`; otherwise fall through to SSR.
+- `PrerenderProtected bool` ([#187](https://github.com/binsarjr/sveltego/issues/187)) — emit static HTML at build time but gate it behind `PrerenderAuthGate` at request time.
+- `Templates string` — pipeline pick. `"svelte"` (the default and only supported value as of RFC #379 phase 5) routes through Vite + Svelte for the client and `svelte_js2go` for SSR.
+- `CSRF bool` — toggle CSRF protection for form actions.
+- `TrailingSlash TrailingSlash` — request-path trailing-slash normalization.
+
+The four render modes the framework supports — **SSR** (default), **SSG** (`Prerender: true`), **SPA** (`SSR: false`), **Static** (no `_page.server.go`) — are stable selections backed by these fields. See [`docs/render-modes.md`](../../docs/render-modes.md) for the full reference.
+
+Layout-level values cascade to descendants per field; page-level values override the cascade. The cascade contract is stable.
 
 ## Experimental
 

--- a/playgrounds/basic/README.md
+++ b/playgrounds/basic/README.md
@@ -10,6 +10,16 @@ shipped (2026-05-02), this playground returns full SSR HTML on
 targeted. No JS engine on the request path — Node only ran during
 `sveltego build` to produce the per-route `Render()` Go functions.
 
+## Render mode
+
+This playground runs every route in **SSR mode** — the default. `_page.server.go` files declare a `Load(ctx)` and emit no `Prerender` / `SSR` constants, so codegen seeds them with `kit.DefaultPageOptions()` (`SSR: true`). To switch a route into another mode, edit its `_page.server.go`:
+
+- **SSG** — add `const Prerender = true` to render once at build time.
+- **SPA** — add `const SSR = false` to ship the app shell + JSON payload only.
+- **Static** — delete `_page.server.go` entirely; only `_page.svelte` remains.
+
+See [`docs/render-modes.md`](../../docs/render-modes.md) for the full reference and decision tree.
+
 ## Layout
 
 ```


### PR DESCRIPTION
## Summary

Refresh README + AGENTS.md + CLAUDE.md so all four render modes (SSR, SSG, SPA, Static) are documented end-to-end with the post-Phase-9 / ADR-0009 reality. Adds a new full reference at `docs/render-modes.md` and calls out the SvelteKit-conventional default (SSR-on) explicitly across the doc set.

Closes #449.

## Highlights

- New section in `README.md` between the Architecture diagram and Quickstart — four-mode table with defaults, page-options recipe, runtime path, plus per-mode code examples.
- New `docs/render-modes.md` reference: mode table, decision tree, per-mode walkthrough (file layout, `_page.server.go`, `_page.svelte`, runtime path, trade-off), common pitfalls (layout cascade silent downgrade, `Prerender` skips Handle hooks, `SSROnly` disables hydration, `<!-- sveltego:ssr-fallback -->` requires Node).
- Names the four modes explicitly in `CLAUDE.md` and `AGENTS.md` invariant lists; `.cursorrules` + `.github/copilot-instructions.md` regenerated via `scripts/sync-ai-docs.sh`.
- `playgrounds/basic/README.md` now has a Render-mode section that says it runs SSR by default and shows how to switch a route into SSG / SPA / Static.
- `packages/sveltego/STABILITY.md` documents `kit.DefaultPageOptions()` defaults and the per-mode opt-out fields (`Prerender`, `SSR`, `SSROnly`, `CSR`, `PrerenderAuto`, `PrerenderProtected`, `Templates`, `CSRF`, `TrailingSlash`) as Stable.
- Honest `adapter-static` callout — stub tracked by #65; until it lands, ship `Prerender: true` route output from `static/` directly.

## Test plan

- [ ] `agents-sync` CI gate green (.cursorrules + copilot-instructions.md regenerated)
- [ ] Cross-doc grep: `Four render modes` / `SSR is the default` consistent across README, CLAUDE.md, AGENTS.md, docs/render-modes.md
- [ ] Manual review: every "see X" link resolves
- [ ] No drift between mode descriptions across files

## References

- ADR 0008 — pure-Svelte pivot (template invariant).
- ADR 0009 — SSR Option B (build-time JS-to-Go transpile, the dominant SSR path).
- `kit.PageOptions` at `packages/sveltego/exports/kit/page_options.go` — full per-route mode-picker surface.