### PR TITLE
fix(playgrounds): wire ViteManifest into main.go (closes #462)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1035,11 +1035,14 @@ jobs:
           kill "$(cat server.pid)" 2>/dev/null || true
           exit 1
 
-      # Live-route hydration smoke is gated on #462 (wire ViteManifest into
-      # the playground main.go files). Until that lands, the served HTML has
-      # no <script type="module"> tag, so window.__sveltego_hydrated never
-      # fires. The synthetic --self-test below proves the harness gate is
-      # real; flip the routes back on in a one-line edit once #462 ships.
+      # Live-route hydration smoke is held on #471: PR #463 emits
+      # `$state(...)` rune calls in client `.ts` files under
+      # `.gen/client/__router/state.ts` (source: `packages/sveltego/internal/vite/state.go`),
+      # which vite-plugin-svelte does not compile. The bundled router.js
+      # throws "ReferenceError: $state is not defined" at hydration. #462
+      # wires the playground ViteManifest so the bundle is at least
+      # delivered to the browser; the live-mode flip lands once #471
+      # renames the emit so vite-plugin-svelte picks the runes up.
       - name: Self-test (synthetic mismatch must fail the gate)
         shell: bash
         run: |

--- a/playgrounds/basic/cmd/app/main.go
+++ b/playgrounds/basic/cmd/app/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log"
+	"net/http"
 	"os"
+	"time"
 
 	gen "github.com/binsarjr/sveltego/playgrounds/basic/.gen"
 
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit/params"
 	"github.com/binsarjr/sveltego/packages/sveltego/server"
 )
@@ -15,16 +20,34 @@ func main() {
 	if err != nil {
 		log.Fatalf("read app.html: %v", err)
 	}
+	manifest, err := os.ReadFile("static/_app/.vite/manifest.json")
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Fatalf("read vite manifest: %v", err)
+	}
 	s, err := server.New(server.Config{
-		Routes:   gen.Routes(),
-		Matchers: params.DefaultMatchers(),
-		Shell:    string(shell),
-		Hooks:    gen.Hooks(),
+		Routes:       gen.Routes(),
+		Matchers:     params.DefaultMatchers(),
+		Shell:        string(shell),
+		Hooks:        gen.Hooks(),
+		ViteManifest: string(manifest),
+		ViteBase:     "/_app",
 	})
 	if err != nil {
 		log.Fatalf("server.New: %v", err)
 	}
+	mux := http.NewServeMux()
+	mux.Handle("/_app/", http.StripPrefix("/_app", server.StaticHandler(kit.StaticConfig{
+		Dir:  "static/_app",
+		ETag: true,
+	})))
+	mux.Handle("/", s)
+	s.RunInitAsync(context.Background())
 	addr := ":3000"
 	log.Printf("listening on %s", addr)
-	log.Fatal(s.ListenAndServe(addr))
+	httpSrv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(httpSrv.ListenAndServe())
 }

--- a/playgrounds/blog/cmd/app/main.go
+++ b/playgrounds/blog/cmd/app/main.go
@@ -7,11 +7,16 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log"
+	"net/http"
 	"os"
+	"time"
 
 	gen "github.com/binsarjr/sveltego/playgrounds/blog/.gen"
 
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit/params"
 	"github.com/binsarjr/sveltego/packages/sveltego/server"
 )
@@ -21,16 +26,34 @@ func main() {
 	if err != nil {
 		log.Fatalf("read app.html: %v", err)
 	}
+	manifest, err := os.ReadFile("static/_app/.vite/manifest.json")
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Fatalf("read vite manifest: %v", err)
+	}
 	s, err := server.New(server.Config{
-		Routes:   gen.Routes(),
-		Matchers: params.DefaultMatchers(),
-		Shell:    string(shell),
-		Hooks:    gen.Hooks(),
+		Routes:       gen.Routes(),
+		Matchers:     params.DefaultMatchers(),
+		Shell:        string(shell),
+		Hooks:        gen.Hooks(),
+		ViteManifest: string(manifest),
+		ViteBase:     "/_app",
 	})
 	if err != nil {
 		log.Fatalf("server.New: %v", err)
 	}
+	mux := http.NewServeMux()
+	mux.Handle("/_app/", http.StripPrefix("/_app", server.StaticHandler(kit.StaticConfig{
+		Dir:  "static/_app",
+		ETag: true,
+	})))
+	mux.Handle("/", s)
+	s.RunInitAsync(context.Background())
 	addr := ":8080"
 	log.Printf("listening on %s", addr)
-	log.Fatal(s.ListenAndServe(addr))
+	httpSrv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(httpSrv.ListenAndServe())
 }

--- a/playgrounds/dashboard/cmd/app/main.go
+++ b/playgrounds/dashboard/cmd/app/main.go
@@ -2,11 +2,16 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log"
+	"net/http"
 	"os"
+	"time"
 
 	gen "github.com/binsarjr/sveltego/playgrounds/dashboard/.gen"
 
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit/params"
 	"github.com/binsarjr/sveltego/packages/sveltego/server"
 )
@@ -16,16 +21,34 @@ func main() {
 	if err != nil {
 		log.Fatalf("read app.html: %v", err)
 	}
+	manifest, err := os.ReadFile("static/_app/.vite/manifest.json")
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Fatalf("read vite manifest: %v", err)
+	}
 	s, err := server.New(server.Config{
-		Routes:   gen.Routes(),
-		Matchers: params.DefaultMatchers(),
-		Shell:    string(shell),
-		Hooks:    gen.Hooks(),
+		Routes:       gen.Routes(),
+		Matchers:     params.DefaultMatchers(),
+		Shell:        string(shell),
+		Hooks:        gen.Hooks(),
+		ViteManifest: string(manifest),
+		ViteBase:     "/_app",
 	})
 	if err != nil {
 		log.Fatalf("server.New: %v", err)
 	}
