### PR TITLE
feat(codegen,server): wire SSR layout-chain via children-callback ABI

### DIFF
--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -330,6 +330,7 @@ func Build(ctx context.Context, opts BuildOptions) (*BuildResult, error) {
 		HasServiceWorker:  hasServiceWorker,
 		SSRRenderRoutes:   ssrPlan.Transpiled,
 		SSRFallbackRoutes: ssrPlan.Fallback,
+		SSRRenderLayouts:  ssrPlan.Layouts,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("codegen: generate manifest: %w", err)

--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -32,6 +32,10 @@ type layoutImport struct {
 	alias     string
 	hasServer bool
 	hasHead   bool
+	// hasSSR is set for layouts in SSRRenderLayouts: the manifest emits
+	// the payload-bridge form of render__layout__<alias> that dispatches
+	// to <alias>.RenderLayoutSSR (children-callback ABI from #453).
+	hasSSR bool
 }
 
 // errorImport pairs an error-page package path with the import alias
@@ -91,6 +95,15 @@ type ManifestOptions struct {
 	// that proxies the request to the long-running Node sidecar via the
 	// runtime/svelte/fallback registry.
 	SSRFallbackRoutes []SSRFallbackRoute
+	// SSRRenderLayouts is the set of layout package paths (".gen/..."
+	// prefix preserved) whose `_layout.svelte` received a children-
+	// callback ABI emit under `.gen/layoutsrc/<encoded>/` plus a
+	// `wire_layout_render.gen.go` per route dir (#456). For these
+	// layouts the manifest emits the payload-bridge form of
+	// `render__layout__<alias>` — calling the typed
+	// `RenderLayoutSSR(payload, data, inner)` from the wire — instead of
+	// the legacy `Layout{}.Render(*render.Writer, ..., children)` shape.
+	SSRRenderLayouts map[string]struct{}
 }
 
 // GenerateManifest emits a deterministic, gofmt-clean Go source file
@@ -174,6 +187,10 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	for i := range layoutImports {
 		layoutImports[i].hasServer = layoutHasServer[layoutImports[i].pkgPath]
 		layoutImports[i].hasHead = opts.LayoutHeads[layoutImports[i].pkgPath]
+		if opts.SSRRenderLayouts != nil {
+			_, ok := opts.SSRRenderLayouts[layoutImports[i].pkgPath]
+			layoutImports[i].hasSSR = ok
+		}
 	}
 	sort.Slice(layoutImports, func(i, j int) bool {
 		return layoutImports[i].pkgPath < layoutImports[j].pkgPath
@@ -249,6 +266,36 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	}
 	hasLayout := len(layoutImports) > 0
 	hasError := len(errorImports) > 0
+	if !hasSvelte {
+		for _, li := range layoutImports {
+			if li.hasSSR {
+				hasSvelte = true
+				break
+			}
+		}
+	}
+	// usesFmt reports whether any emitted adapter actually references
+	// fmt.Errorf. Only the legacy Mustache-Go page+layout adapters
+	// (typed-data type-assert error path) use it; the SSR payload-bridge
+	// adapters introduced in Phase 6 (#428) and #456 do not.
+	usesFmt := false
+	for _, e := range entries {
+		if !e.route.HasPage {
+			continue
+		}
+		if !isSvelteRoute(e.route.Pattern, opts.RouteOptions) {
+			usesFmt = true
+			break
+		}
+	}
+	if !usesFmt {
+		for _, li := range layoutImports {
+			if !li.hasSSR {
+				usesFmt = true
+				break
+			}
+		}
+	}
 
 	// Build a deduplicated set of (alias, packagePath) pairs across page
 	// entries, layout-only imports, and error-only imports.
@@ -303,8 +350,10 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	b.Indent()
 	switch {
 	case hasPage || hasLayout:
-		b.Line(`"fmt"`)
-		b.Line("")
+		if usesFmt {
+			b.Line(`"fmt"`)
+			b.Line("")
+		}
 		b.Line(`"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"`)
 		b.Line(`"github.com/binsarjr/sveltego/packages/sveltego/render"`)
 	case hasError:
@@ -605,32 +654,40 @@ func emitFallbackInit(b *Builder, fallback []SSRFallbackRoute) {
 }
 
 // emitLayoutAdapters writes one `render__layout__<alias>` function per
-// unique layout package. Each adapter widens Layout{}.Render's typed
-// LayoutData to the `any`-shaped router.LayoutHandler. Layout packages
-// with a sibling layout.server.go additionally receive a load adapter
-// `loadLayout__<alias>` that wraps the wire-emitted LayoutLoad to
-// satisfy router.LayoutLoadHandler.
+// unique layout package. The default form widens Layout{}.Render's typed
+// LayoutData to the `any`-shaped router.LayoutHandler (legacy mustache
+// path). Layouts in SSRRenderLayouts swap to the payload-bridge form
+// from #456: dispatch to the wire-emitted RenderLayoutSSR through a
+// fresh server.Payload, bridge the writer-shape `children` callback
+// into the payload, and copy payload.Body() into the outer writer at
+// the end. Layout packages with a sibling layout.server.go additionally
+// receive a load adapter `loadLayout__<alias>` that wraps the wire-
+// emitted LayoutLoad to satisfy router.LayoutLoadHandler.
 func emitLayoutAdapters(b *Builder, imports []layoutImport) {
 	for _, li := range imports {
-		b.Linef("// render__layout__%s adapts %s.Layout{}.Render to router.LayoutHandler.", li.alias, li.alias)
-		b.Linef("func render__layout__%s(w *render.Writer, ctx *kit.RenderCtx, data any, children func(*render.Writer) error) error {", li.alias)
-		b.Indent()
-		b.Linef("var typed %s.LayoutData", li.alias)
-		b.Line("if data != nil {")
-		b.Indent()
-		b.Linef("v, ok := data.(%s.LayoutData)", li.alias)
-		b.Line("if !ok {")
-		b.Indent()
-		b.Linef(`return fmt.Errorf("sveltego: layout %%q: LayoutData type mismatch (got %%T, want %s.LayoutData)", %s, data)`, li.alias, quoteGo(li.pkgPath))
-		b.Dedent()
-		b.Line("}")
-		b.Line("typed = v")
-		b.Dedent()
-		b.Line("}")
-		b.Linef("return %s.Layout{}.Render(w, ctx, typed, children)", li.alias)
-		b.Dedent()
-		b.Line("}")
-		b.Line("")
+		if li.hasSSR {
+			emitSSRLayoutAdapter(b, li)
+		} else {
+			b.Linef("// render__layout__%s adapts %s.Layout{}.Render to router.LayoutHandler.", li.alias, li.alias)
+			b.Linef("func render__layout__%s(w *render.Writer, ctx *kit.RenderCtx, data any, children func(*render.Writer) error) error {", li.alias)
+			b.Indent()
+			b.Linef("var typed %s.LayoutData", li.alias)
+			b.Line("if data != nil {")
+			b.Indent()
+			b.Linef("v, ok := data.(%s.LayoutData)", li.alias)
+			b.Line("if !ok {")
+			b.Indent()
+			b.Linef(`return fmt.Errorf("sveltego: layout %%q: LayoutData type mismatch (got %%T, want %s.LayoutData)", %s, data)`, li.alias, quoteGo(li.pkgPath))
+			b.Dedent()
+			b.Line("}")
+			b.Line("typed = v")
+			b.Dedent()
+			b.Line("}")
+			b.Linef("return %s.Layout{}.Render(w, ctx, typed, children)", li.alias)
+			b.Dedent()
+			b.Line("}")
+			b.Line("")
+		}
 
 		if li.hasServer {
 			b.Linef("// loadLayout__%s adapts %s.LayoutLoad to router.LayoutLoadHandler.", li.alias, li.alias)
@@ -638,6 +695,61 @@ func emitLayoutAdapters(b *Builder, imports []layoutImport) {
 			b.Line("")
 		}
 	}
+}
+
+// emitSSRLayoutAdapter writes the children-callback payload-bridge form
+// of render__layout__<alias> introduced by #456. The emitted adapter
+// allocates a fresh server.Payload, dispatches to the wire-emitted
+// RenderLayoutSSR (which calls the typed Render(payload, data, inner)
+// from the layoutsrc package), bridges the writer-shape `children`
+// callback into the payload via a temporary render.Writer, and copies
+// the rendered head + body into the outer writer.
+func emitSSRLayoutAdapter(b *Builder, li layoutImport) {
+	b.Linef("// render__layout__%s bridges %s.RenderLayoutSSR (Svelte SSR Option B,", li.alias, li.alias)
+	b.Linef("// children-callback ABI from #453) into router.LayoutHandler.")
+	b.Linef("func render__layout__%s(w *render.Writer, ctx *kit.RenderCtx, data any, children func(*render.Writer) error) error {", li.alias)
+	b.Indent()
+	b.Line("_ = ctx")
+	b.Line("var payload server.Payload")
+	b.Line("var childErr error")
+	b.Line("inner := func(p *server.Payload) {")
+	b.Indent()
+	b.Line("if childErr != nil {")
+	b.Indent()
+	b.Line("return")
+	b.Dedent()
+	b.Line("}")
+	b.Line("buf := render.Acquire()")
+	b.Line("defer render.Release(buf)")
+	b.Line("if err := children(buf); err != nil {")
+	b.Indent()
+	b.Line("childErr = err")
+	b.Line("return")
+	b.Dedent()
+	b.Line("}")
+	b.Line("p.Push(string(buf.Bytes()))")
+	b.Dedent()
+	b.Line("}")
+	b.Linef("if err := %s.RenderLayoutSSR(&payload, data, inner); err != nil {", li.alias)
+	b.Indent()
+	b.Line("return err")
+	b.Dedent()
+	b.Line("}")
+	b.Line("if childErr != nil {")
+	b.Indent()
+	b.Line("return childErr")
+	b.Dedent()
+	b.Line("}")
+	b.Line("if head := payload.HeadHTML(); head != \"\" {")
+	b.Indent()
+	b.Line("w.WriteString(head)")
+	b.Dedent()
+	b.Line("}")
+	b.Line("w.WriteString(payload.Body())")
+	b.Line("return nil")
+	b.Dedent()
+	b.Line("}")
+	b.Line("")
 }
 
 // isSvelteRoute reports whether the route's resolved page options

--- a/packages/sveltego/internal/codegen/ssr.go
+++ b/packages/sveltego/internal/codegen/ssr.go
@@ -33,9 +33,16 @@ type ssrPlan struct {
 // Fallback holds routes that explicitly opted out via the
 // `<!-- sveltego:ssr-fallback -->` comment; those route through the
 // long-running Node sidecar at request time (Phase 8, #430).
+//
+// Layouts holds layout package paths (with the ".gen/" prefix, matching
+// LayoutPackagePaths) that received a wire_layout_render.gen.go emit so
+// the manifest can swap their adapter from the legacy
+// `Layout{}.Render(*render.Writer, ...)` form to the children-callback
+// payload bridge wired via #453 (issue #456).
 type SSRPlanResult struct {
 	Transpiled map[string]string
 	Fallback   []SSRFallbackRoute
+	Layouts    map[string]struct{}
 }
 
 // SSRFallbackRoute names one route the runtime must dispatch to the
@@ -45,6 +52,20 @@ type SSRPlanResult struct {
 type SSRFallbackRoute struct {
 	Pattern string
 	Source  string
+}
+
+// layoutPlan is the per-layout work item for #456. dir is the absolute
+// layout directory (matches a routescan LayoutChain entry); pkgPath is
+// the encoded gen package path (`.gen/routes/...`); pkgName is the
+// leaf-encoded package name; serverFile points at `_layout.server.go`
+// when present; shape carries the typegen Shape used by the Lowerer
+// (synthetic empty LayoutData when no server file exists).
+type layoutPlan struct {
+	dir        string
+	pkgPath    string
+	pkgName    string
+	serverFile string
+	shape      typegen.Shape
 }
 
 // runSSRTranspile drives the Phase 6 (#428) + Phase 8 (#430) SSR codegen
@@ -63,11 +84,12 @@ type SSRFallbackRoute struct {
 //     or annotate the route to opt into the sidecar fallback.
 func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string, logger *slog.Logger, scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions) (SSRPlanResult, error) {
 	transpilePlan, fallback := planSSR(scan, routeOptions)
+	layoutPlans := planSSRLayouts(scan, transpilePlan)
 	result := SSRPlanResult{Fallback: fallback}
-	if len(transpilePlan) == 0 && len(fallback) == 0 {
+	if len(transpilePlan) == 0 && len(fallback) == 0 && len(layoutPlans) == 0 {
 		return result, nil
 	}
-	if len(transpilePlan) == 0 {
+	if len(transpilePlan) == 0 && len(layoutPlans) == 0 {
 		logger.Info("ssr fallback only: no routes transpiled to Go",
 			logKeyFallbackCount, len(fallback))
 		return result, nil
@@ -76,7 +98,7 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 		return result, fmt.Errorf("codegen: ssr requires node 18+ on $PATH (or annotate routes with <!-- sveltego:ssr-fallback --> if they intentionally bypass the transpiler): %w", err)
 	}
 
-	jobs := make([]svelterender.SSRJob, 0, len(transpilePlan))
+	jobs := make([]svelterender.SSRJob, 0, len(transpilePlan)+len(layoutPlans))
 	for _, p := range transpilePlan {
 		rel, err := filepath.Rel(projectRoot, filepath.Join(p.route.Dir, "_page.svelte"))
 		if err != nil {
@@ -84,6 +106,20 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 		}
 		jobs = append(jobs, svelterender.SSRJob{
 			Route:  p.route.Pattern,
+			Source: filepath.ToSlash(rel),
+		})
+	}
+	for _, lp := range layoutPlans {
+		layoutSrc, err := resolveLayoutSource(lp.dir)
+		if err != nil {
+			return result, fmt.Errorf("codegen: ssr layout source %s: %w", lp.dir, err)
+		}
+		rel, err := filepath.Rel(projectRoot, layoutSrc)
+		if err != nil {
+			return result, fmt.Errorf("codegen: ssr layout rel %s: %w", layoutSrc, err)
+		}
+		jobs = append(jobs, svelterender.SSRJob{
+			Route:  layoutJobKey(lp.pkgPath),
 			Source: filepath.ToSlash(rel),
 		})
 	}
@@ -166,7 +202,106 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 		emitted[p.route.Pattern] = encodedSub
 	}
 	result.Transpiled = emitted
+
+	if len(layoutPlans) == 0 {
+		return result, nil
+	}
+	layoutsByPkg := make(map[string]struct{}, len(layoutPlans))
+	for _, lp := range layoutPlans {
+		jobKey := layoutJobKey(lp.pkgPath)
+		astPath, ok := resultsByRoute[jobKey]
+		if !ok {
+			return result, fmt.Errorf("codegen: ssr ast missing for layout %s", lp.pkgPath)
+		}
+		envelope, err := os.ReadFile(astPath) //nolint:gosec // path is sidecar-emitted under .gen
+		if err != nil {
+			return result, fmt.Errorf("codegen: read ssr ast %s: %w", astPath, err)
+		}
+
+		shape := lp.shape
+		lowerer := sveltejs2go.NewLowerer(&shape, sveltejs2go.LowererOptions{
+			Route:  lp.pkgPath,
+			Strict: true,
+		})
+
+		encodedSub := strings.TrimPrefix(lp.pkgPath, ".gen/")
+		pkgDir := filepath.Join(projectRoot, outDir, "layoutsrc", filepath.FromSlash(encodedSub))
+		if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+			return result, fmt.Errorf("codegen: mkdir %s: %w", pkgDir, err)
+		}
+
+		out, err := sveltejs2go.Transpile(envelope, sveltejs2go.Options{
+			PackageName:       lp.pkgName,
+			FuncName:          "Render",
+			Rewriter:          lowerer,
+			TypedDataParam:    shape.RootType,
+			EmitChildrenParam: true,
+		})
+		if err != nil {
+			return result, fmt.Errorf("codegen: ssr layout transpile %s: %w", lp.pkgPath, err)
+		}
+		if lerr := lowerer.Err(); lerr != nil {
+			return result, fmt.Errorf("codegen: ssr layout lowering %s: %w", lp.pkgPath, lerr)
+		}
+
+		target := filepath.Join(pkgDir, "layout_render.gen.go")
+		if err := os.WriteFile(target, out, genFileMode); err != nil {
+			return result, fmt.Errorf("codegen: write %s: %w", target, err)
+		}
+
+		if _, done := companionDropped[pkgDir]; !done {
+			companion := sveltejs2go.CompanionFile(lp.pkgName)
+			compPath := filepath.Join(pkgDir, "ssr_companion.gen.go")
+			if err := os.WriteFile(compPath, companion, genFileMode); err != nil {
+				return result, fmt.Errorf("codegen: write %s: %w", compPath, err)
+			}
+			companionDropped[pkgDir] = struct{}{}
+		}
+
+		if lp.serverFile == "" {
+			if err := emitSyntheticLayoutData(pkgDir, lp.pkgName); err != nil {
+				return result, err
+			}
+		}
+
+		wireDir := filepath.Join(projectRoot, outDir, filepath.FromSlash(encodedSub))
+		if err := emitSSRLayoutWire(outDir, modulePath, mirrorRoute{
+			encodedSubpath: encodedSub,
+			packageName:    lp.pkgName,
+			wireDir:        wireDir,
+		}); err != nil {
+			return result, err
+		}
+
+		layoutsByPkg[lp.pkgPath] = struct{}{}
+	}
+	result.Layouts = layoutsByPkg
 	return result, nil
+}
+
+// layoutJobKey derives the BuildSSRAST job key for a layout package
+// path. The key feeds the sidecar's `routeSlug` helper which strips
+// leading slashes and `__`-joins segments to form an output directory
+// name. Page jobs use the route Pattern (e.g. `/longlist`) so layouts
+// pick the disjoint `__layout__` namespace to avoid colliding with a
+// hypothetical `/layout` page route.
+func layoutJobKey(layoutPkgPath string) string {
+	return "/__layout__/" + strings.TrimPrefix(layoutPkgPath, ".gen/")
+}
+
+// emitSyntheticLayoutData drops a tiny `layout_synthetic.gen.go` into
+// pkgDir declaring `type LayoutData = struct{}`. The wire-emitted
+// `RenderLayoutSSR` references `usersrc.LayoutData` unconditionally;
+// layouts without a `_layout.server.go` mirror have no other source for
+// the type, so the synthetic alias keeps the typed-data ABI uniform
+// without forcing every layout to author a server file.
+func emitSyntheticLayoutData(pkgDir, pkgName string) error {
+	src := "// Code generated by sveltego. DO NOT EDIT.\n\npackage " + pkgName + "\n\ntype LayoutData = struct{}\n"
+	target := filepath.Join(pkgDir, "layout_synthetic.gen.go")
+	if err := os.WriteFile(target, []byte(src), genFileMode); err != nil {
+		return fmt.Errorf("codegen: write %s: %w", target, err)
+	}
+	return nil
 }
 
 // planSSR partitions routescan.Routes into the build-time transpile
@@ -227,4 +362,68 @@ func planSSR(scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions
 		plans = append(plans, ssrPlan{route: r, shape: shape})
 	}
 	return plans, fallback
+}
+
+// planSSRLayouts collects every unique layout package referenced by a
+// route that qualifies for the Phase 6 SSR transpile (#456). Layouts
+// shared between sibling routes are deduplicated by package path; only
+// layouts reachable from a Svelte-SSR-eligible page route are included.
+//
+// A layout with `_layout.server.go` drives shape inference via typegen
+// (KindLayout); a layout without a server file synthesises an empty
+// shape so the Lowerer leaves bare expressions alone but still hard-
+// errors on `data.X` access (matching the page contract).
+func planSSRLayouts(scan *routescan.ScanResult, pagePlans []ssrPlan) []layoutPlan {
+	if scan == nil {
+		return nil
+	}
+	pageRoutes := make(map[string]struct{}, len(pagePlans))
+	for _, p := range pagePlans {
+		pageRoutes[p.route.Pattern] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+	plans := make([]layoutPlan, 0)
+	for _, r := range scan.Routes {
+		if _, ok := pageRoutes[r.Pattern]; !ok {
+			continue
+		}
+		for i, layoutDir := range r.LayoutChain {
+			if i >= len(r.LayoutPackagePaths) {
+				continue
+			}
+			pkgPath := r.LayoutPackagePaths[i]
+			if _, done := seen[pkgPath]; done {
+				continue
+			}
+			seen[pkgPath] = struct{}{}
+
+			serverFile := ""
+			if i < len(r.LayoutServerFiles) {
+				serverFile = r.LayoutServerFiles[i]
+			}
+			pkgName := layoutPackageName(pkgPath)
+			lp := layoutPlan{
+				dir:        layoutDir,
+				pkgPath:    pkgPath,
+				pkgName:    pkgName,
+				serverFile: serverFile,
+			}
+			if serverFile != "" {
+				shape, _, err := typegen.BuildShape(serverFile, typegen.KindLayout)
+				if err == nil {
+					lp.shape = shape
+				}
+			}
+			if lp.shape.RootType == "" {
+				lp.shape = typegen.Shape{
+					RootType: "LayoutData",
+					Types: map[string]typegen.ShapeType{
+						"LayoutData": {Name: "LayoutData", Fields: nil},
+					},
+				}
+			}
+			plans = append(plans, lp)
+		}
+	}
+	return plans
 }

--- a/packages/sveltego/internal/codegen/ssr_test.go
+++ b/packages/sveltego/internal/codegen/ssr_test.go
@@ -82,3 +82,76 @@ func mkSvelteOpts() kit.PageOptions {
 	o.Templates = kit.TemplatesSvelte
 	return o
 }
+
+// TestPlanSSRLayouts_DedupesAndSynthesisesShape verifies #456: the
+// layout planner enumerates every layout dir reachable from a Svelte-
+// SSR-eligible page route, deduplicates layouts shared between
+// sibling routes, and synthesises an empty-LayoutData shape when no
+// `_layout.server.go` is present so the wire helper still compiles
+// against `usersrc.LayoutData`.
+func TestPlanSSRLayouts_DedupesAndSynthesisesShape(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("src/routes/_layout.svelte", "{@render children()}")
+	mustWrite("src/routes/foo/_layout.svelte", "<header>foo</header>{@render children()}")
+	mustWrite("src/routes/foo/_page.svelte", "<h1>foo</h1>")
+	mustWrite("src/routes/foo/_page.server.go", `package foo
+
+type PageData struct{ Name string `+"`json:\"name\"`"+` }
+
+func Load(ctx any) (PageData, error) { return PageData{}, nil }
+`)
+	mustWrite("src/routes/foo/bar/_page.svelte", "<h1>bar</h1>")
+	mustWrite("src/routes/foo/bar/_page.server.go", `package bar
+
+type PageData struct{ Slug string `+"`json:\"slug\"`"+` }
+
+func Load(ctx any) (PageData, error) { return PageData{}, nil }
+`)
+
+	scan, err := routescan.Scan(routescan.ScanInput{RoutesDir: filepath.Join(root, "src", "routes")})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	routeOptions := map[string]kit.PageOptions{
+		"/foo":     mkSvelteOpts(),
+		"/foo/bar": mkSvelteOpts(),
+	}
+	pagePlans, _ := planSSR(scan, routeOptions)
+	layoutPlans := planSSRLayouts(scan, pagePlans)
+
+	// /foo and /foo/bar share two layouts (root + /foo); planSSRLayouts
+	// dedupes by package path.
+	if got, want := len(layoutPlans), 2; got != want {
+		t.Fatalf("layoutPlans count = %d, want %d (paths: %v)", got, want, layoutPlanPaths(layoutPlans))
+	}
+	for _, lp := range layoutPlans {
+		if lp.shape.RootType != "LayoutData" {
+			t.Fatalf("layout %s: shape RootType = %q, want LayoutData", lp.pkgPath, lp.shape.RootType)
+		}
+		if _, ok := lp.shape.Types["LayoutData"]; !ok {
+			t.Fatalf("layout %s: shape.Types missing LayoutData entry", lp.pkgPath)
+		}
+		if lp.serverFile != "" {
+			t.Fatalf("layout %s: unexpected serverFile %q", lp.pkgPath, lp.serverFile)
+		}
+	}
+}
+
+func layoutPlanPaths(ps []layoutPlan) []string {
+	out := make([]string, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, p.pkgPath)
+	}
+	return out
+}

--- a/packages/sveltego/internal/codegen/svelte_mode_test.go
+++ b/packages/sveltego/internal/codegen/svelte_mode_test.go
@@ -94,6 +94,63 @@ func TestGenerateManifest_SvelteMode_SSRRender(t *testing.T) {
 	}
 }
 
+// TestGenerateManifest_SvelteMode_SSRLayout verifies #456: when a
+// layout package is in SSRRenderLayouts, the manifest swaps its
+// `render__layout__<alias>` adapter from the legacy
+// `Layout{}.Render(*render.Writer, ...)` call to the children-callback
+// payload bridge that dispatches `<alias>.RenderLayoutSSR`.
+func TestGenerateManifest_SvelteMode_SSRLayout(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("routes/_layout.svelte", "{@render children()}")
+	mustWrite("routes/_page.svelte", "<h1>home</h1>")
+
+	scan, err := routescan.Scan(routescan.ScanInput{RoutesDir: filepath.Join(root, "routes")})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	pattern := scan.Routes[0].Pattern
+	pkgPath := scan.Routes[0].PackagePath
+	routeOpts := map[string]kit.PageOptions{
+		pattern: {SSR: true, CSR: true, CSRF: true, TrailingSlash: kit.TrailingSlashNever, Templates: kit.TemplatesSvelte},
+	}
+	out, err := GenerateManifest(scan, ManifestOptions{
+		PackageName:  "gen",
+		ModulePath:   "myapp",
+		GenRoot:      ".gen",
+		RouteOptions: routeOpts,
+		SSRRenderRoutes: map[string]string{
+			pattern: "routes",
+		},
+		SSRRenderLayouts: map[string]struct{}{
+			pkgPath: {},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifest: %v", err)
+	}
+	s := string(out)
+	if !bytes.Contains(out, []byte(".RenderLayoutSSR(&payload, data, inner)")) {
+		t.Errorf("expected RenderLayoutSSR call inside layout bridge:\n%s", s)
+	}
+	if bytes.Contains(out, []byte(".Layout{}.Render(w, ctx, typed, children)")) {
+		t.Errorf("legacy Layout{}.Render call should not appear when layout is SSR-bridged:\n%s", s)
+	}
+	if !bytes.Contains(out, []byte("inner := func(p *server.Payload) {")) {
+		t.Errorf("expected children-bridge closure:\n%s", s)
+	}
+}
+
 // TestNeedsNodeForSvelteSSG verifies the SSG sidecar trigger fires
 // only when at least one route combines Templates: "svelte" with
 // Prerender: true.

--- a/playgrounds/ssr-stress/README.md
+++ b/playgrounds/ssr-stress/README.md
@@ -28,11 +28,13 @@ Tracked together in [#443](https://github.com/binsarjr/sveltego/issues/443):
   non-boolean in Go. Awaiting a lowerer guard for truthy-struct
   conditions.
 
-[#440](https://github.com/binsarjr/sveltego/issues/440) tracks the
-deeper layout-chain carryover (children-callback ABI) — the
-`/layoutdeep/...` route is the test fixture for that work; today the
-slot-only path renders, but per-level body content beyond the first
-level depends on #440.
+[#456](https://github.com/binsarjr/sveltego/issues/456) wired the
+deep layout chain into the children-callback ABI shipped in
+[#440](https://github.com/binsarjr/sveltego/issues/440) /
+[PR #453](https://github.com/binsarjr/sveltego/pull/453). The
+`/layoutdeep/level2/level3` route is the end-to-end fixture: every
+level emits non-trivial chrome (`<header>`, `<section>`, `<aside>`)
+that wraps the inner page output in `curl` against the SSR'd HTML.
 
 ## Snapshots
 

--- a/playgrounds/ssr-stress/testdata/snapshots/layoutdeep.html
+++ b/playgrounds/ssr-stress/testdata/snapshots/layoutdeep.html
@@ -6,19 +6,6 @@
 
 </head>
 <body>
-
-<header data-layout="1">layout 1</header>
-
-<section data-layout="2">layout 2</section>
-
-<aside data-layout="3">layout 3</aside>
-<h1>deep layout leaf</h1> <p>3-level layout chain leaf.</p>
-<aside data-layout="3">end 3</aside>
-
-<section data-layout="2">end 2</section>
-
-<footer data-layout="1">end 1</footer>
-
-<!--SVELTEGO-DATA-OMITTED-->
+<header data-layout="1">layout 1</header> <section data-layout="2">layout 2</section> <aside data-layout="3">layout 3</aside> <h1>deep layout leaf</h1> <p>3-level layout chain leaf.</p><!----> <aside data-layout="3">end 3</aside><!----> <section data-layout="2">end 2</section><!----> <footer data-layout="1">end 1</footer><!----><!--SVELTEGO-DATA-OMITTED-->
 </body>
 </html>


### PR DESCRIPTION
## Summary

Closes [#456](https://github.com/binsarjr/sveltego/issues/456).

Wires the primitives shipped in [PR #453](https://github.com/binsarjr/sveltego/pull/453) (children-callback ABI, `EmitChildrenParam`, `LocalCallback`, `RenderLayoutSSR` helper) into the request-time pipeline so layouts with content render server-side end-to-end. The Phase 6 soft-fallback path for layouts goes silent.

The `ssr-stress` `/layoutdeep/level2/level3` route is the end-to-end fixture — it now SSRs the full nested chrome (header → section → aside → page leaf → aside → section → footer) via the new payload bridge. Verified locally with `curl` against the playground binary; output matches the regenerated `testdata/snapshots/layoutdeep.html`.

## Acceptance criteria (#456)

- [x] Manifest emits `render__layout__<alias>` payload-bridge per layout
- [x] `planSSR` enumerates `_layout.svelte` files and drives sidecar
- [x] `.gen/layoutsrc/<encoded>/layout_render.gen.go` per layout
- [x] `wire_layout_render.gen.go` per package via `RenderLayoutSSR` helper
- [x] ssr-stress `/layoutdeep/...` SSRs full layout chain (curl returns nested chrome)
- [x] Phase 6 soft-fallback path for layouts removed
- [x] `go test -race ./packages/sveltego/...` 1705 pass (≥1702 baseline + new tests)

## Implementation notes

- `planSSRLayouts` deduplicates layouts shared between sibling routes by package path. Layouts without `_layout.server.go` synthesise an empty `LayoutData` shape so the wire compiles uniformly.
- A new `layoutsrc/<encoded>/layout_synthetic.gen.go` is emitted alongside `layout_render.gen.go` when no server file exists, declaring `type LayoutData = struct{}`. The mirror is sibling to the `usersrc/<encoded>/` page tree so a route directory that owns both `_page.server.go` and `_layout.server.go` keeps two independent gen packages.
- The payload-bridge adapter in `manifest.go` allocates a fresh `server.Payload`, dispatches `<alias>.RenderLayoutSSR(payload, data, inner)`, and bridges the writer-shape `children` callback through a temporary `render.Writer`. Per-level allocation keeps the existing pipeline composition (`route.LayoutChain[]` of writer-shaped handlers) unchanged — no `router.Route` shape change.
- Layouts outside the new SSR set keep the legacy `Layout{}.Render(*render.Writer, ...)` adapter so non-Svelte routes that share the same layout dir continue to render unchanged.
- `usesFmt` gating on the `fmt` import: only the legacy Mustache-Go adapters reference `fmt.Errorf`; SSR-bridge adapters do not. The previous unconditional import surfaced "imported and not used" once every route + layout in a project went through the Svelte SSR pipeline.

## Issue # mismatch

Team-lead's dispatch named `#455`, but `#455` is `expose Routes() on *server.Server for adapter enumeration` — unrelated to layout wiring. The spec described in the dispatch matches `#456` exactly. Branch name kept as dispatched (`phase/ssr-layout-wire-455`); commit + PR + close target `#456`.

## Test plan

- [x] `go test -race ./packages/sveltego/...` — 1705 pass (incl. 2 new tests in `ssr_test.go` and `svelte_mode_test.go`).
- [x] `go vet ./packages/sveltego/...` — clean.
- [x] `gofumpt -l` + `goimports -l -local github.com/binsarjr/sveltego` on touched files — clean.
- [x] `golangci-lint run --new-from-rev=origin/main` — clean.
- [x] ssr-stress idempotency: two consecutive `compile` runs produce byte-identical `.gen/` trees.
- [x] ssr-stress smoke: `curl /layoutdeep/level2/level3` returns full nested chrome matching the updated snapshot.

Refs #440, #453.