### PR TITLE
chore: migrate <slot/> to {@render children()} (closes #450)

### DIFF
--- a/packages/init/internal/scaffold/scaffold.go
+++ b/packages/init/internal/scaffold/scaffold.go
@@ -402,7 +402,11 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
 }
 `
 
-const layoutSvelteBody = `<slot />
+const layoutSvelteBody = `<script lang="ts">
+  let { children } = $props();
+</script>
+
+{@render children()}
 `
 
 // serviceWorkerStarter is the opt-in Service Worker scaffold written when

--- a/packages/init/internal/scaffold/tailwind.go
+++ b/packages/init/internal/scaffold/tailwind.go
@@ -115,8 +115,10 @@ func renderLayoutSvelte(flavor TailwindFlavor) string {
 	var b strings.Builder
 	b.WriteString("<script lang=\"ts\">\n")
 	b.WriteString("  import './app.css';\n")
+	b.WriteString("\n")
+	b.WriteString("  let { children } = $props();\n")
 	b.WriteString("</script>\n\n")
-	b.WriteString("<slot />\n")
+	b.WriteString("{@render children()}\n")
 	return b.String()
 }
 

--- a/playgrounds/basic/src/routes/_layout.svelte
+++ b/playgrounds/basic/src/routes/_layout.svelte
@@ -1,2 +1,6 @@
+<script lang="ts">
+  let { children } = $props();
+</script>
+
 <!-- Inert in MVP. Layout chain rendering lands in v0.2 (#24). -->
-<slot />
+{@render children()}

--- a/playgrounds/blog/src/routes/_layout.svelte
+++ b/playgrounds/blog/src/routes/_layout.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  let { children } = $props();
+</script>
+
 <!--
   Root layout for the blog. Provides shared chrome (header + nav) so
   pages render inside one consistent shell. Layout chain rendering
@@ -21,7 +25,7 @@
 </header>
 
 <main class="mx-auto max-w-3xl px-4 py-8">
-  <slot />
+  {@render children()}
 </main>
 
 <footer class="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 mt-12">

--- a/playgrounds/dashboard/src/routes/_layout.svelte
+++ b/playgrounds/dashboard/src/routes/_layout.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  let { children } = $props();
+</script>
+
 <!-- Inert in MVP. Layout chain rendering lands in v0.2 (#24). The
      dashboard demo enforces auth via the Handle hook instead. -->
-<slot />
+{@render children()}

--- a/playgrounds/ssr-stress/src/routes/_layout.svelte
+++ b/playgrounds/ssr-stress/src/routes/_layout.svelte
@@ -1,1 +1,5 @@
-<slot />
+<script lang="ts">
+  let { children } = $props();
+</script>
+
+{@render children()}

--- a/playgrounds/ssr-stress/src/routes/layoutdeep/_layout.svelte
+++ b/playgrounds/ssr-stress/src/routes/layoutdeep/_layout.svelte
@@ -1,7 +1,11 @@
+<script lang="ts">
+  let { children } = $props();
+</script>
+
 <!-- Level 1 layout: top-level wrapper. Content rendering is gated on
      issue #439 (children-callback ABI). Today this acts as a slot
      pass-through under SSR; once #439 lands, the surrounding markup
      should appear in the rendered body. -->
 <header data-layout="1">layout 1</header>
-<slot />
+{@render children()}
 <footer data-layout="1">end 1</footer>

--- a/playgrounds/ssr-stress/src/routes/layoutdeep/level2/_layout.svelte
+++ b/playgrounds/ssr-stress/src/routes/layoutdeep/level2/_layout.svelte
@@ -1,4 +1,8 @@
+<script lang="ts">
+  let { children } = $props();
+</script>
+
 <!-- Level 2 layout: nested under level1. -->
 <section data-layout="2">layout 2</section>
-<slot />
+{@render children()}
 <section data-layout="2">end 2</section>

--- a/playgrounds/ssr-stress/src/routes/layoutdeep/level2/level3/_layout.svelte
+++ b/playgrounds/ssr-stress/src/routes/layoutdeep/level2/level3/_layout.svelte
@@ -1,4 +1,8 @@
+<script lang="ts">
+  let { children } = $props();
+</script>
+
 <!-- Level 3 layout: innermost wrapper. -->
 <aside data-layout="3">layout 3</aside>
-<slot />
+{@render children()}
 <aside data-layout="3">end 3</aside>


### PR DESCRIPTION
## Summary

Migrate every `_layout.svelte` in playgrounds plus the init scaffold templates from Svelte 4 `<slot/>` to Svelte 5 runes form (`let { children } = $props();` + `{@render children()}`). Closes #450.

## Why

`<slot/>` is deprecated in Svelte 5. The codegen `slot:helper` lowering keeps working today, but the source-side idiom should be the Svelte 5 form so:

1. Svelte LSP stops emitting deprecation warnings against every layout.
2. Future Svelte minors that drop `<slot>` parsing don't break us.
3. The children-callback ABI work in #440 lands against the Svelte 5 idiom from day one.

## Surface map

Files migrated (9 total):

- `playgrounds/basic/src/routes/_layout.svelte`
- `playgrounds/blog/src/routes/_layout.svelte`
- `playgrounds/dashboard/src/routes/_layout.svelte`
- `playgrounds/ssr-stress/src/routes/_layout.svelte`
- `playgrounds/ssr-stress/src/routes/layoutdeep/_layout.svelte`
- `playgrounds/ssr-stress/src/routes/layoutdeep/level2/_layout.svelte`
- `playgrounds/ssr-stress/src/routes/layoutdeep/level2/level3/_layout.svelte`
- `packages/init/internal/scaffold/scaffold.go` — `layoutSvelteBody` constant
- `packages/init/internal/scaffold/tailwind.go` — `renderLayoutSvelte` Tailwind branch

## Out-of-scope observations

- **AI templates** (`templates/ai/`, `packages/init/internal/aitemplates/files/`) are explanatory docs (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, copilot instructions). `grep '<slot\|@render\|children'` returned 0 hits — they don't reference the slot syntax at all. Left untouched per the issue's "Out of Scope" clause.
- Codegen testdata under `packages/sveltego/internal/codegen/testdata/codegen/layout/*` and `packages/sveltego/internal/codegen/testdata/component/*` keeps `<slot/>` fixtures verbatim — these test the legacy `slot:helper` backwards-compat path the issue explicitly preserves.
- No named slots existed in any tracked playground, so no snippet-side conversion was needed.

## Verification

- `grep -rn '<slot' playgrounds/ packages/init/ templates/` → **0 hits**.
- `packages/init` scaffold tests: 25 passed.
- `packages/sveltego` codegen + `svelte_js2go` tests: 656 passed (focused subset).
- `gofumpt -l` + `goimports -l` clean on changed Go files.
- `go vet ./...` + `go build ./...` green.
- Playground build smoke (per #450 acceptance criteria):
  - `basic`: `pnpm install && pnpm build` (`sveltego build`) → green.
  - `ssr-stress`: `pnpm install && pnpm build` (`sveltego build`) → green; layoutdeep chain compiles end-to-end through level3.
  - `blog`: `pnpm install && pnpm build` (`vite build`) → green.
  - `dashboard`: `pnpm install && pnpm build` (`vite build`) → green.

## Test plan

- [ ] CI green on `phase/slot-migration-450`.
- [ ] `init-smoke` job (if present) sees `{@render children()}` in the generated layout.
- [ ] No new Svelte LSP deprecation warnings against migrated layouts.
- [ ] Compiled-server output for `<slot/>`-empty layouts matches pre-migration byte-for-byte (validated by golden corpus passing).

## Coordination

- This migration is template-level only; runtime/codegen surfaces (`packages/sveltego/internal/codegen/svelte_js2go/`, `packages/sveltego/server/manifest.go`) untouched, leaving room for the codegen-track (#440) children-callback ABI work to consume the new shape on rebase.
- Docs surface (`README.md`, `CLAUDE.md`, `AGENTS.md`) untouched — those are docs-track (#449)'s scope.