+	mux := http.NewServeMux()
+	mux.Handle("/_app/", http.StripPrefix("/_app", server.StaticHandler(kit.StaticConfig{
+		Dir:  "static/_app",
+		ETag: true,
+	})))
+	mux.Handle("/", s)
+	s.RunInitAsync(context.Background())
 	addr := ":3000"
 	log.Printf("dashboard listening on %s", addr)
-	log.Fatal(s.ListenAndServe(addr))
+	httpSrv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(httpSrv.ListenAndServe())
 }

--- a/playgrounds/ssr-stress/cmd/app/main.go
+++ b/playgrounds/ssr-stress/cmd/app/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log"
+	"net/http"
 	"os"
+	"time"
 
 	gen "github.com/binsarjr/sveltego/playgrounds/ssr-stress/.gen"
 
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit/params"
 	"github.com/binsarjr/sveltego/packages/sveltego/server"
 )
@@ -15,16 +20,34 @@ func main() {
 	if err != nil {
 		log.Fatalf("read app.html: %v", err)
 	}
+	manifest, err := os.ReadFile("static/_app/.vite/manifest.json")
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Fatalf("read vite manifest: %v", err)
+	}
 	s, err := server.New(server.Config{
-		Routes:   gen.Routes(),
-		Matchers: params.DefaultMatchers(),
-		Shell:    string(shell),
-		Hooks:    gen.Hooks(),
+		Routes:       gen.Routes(),
+		Matchers:     params.DefaultMatchers(),
+		Shell:        string(shell),
+		Hooks:        gen.Hooks(),
+		ViteManifest: string(manifest),
+		ViteBase:     "/_app",
 	})
 	if err != nil {
 		log.Fatalf("server.New: %v", err)
 	}
+	mux := http.NewServeMux()
+	mux.Handle("/_app/", http.StripPrefix("/_app", server.StaticHandler(kit.StaticConfig{
+		Dir:  "static/_app",
+		ETag: true,
+	})))
+	mux.Handle("/", s)
+	s.RunInitAsync(context.Background())
 	addr := ":3000"
 	log.Printf("listening on %s", addr)
-	log.Fatal(s.ListenAndServe(addr))
+	httpSrv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(httpSrv.ListenAndServe())
 }


### PR DESCRIPTION
## Summary

- Each playground `cmd/app/main.go` (basic, blog, dashboard, ssr-stress) now reads `static/_app/.vite/manifest.json`, passes it into `server.Config{ViteManifest, ViteBase: "/_app"}`, mounts `server.StaticHandler` at `/_app/`, and calls `s.RunInitAsync(ctx)` before serving so the SSR fallback sidecar boots when annotated routes are present. Mirrors the wiring PR #418 shipped for the scaffold init template.
- `.github/workflows/ci.yml` hydration-parity comment block now points at follow-up #471 for the live-route flip; the synthetic `--self-test` step stays as the must-pass gate.

Closes #462.

## Local verification

- `go build ./playgrounds/...` clean across all four playgrounds.
- `gofumpt -l .` and `goimports -l -local github.com/binsarjr/sveltego .` empty.
- `go vet ./...` clean per playground.
- `sveltego compile` + full `sveltego build` (with client) on basic + ssr-stress.
- `curl http://localhost:3000/` on basic returns 200 with `<script type="module" src="/_app/assets/routes/_page-…js">` injected.
- `curl http://localhost:3000/_app/assets/router-…js` returns 200 (~38 KB).
- Server log on boot: `INFO server: ssr fallback sidecar started endpoint=…` confirms `RunInitAsync` ran.
- Same checks pass on ssr-stress home + `/longlist`.

## Scope cuts (deferred to follow-ups)

- **#458 live-route hydration-parity flip — DEFERRED to #471.** Live mode exposed a real regression from PR #463: `$state(...)` calls land in client `.ts` files (`packages/sveltego/internal/vite/state.go:79-81` → `.gen/client/__router/state.ts`), which vite-plugin-svelte does not compile. The bundled `router.js` throws `ReferenceError: $state is not defined` at hydration. #462 still ships the playground ViteManifest wiring so the bundle is at least delivered to the browser; the flip lands once #471 renames the emit so vite-plugin-svelte picks the runes up. Synthetic `--self-test` step remains the must-pass gate.

- **#457 adapter-static smoke matrix — DEFERRED to #468.** Codegen does not yet emit a Page closure for Svelte+Prerender routes (`planSSR` excludes prerender from the SSR transpile plan; `Server.Prerender` skips routes where `r.Page == nil`). Reproduced locally — minimal scaffold + `Prerender = true` writes 0 entries. #468 tracks the codegen gap and carries the CI matrix entry as a sub-acceptance.

## Test plan

- [x] go build ./playgrounds/... clean
- [x] gofumpt + goimports clean
- [x] go vet ./... clean per playground
- [x] basic curl smoke (HTML + module script + asset 200)
- [x] ssr-stress curl smoke (HTML + module script + `/longlist` SSR)
- [ ] CI green on PR (lint-and-test-pr + playground-smoke + hydration-parity self-test)