### PR TITLE
feat(server,adapter-static): expose Routes() for adapter enumeration

### DIFF
--- a/packages/adapter-static/subprocess_runner.go
+++ b/packages/adapter-static/subprocess_runner.go
@@ -3,8 +3,10 @@ package adapterstatic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -92,11 +94,44 @@ func (r *subprocessRunner) Prerender(ctx context.Context, projectRoot, scratchDi
 	}
 	sort.Strings(prerendered)
 
-	// The subprocess runner does not have direct access to the user
-	// binary's full route table, so it cannot enumerate dynamic routes
-	// here. FailOnDynamic via the subprocess path is therefore a no-op
-	// today — see the package README for the in-process workaround.
-	return RunInfo{PrerenderedRoutes: prerendered}, nil
+	dynamic, err := readDynamicRoutes(scratchDir, seen)
+	if err != nil {
+		return RunInfo{}, err
+	}
+
+	return RunInfo{PrerenderedRoutes: prerendered, DynamicRoutes: dynamic}, nil
+}
+
+// readDynamicRoutes parses the routes.json sidecar the user binary's
+// MaybePrerenderFromEnv writes alongside manifest.json. Routes whose
+// pattern is not in the prerendered set are treated as dynamic. Returns
+// nil + nil when the sidecar is absent so older binaries (without #455)
+// keep producing the same RunInfo as before.
+func readDynamicRoutes(scratchDir string, prerendered map[string]struct{}) ([]string, error) {
+	routesPath := filepath.Join(scratchDir, "routes.json")
+	body, err := os.ReadFile(routesPath) //nolint:gosec // path is adapter-controlled
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("adapter-static: read routes manifest: %w", err)
+	}
+	var summaries []struct {
+		Pattern   string `json:"Pattern"`
+		Prerender bool   `json:"Prerender"`
+	}
+	if err := json.Unmarshal(body, &summaries); err != nil {
+		return nil, fmt.Errorf("adapter-static: parse routes manifest: %w", err)
+	}
+	out := make([]string, 0, len(summaries))
+	for _, s := range summaries {
+		if _, ok := prerendered[s.Pattern]; ok {
+			continue
+		}
+		out = append(out, s.Pattern)
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 // compile-time assertion: keep the runner satisfying the Runner contract.

--- a/packages/adapter-static/subprocess_runner_test.go
+++ b/packages/adapter-static/subprocess_runner_test.go
@@ -1,0 +1,83 @@
+package adapterstatic
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestSubprocessRunner_EnumeratesRoutes verifies that readDynamicRoutes
+// correctly classifies routes from the routes.json sidecar emitted by
+// the user binary's MaybePrerenderFromEnv. Routes that produced HTML
+// are filtered out; the remainder is returned sorted as DynamicRoutes.
+//
+// We exercise the parsing helper directly rather than spawning a real
+// Go build — the production runner path is covered end-to-end by the
+// CLI integration tests.
+func TestSubprocessRunner_EnumeratesRoutes(t *testing.T) {
+	t.Parallel()
+
+	scratch := t.TempDir()
+
+	type summary struct {
+		Pattern   string `json:"Pattern"`
+		Prerender bool   `json:"Prerender"`
+	}
+	all := []summary{
+		{Pattern: "/", Prerender: true},
+		{Pattern: "/about", Prerender: true},
+		{Pattern: "/post/[id]", Prerender: false},
+		{Pattern: "/api/data", Prerender: false},
+		{Pattern: "/dashboard", Prerender: false},
+	}
+	body, err := json.Marshal(all)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scratch, "routes.json"), body, 0o600); err != nil {
+		t.Fatalf("write routes.json: %v", err)
+	}
+
+	prerendered := map[string]struct{}{
+		"/":      {},
+		"/about": {},
+	}
+
+	got, err := readDynamicRoutes(scratch, prerendered)
+	if err != nil {
+		t.Fatalf("readDynamicRoutes: %v", err)
+	}
+
+	want := []string{"/api/data", "/dashboard", "/post/[id]"}
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dynamic routes = %v, want %v", got, want)
+	}
+}
+
+func TestSubprocessRunner_RoutesManifestAbsent(t *testing.T) {
+	t.Parallel()
+	scratch := t.TempDir()
+	got, err := readDynamicRoutes(scratch, map[string]struct{}{"/": {}})
+	if err != nil {
+		t.Fatalf("readDynamicRoutes: %v", err)
+	}
+	if got != nil {
+		t.Errorf("dynamic = %v, want nil for missing routes.json (back-compat)", got)
+	}
+}
+
+func TestSubprocessRunner_RoutesManifestMalformed(t *testing.T) {
+	t.Parallel()
+	scratch := t.TempDir()
+	if err := os.WriteFile(filepath.Join(scratch, "routes.json"), []byte("not json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := readDynamicRoutes(scratch, map[string]struct{}{})
+	if err == nil {
+		t.Errorf("expected parse error for malformed routes.json")
+	}
+}

--- a/packages/sveltego/STABILITY.md
+++ b/packages/sveltego/STABILITY.md
@@ -27,7 +27,14 @@ Layout-level values cascade to descendants per field; page-level values override
 
 ## Experimental
 
-(none yet)
+### `server.Server.Routes()` and `server.RouteSummary` ([#455](https://github.com/binsarjr/sveltego/issues/455))
+
+Adapter-facing accessor exposing the runtime route table:
+
+- `Routes() []RouteSummary` — projects every registered route into a `RouteSummary{Pattern, Prerender, SSR, DynamicParams, PageOptions}` snapshot. Returned slice is a copy; callers may sort or filter freely.
+- `RoutesManifestFilename` (`"routes.json"`) — sidecar written next to `manifest.json` when the user binary runs under `MaybePrerenderFromEnv`. Adapter-static's subprocess runner reads it to enumerate dynamic routes through the binary boundary.
+
+The shape is provisional. The struct may grow new fields and the JSON field names may change once tooling consumers stabilize.
 
 ## Deprecated
 

--- a/packages/sveltego/server/prerender.go
+++ b/packages/sveltego/server/prerender.go
@@ -438,6 +438,15 @@ func MaybePrerenderFromEnv(ctx context.Context, projectRoot string, s *Server) (
 	if err != nil {
 		return true, err
 	}
+	// Drop a routes.json sidecar so adapter-static's subprocess runner
+	// can enumerate dynamic routes through the binary boundary (#455).
+	// Best-effort: a write failure here is logged but does not fail the
+	// prerender pass.
+	if res != nil && res.ManifestPath != "" {
+		if werr := s.writeRoutesManifest(filepath.Dir(res.ManifestPath)); werr != nil {
+			fmt.Fprintf(os.Stderr, "prerender: write routes manifest: %v\n", werr)
+		}
+	}
 	return true, nil
 }
 

--- a/packages/sveltego/server/routes.go
+++ b/packages/sveltego/server/routes.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
+)
+
+// RoutesManifestFilename is the file MaybePrerenderFromEnv writes
+// alongside manifest.json so adapters spawning the user binary can
+// enumerate the full route table — including dynamic routes that did
+// not produce prerendered HTML. Consumed by adapter-static's subprocess
+// runner.
+//
+// Experimental — see STABILITY.md.
+const RoutesManifestFilename = "routes.json"
+
+// RouteSummary projects one entry from the runtime route table into the
+// minimal shape adapter tooling needs: pattern plus the prerender,
+// SSR, dynamic-segment, and full PageOptions snapshot. Returned by
+// Server.Routes.
+//
+// Experimental — see STABILITY.md.
+type RouteSummary struct {
+	// Pattern is the canonical SvelteKit-style path, e.g. "/post/[id]".
+	Pattern string
+	// Prerender mirrors the route's resolved kit.PageOptions.Prerender.
+	Prerender bool
+	// SSR mirrors the route's resolved kit.PageOptions.SSR.
+	SSR bool
+	// DynamicParams lists the parameter names for every non-static
+	// segment in declaration order. Empty for fully static routes.
+	DynamicParams []string
+	// PageOptions is the full resolved options snapshot for the route.
+	PageOptions kit.PageOptions
+}
+
+// Routes returns one RouteSummary per registered route. The slice is a
+// fresh allocation; callers may sort or filter without affecting the
+// server. Order matches the underlying route table (insertion order).
+//
+// Experimental — see STABILITY.md.
+func (s *Server) Routes() []RouteSummary {
+	routes := s.tree.Routes()
+	out := make([]RouteSummary, len(routes))
+	for i := range routes {
+		out[i] = routeSummaryFor(&routes[i])
+	}
+	return out
+}
+
+// writeRoutesManifest writes one JSON file at outDir/RoutesManifestFilename
+// holding s.Routes(). The file is the side-channel adapter-static reads
+// to surface dynamic routes through the subprocess boundary.
+func (s *Server) writeRoutesManifest(outDir string) error {
+	if outDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("server: mkdir routes manifest: %w", err)
+	}
+	body, err := json.MarshalIndent(s.Routes(), "", "  ")
+	if err != nil {
+		return fmt.Errorf("server: marshal routes manifest: %w", err)
+	}
+	body = append(body, '\n')
+	target := filepath.Join(outDir, RoutesManifestFilename)
+	if err := os.WriteFile(target, body, 0o644); err != nil { //nolint:gosec
+		return fmt.Errorf("server: write routes manifest: %w", err)
+	}
+	return nil
+}
+
+func routeSummaryFor(r *router.Route) RouteSummary {
+	var params []string
+	for _, seg := range r.Segments {
+		switch seg.Kind {
+		case router.SegmentParam, router.SegmentOptional, router.SegmentRest:
+			params = append(params, seg.Name)
+		}
+	}
+	return RouteSummary{
+		Pattern:       r.Pattern,
+		Prerender:     r.Options.Prerender,
+		SSR:           r.Options.SSR,
+		DynamicParams: params,
+		PageOptions:   r.Options,
+	}
+}

--- a/packages/sveltego/server/routes_test.go
+++ b/packages/sveltego/server/routes_test.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
+)
+
+func TestServer_Routes_StaticAndDynamic(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, []router.Route{
+		{
+			Pattern:  "/",
+			Segments: segmentsFor("/"),
+			Page:     staticPage("home"),
+			Options: kit.PageOptions{
+				Prerender: true,
+				SSR:       true,
+				CSR:       true,
+			},
+		},
+		{
+			Pattern:  "/post/[id=int]",
+			Segments: segmentsFor("/post/[id=int]"),
+			Page:     paramPage(),
+			Options: kit.PageOptions{
+				SSR: true,
+				CSR: true,
+			},
+		},
+		{
+			Pattern:  "/docs/[...path]",
+			Segments: segmentsFor("/docs/[...path]"),
+			Page:     staticPage("docs"),
+			Options: kit.PageOptions{
+				SSR: true,
+			},
+		},
+	})
+
+	got := srv.Routes()
+	if len(got) != 3 {
+		t.Fatalf("len(Routes()) = %d, want 3", len(got))
+	}
+
+	byPattern := make(map[string]RouteSummary, len(got))
+	for _, r := range got {
+		byPattern[r.Pattern] = r
+	}
+
+	root, ok := byPattern["/"]
+	if !ok {
+		t.Fatalf("missing summary for /")
+	}
+	if !root.Prerender {
+		t.Errorf("/ Prerender = false, want true")
+	}
+	if !root.SSR {
+		t.Errorf("/ SSR = false, want true")
+	}
+	if len(root.DynamicParams) != 0 {
+		t.Errorf("/ DynamicParams = %v, want empty", root.DynamicParams)
+	}
+	if !root.PageOptions.CSR {
+		t.Errorf("/ PageOptions.CSR = false, want true")
+	}
+
+	post, ok := byPattern["/post/[id=int]"]
+	if !ok {
+		t.Fatalf("missing summary for /post/[id=int]")
+	}
+	if post.Prerender {
+		t.Errorf("/post/[id=int] Prerender = true, want false")
+	}
+	if !reflect.DeepEqual(post.DynamicParams, []string{"id"}) {
+		t.Errorf("/post/[id=int] DynamicParams = %v, want [id]", post.DynamicParams)
+	}
+
+	docs, ok := byPattern["/docs/[...path]"]
+	if !ok {
+		t.Fatalf("missing summary for /docs/[...path]")
+	}
+	if !reflect.DeepEqual(docs.DynamicParams, []string{"path"}) {
+		t.Errorf("/docs/[...path] DynamicParams = %v, want [path]", docs.DynamicParams)
+	}
+}
+
+func TestServer_Routes_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, []router.Route{
+		{
+			Pattern:  "/",
+			Segments: segmentsFor("/"),
+			Page:     staticPage("home"),
+			Options:  kit.PageOptions{SSR: true},
+		},
+	})
+
+	first := srv.Routes()
+	if len(first) != 1 {
+		t.Fatalf("len = %d", len(first))
+	}
+	first[0].Pattern = "/mutated"
+	second := srv.Routes()
+	if second[0].Pattern != "/" {
+		t.Errorf("Routes mutation leaked: pattern = %q", second[0].Pattern)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #455. Adds the adapter-facing route accessor PR #454 deferred:

- `Server.Routes() []RouteSummary` projects every registered route into `{Pattern, Prerender, SSR, DynamicParams, PageOptions}`. Slice is a fresh copy so callers may sort or filter freely.
- `MaybePrerenderFromEnv` now drops a `routes.json` sidecar next to `manifest.json` so the user binary ships its full route table to adapter-static across the subprocess boundary. Best-effort write — an older user binary without #455 still produces a valid prerender manifest.
- `subprocessRunner` reads `routes.json` and populates `RunInfo.DynamicRoutes` with patterns that did not produce HTML, unblocking `FailOnDynamic` for the default subprocess path. Sidecar absent → previous behavior preserved.
- New surface marked **Experimental** in `packages/sveltego/STABILITY.md`.

## Test plan

- [x] `go test -race ./...` for `packages/sveltego` — 1711 passes (≥ 1705 baseline).
- [x] `go test -race ./...` for `packages/adapter-static` — 12 passes including new `TestSubprocessRunner_EnumeratesRoutes`, `_RoutesManifestAbsent`, `_RoutesManifestMalformed`.
- [x] `go test -race ./...` for every other module under `packages/` — green across the board (adapter-server/cloudflare/docker/fastly/lambda/auto/auth/cookiesession/init/lsp/mcp/enhanced-img).
- [x] `gofumpt -l` and `goimports -l -local github.com/binsarjr/sveltego` — clean.
- [x] `go vet ./...` — clean.
- [x] `golangci-lint run --new-from-rev=main` on `packages/sveltego/server` — only the pre-existing repo-wide depguard noise on `kit`/`router` imports (matches every other file in the package). On `packages/adapter-static` — clean.
- [x] `go build ./...` across every workspace module.

## Acceptance criteria (#455)

- [x] Public `Routes()` method on `*server.Server`
- [x] `RouteSummary` struct with pattern, prerender flag, dynamic segments, page-options snapshot
- [x] `subprocessRunner` consumes the new API for dynamic-route enumeration
- [x] Test: `TestSubprocessRunner_EnumeratesRoutes` passes for static + dynamic mix
- [x] STABILITY.md marks new API Experimental
- [x] `go test -race ./... ≥ 1705` baseline passes