### PR TITLE
fix(codegen): SSR sidecar respects vite $app/* aliases (closes #460)

### DIFF
--- a/packages/sveltego/internal/codegen/svelterender/sidecar/shims/app-navigation.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/shims/app-navigation.mjs
@@ -1,0 +1,38 @@
+// Server-side shim for `$app/navigation` consumed by the runtime SSR
+// fallback sidecar (`--mode=ssr-serve`). All exports are inert no-ops:
+// navigation is a client-side concern. The shim exists so user code that
+// imports `goto`, `invalidate`, etc. at module scope doesn't crash the
+// initial server render — the imported symbols only get called from
+// event handlers that never fire during SSR.
+
+export function goto(_url, _opts) {
+	return Promise.resolve();
+}
+
+export function invalidate(_dep) {
+	return Promise.resolve();
+}
+
+export function invalidateAll() {
+	return Promise.resolve();
+}
+
+export function preloadCode(_url) {
+	return Promise.resolve();
+}
+
+export function preloadData(_url) {
+	return Promise.resolve();
+}
+
+export function pushState(_url, _state) {}
+
+export function replaceState(_url, _state) {}
+
+export function beforeNavigate(_callback) {}
+
+export function afterNavigate(_callback) {}
+
+export function onNavigate(_callback) {}
+
+export function disableScrollHandling() {}

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/shims/app-state.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/shims/app-state.mjs
@@ -1,0 +1,80 @@
+// Server-side shim for `$app/state` consumed by the runtime SSR
+// fallback sidecar (`--mode=ssr-serve`). The compiled .mjs the sidecar
+// emits per route imports `'$app/state'`; without this shim Node fails
+// to resolve the bare specifier and the render call throws.
+//
+// On the client these symbols are runes backed by the SPA router. On
+// the SSR fallback path they are static objects populated per render
+// via _setPage / _setNavigating / _setUpdated. The Go fallback supervisor
+// will extend the render-request envelope to carry the page snapshot in
+// a follow-up; until then defaults ship to keep imports resolvable and
+// `svelte/server` rendering of `page.url.pathname` etc. from crashing.
+
+let pageState = {
+	url: new URL("http://localhost/"),
+	params: {},
+	route: { id: null },
+	status: 200,
+	error: null,
+	data: null,
+	form: null,
+	state: {},
+};
+
+let navigatingState = { current: null };
+let updatedState = { current: false };
+
+export const page = new Proxy(
+	{},
+	{
+		get(_target, prop) {
+			return pageState[prop];
+		},
+		ownKeys() {
+			return Reflect.ownKeys(pageState);
+		},
+		getOwnPropertyDescriptor(_target, prop) {
+			if (prop in pageState) {
+				return {
+					configurable: true,
+					enumerable: true,
+					value: pageState[prop],
+				};
+			}
+			return undefined;
+		},
+		has(_target, prop) {
+			return prop in pageState;
+		},
+	},
+);
+
+export const navigating = new Proxy(
+	{},
+	{
+		get(_target, prop) {
+			return navigatingState[prop];
+		},
+	},
+);
+
+export const updated = new Proxy(
+	{},
+	{
+		get(_target, prop) {
+			return updatedState[prop];
+		},
+	},
+);
+
+export function _setPage(next) {
+	pageState = next;
+}
+
+export function _setNavigating(next) {
+	navigatingState = next;
+}
+
+export function _setUpdated(next) {
+	updatedState = next;
+}

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/ssr.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/ssr.mjs
@@ -61,20 +61,32 @@ export function parseToAST(jsSource) {
 // minor changes in Acorn's property emission order can never produce a
 // different golden file. Arrays preserve order (semantics depend on
 // position). null and primitives pass through.
+//
+// Cycle detection tracks ancestors on the current walk path, not every
+// node ever seen. ESTree ASTs are DAGs in the wild — Acorn shares the
+// same Identifier object between `imported` and `local` on a non-rename
+// `ImportSpecifier` (`import { page }` from '$app/state'), and any
+// `WeakSet`-add-only check would mis-flag that as a cycle. A genuine
+// cycle is a node reachable from itself via parent→child edges, which
+// is what an enter/exit ancestor stack catches.
 export function stableStringify(value) {
-	const seen = new WeakSet();
+	const ancestors = new WeakSet();
 	const walk = (node) => {
 		if (node === null || typeof node !== "object") return node;
-		if (seen.has(node)) {
+		if (ancestors.has(node)) {
 			throw new Error("stableStringify: cycle in AST");
 		}
-		seen.add(node);
-		if (Array.isArray(node)) return node.map(walk);
-		const out = {};
-		for (const key of Object.keys(node).sort()) {
-			out[key] = walk(node[key]);
+		ancestors.add(node);
+		try {
+			if (Array.isArray(node)) return node.map(walk);
+			const out = {};
+			for (const key of Object.keys(node).sort()) {
+				out[key] = walk(node[key]);
+			}
+			return out;
+		} finally {
+			ancestors.delete(node);
 		}
-		return out;
 	};
 	return JSON.stringify(walk(value), null, 2) + "\n";
 }

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/ssr_serve.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/ssr_serve.mjs
@@ -29,6 +29,38 @@ const compiledCache = new Map();
 let cacheDir = null;
 const sidecarDir = dirname(fileURLToPath(import.meta.url));
 
+// Server-side shim URLs for the `$app/*` virtual modules the client
+// build resolves via Vite alias. The compiled .mjs the sidecar emits per
+// route imports `'$app/state'` and `'$app/navigation'`; without these
+// shims Node fails to resolve the bare specifier and the render call
+// throws (#460). Resolved once at module load — `pathToFileURL` is the
+// canonical way to import a local file by absolute path.
+const appShimURLs = {
+	"$app/state": pathToFileURL(joinPath(sidecarDir, "shims", "app-state.mjs"))
+		.href,
+	"$app/navigation": pathToFileURL(
+		joinPath(sidecarDir, "shims", "app-navigation.mjs"),
+	).href,
+};
+
+// rewriteAppAliases substitutes `'$app/state'` and `'$app/navigation'`
+// import sources in the compiled JS with absolute file URLs of the
+// server-side shims. The regex matches both single and double quotes
+// (Svelte's compiler picks per-output) and allows the source string to
+// appear either in `from '...'` (static imports) or `import('...')`
+// (dynamic imports). Any other `$app/*` specifier is left alone so the
+// caller surfaces a clear "unresolved $app/<name>" error rather than
+// silently substituting an unrelated module.
+export function rewriteAppAliases(code) {
+	return code.replace(
+		/(\bfrom\s*|\bimport\s*\(\s*)(['"])(\$app\/(?:state|navigation))\2/g,
+		(_match, prefix, quote, specifier) => {
+			const url = appShimURLs[specifier];
+			return `${prefix}${quote}${url}${quote}`;
+		},
+	);
+}
+
 async function ensureCacheDir() {
 	if (cacheDir) return cacheDir;
 	// Place the cache dir inside the sidecar tree so Node's module
@@ -57,10 +89,11 @@ async function loadComponent(root, source) {
 	if (!result || typeof result.js?.code !== "string") {
 		throw new Error(`svelte/compiler produced no js.code for ${source}`);
 	}
+	const rewritten = rewriteAppAliases(result.js.code);
 	const dir = await ensureCacheDir();
 	const safe = absolute.replace(/[^a-zA-Z0-9_]/g, "_");
 	const modPath = joinPath(dir, `${safe}.mjs`);
-	await writeFile(modPath, result.js.code, "utf8");
+	await writeFile(modPath, rewritten, "utf8");
 	const url = pathToFileURL(modPath).href;
 	const mod = await import(url);
 	const fn = mod.default;

--- a/packages/sveltego/internal/codegen/svelterender/svelterender_test.go
+++ b/packages/sveltego/internal/codegen/svelterender/svelterender_test.go
@@ -1,15 +1,21 @@
 package svelterender
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 )
 
 var updateGolden = flag.Bool("update", false, "rewrite *.golden.json fixtures from sidecar output")
@@ -99,13 +105,14 @@ func TestBuildSSRAST_HelloWorld(t *testing.T) {
 		Jobs: []SSRJob{
 			{Route: "/hello-world", Source: "hello-world/_page.svelte"},
 			{Route: "/each-list", Source: "each-list/_page.svelte"},
+			{Route: "/named-import", Source: "named-import/_page.svelte"},
 		},
 	})
 	if err != nil {
 		t.Fatalf("BuildSSRAST: %v", err)
 	}
-	if len(results) != 2 {
-		t.Fatalf("results = %d, want 2", len(results))
+	if len(results) != 3 {
+		t.Fatalf("results = %d, want 3", len(results))
 	}
 
 	for _, r := range results {
@@ -121,6 +128,12 @@ func TestBuildSSRAST_HelloWorld(t *testing.T) {
 	}{
 		{"hello-world", filepath.Join(out, "hello-world", "ast.json"), filepath.Join(absRoot, "hello-world", "ast.golden.json")},
 		{"each-list", filepath.Join(out, "each-list", "ast.json"), filepath.Join(absRoot, "each-list", "ast.golden.json")},
+		// named-import is the regression case for the Acorn shared-Identifier
+		// DAG that crashed the legacy WeakSet cycle detector. Source carries
+		// `import { page } from '$app/state'` — the no-rename form that pins
+		// `imported === local` on the ImportSpecifier (#460). The job MUST
+		// produce a clean ast.json; absence of an error here is the test.
+		{"named-import", filepath.Join(out, "named-import", "ast.json"), filepath.Join(absRoot, "named-import", "ast.golden.json")},
 	}
 	for _, tc := range cases {
 		got, err := os.ReadFile(tc.out)
@@ -209,4 +222,110 @@ func TestBuildSSRAST_Determinism(t *testing.T) {
 	if !bytes.Equal(a, b) {
 		t.Fatalf("ast.json not byte-identical across runs (sidecar non-deterministic)")
 	}
+}
+
+// TestSSRServe_AppAliases boots the real --mode=ssr-serve sidecar and
+// renders a fixture that imports `$app/state` and `$app/navigation`.
+// The fix for #460 wires server-side shims into the sidecar so the
+// `$app/*` bare specifiers resolve at request time; before the fix Node
+// would throw `Cannot find package '$app'` and the render would 5xx.
+//
+// The test only asserts a 200 response with non-empty body — it
+// deliberately doesn't pin the exact rendered HTML, which depends on
+// svelte/server output details and the shim's default page state.
+func TestSSRServe_AppAliases(t *testing.T) {
+	t.Parallel()
+	sidecarDir, nodePath := requireSidecarReady(t)
+
+	root := filepath.Join("testdata", "ssr-ast")
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, nodePath, filepath.Join(sidecarDir, "index.mjs"),
+		"--mode=ssr-serve",
+		"--root="+absRoot,
+		"--port=0",
+	)
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sidecar: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	port, err := readSidecarPort(stderrPipe, 20*time.Second)
+	if err != nil {
+		t.Fatalf("read sidecar port: %v", err)
+	}
+	endpoint := "http://127.0.0.1:" + strconv.Itoa(port) + "/render"
+
+	body, _ := json.Marshal(map[string]any{
+		"route":  "/named-import",
+		"source": "named-import/_page.svelte",
+		"data":   map[string]any{"greeting": "hi"},
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("post render: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d, body=%s", resp.StatusCode, string(raw))
+	}
+	var out struct {
+		Body  string `json:"body"`
+		Head  string `json:"head"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode: %v (raw=%s)", err, string(raw))
+	}
+	if out.Error != "" {
+		t.Fatalf("sidecar error: %s", out.Error)
+	}
+	if out.Body == "" {
+		t.Fatalf("empty body, raw=%s", string(raw))
+	}
+}
+
+// readSidecarPort drains the sidecar's stderr until it sees the listen
+// announcement, returning the port. Lines that don't match the prefix
+// are discarded; a timeout is treated as boot failure.
+func readSidecarPort(r io.Reader, timeout time.Duration) (int, error) {
+	deadline := time.Now().Add(timeout)
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if idx := strings.Index(line, "SVELTEGO_SSR_FALLBACK_LISTEN port="); idx >= 0 {
+			n, err := strconv.Atoi(strings.TrimSpace(line[idx+len("SVELTEGO_SSR_FALLBACK_LISTEN port="):]))
+			if err != nil {
+				return 0, err
+			}
+			return n, nil
+		}
+		if time.Now().After(deadline) {
+			return 0, errors.New("timed out waiting for sidecar listen line")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return 0, errors.New("sidecar exited before announcing port")
 }

--- a/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/named-import/_page.svelte
+++ b/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/named-import/_page.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { page, navigating } from '$app/state';
+	import { goto } from '$app/navigation';
+	let { data } = $props();
+	const target = '/named-import';
+	function nav() {
+		goto(target);
+	}
+</script>
+
+<h1>{data.greeting}</h1>
+<p>{page.url.pathname}</p>
+<p>{navigating.current ? 'navigating' : 'idle'}</p>
+<button onclick={nav}>go</button>

--- a/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/named-import/ast.golden.json
+++ b/packages/sveltego/internal/codegen/svelterender/testdata/ssr-ast/named-import/ast.golden.json
@@ -1,0 +1,586 @@
+{
+  "ast": {
+    "body": [
+      {
+        "attributes": [],
+        "end": 44,
+        "source": {
+          "end": 43,
+          "raw": "'svelte/internal/server'",
+          "start": 19,
+          "type": "Literal",
+          "value": "svelte/internal/server"
+        },
+        "specifiers": [
+          {
+            "end": 13,
+            "local": {
+              "end": 13,
+              "name": "$",
+              "start": 12,
+              "type": "Identifier"
+            },
+            "start": 7,
+            "type": "ImportNamespaceSpecifier"
+          }
+        ],
+        "start": 0,
+        "type": "ImportDeclaration"
+      },
+      {
+        "attributes": [],
+        "end": 91,
+        "source": {
+          "end": 90,
+          "raw": "'$app/state'",
+          "start": 78,
+          "type": "Literal",
+          "value": "$app/state"
+        },
+        "specifiers": [
+          {
+            "end": 58,
+            "imported": {
+              "end": 58,
+              "name": "page",
+              "start": 54,
+              "type": "Identifier"
+            },
+            "local": {
+              "end": 58,
+              "name": "page",
+              "start": 54,
+              "type": "Identifier"
+            },
+            "start": 54,
+            "type": "ImportSpecifier"
+          },
+          {
+            "end": 70,
+            "imported": {
+              "end": 70,
+              "name": "navigating",
+              "start": 60,
+              "type": "Identifier"
+            },
+            "local": {
+              "end": 70,
+              "name": "navigating",
+              "start": 60,
+              "type": "Identifier"
+            },
+            "start": 60,
+            "type": "ImportSpecifier"
+          }
+        ],
+        "start": 45,
+        "type": "ImportDeclaration"
+      },
+      {
+        "attributes": [],
+        "end": 131,
+        "source": {
+          "end": 130,
+          "raw": "'$app/navigation'",
+          "start": 113,
+          "type": "Literal",
+          "value": "$app/navigation"
+        },
+        "specifiers": [
+          {
+            "end": 105,
+            "imported": {
+              "end": 105,
+              "name": "goto",
+              "start": 101,
+              "type": "Identifier"
+            },
+            "local": {
+              "end": 105,
+              "name": "goto",
+              "start": 101,
+              "type": "Identifier"
+            },
+            "start": 101,
+            "type": "ImportSpecifier"
+          }
+        ],
+        "start": 92,
+        "type": "ImportDeclaration"
+      },
+      {
+        "declaration": {
+          "async": false,
+          "body": {
+            "body": [
+              {
+                "end": 511,
+                "expression": {
+                  "arguments": [
+                    {
+                      "async": false,
+                      "body": {
+                        "body": [
+                          {
+                            "declarations": [
+                              {
+                                "end": 250,
+                                "id": {
+                                  "end": 240,
+                                  "properties": [
+                                    {
+                                      "computed": false,
+                                      "end": 238,
+                                      "key": {
+                                        "end": 238,
+                                        "name": "data",
+                                        "start": 234,
+                                        "type": "Identifier"
+                                      },
+                                      "kind": "init",
+                                      "method": false,
+                                      "shorthand": true,
+                                      "start": 234,
+                                      "type": "Property",
+                                      "value": {
+                                        "end": 238,
+                                        "name": "data",
+                                        "start": 234,
+                                        "type": "Identifier"
+                                      }
+                                    }
+                                  ],
+                                  "start": 232,
+                                  "type": "ObjectPattern"
+                                },
+                                "init": {
+                                  "end": 250,
+                                  "name": "$$props",
+                                  "start": 243,
+                                  "type": "Identifier"
+                                },
+                                "start": 232,
+                                "type": "VariableDeclarator"
+                              }
+                            ],
+                            "end": 251,
+                            "kind": "let",
+                            "start": 228,
+                            "type": "VariableDeclaration"
+                          },
+                          {
+                            "declarations": [
+                              {
+                                "end": 284,
+                                "id": {
+                                  "end": 266,
+                                  "name": "target",
+                                  "start": 260,
+                                  "type": "Identifier"
+                                },
+                                "init": {
+                                  "end": 284,
+                                  "raw": "'/named-import'",
+                                  "start": 269,
+                                  "type": "Literal",
+                                  "value": "/named-import"
+                                },
+                                "start": 260,
+                                "type": "VariableDeclarator"
+                              }
+                            ],
+                            "end": 285,
+                            "kind": "const",
+                            "start": 254,
+                            "type": "VariableDeclaration"
+                          },
+                          {
+                            "async": false,
+                            "body": {
+                              "body": [
+                                {
+                                  "end": 322,
+                                  "expression": {
+                                    "arguments": [
+                                      {
+                                        "end": 320,
+                                        "name": "target",
+                                        "start": 314,
+                                        "type": "Identifier"
+                                      }
+                                    ],
+                                    "callee": {
+                                      "end": 313,
+                                      "name": "goto",
+                                      "start": 309,
+                                      "type": "Identifier"
+                                    },
+                                    "end": 321,
+                                    "optional": false,
+                                    "start": 309,
+                                    "type": "CallExpression"
+                                  },
+                                  "start": 309,
+                                  "type": "ExpressionStatement"
+                                }
+                              ],
+                              "end": 326,
+                              "start": 304,
+                              "type": "BlockStatement"
+                            },
+                            "end": 326,
+                            "expression": false,
+                            "generator": false,
+                            "id": {
+                              "end": 301,
+                              "name": "nav",
+                              "start": 298,
+                              "type": "Identifier"
+                            },
+                            "params": [],
+                            "start": 289,
+                            "type": "FunctionDeclaration"
+                          },
+                          {
+                            "end": 506,
+                            "expression": {
+                              "arguments": [
+                                {
+                                  "end": 504,
+                                  "expressions": [
+                                    {
+                                      "arguments": [
+                                        {
+                                          "computed": false,
+                                          "end": 375,
+                                          "object": {
+                                            "end": 366,
+                                            "name": "data",
+                                            "start": 362,
+                                            "type": "Identifier"
+                                          },
+                                          "optional": false,
+                                          "property": {
+                                            "end": 375,
+                                            "name": "greeting",
+                                            "start": 367,
+                                            "type": "Identifier"
+                                          },
+                                          "start": 362,
+                                          "type": "MemberExpression"
+                                        }
+                                      ],
+                                      "callee": {
+                                        "computed": false,
+                                        "end": 361,
+                                        "object": {
+                                          "end": 354,
+                                          "name": "$",
+                                          "start": 353,
+                                          "type": "Identifier"
+                                        },
+                                        "optional": false,
+                                        "property": {
+                                          "end": 361,
+                                          "name": "escape",
+                                          "start": 355,
+                                          "type": "Identifier"
+                                        },
+                                        "start": 353,
+                                        "type": "MemberExpression"
+                                      },
+                                      "end": 376,
+                                      "optional": false,
+                                      "start": 353,
+                                      "type": "CallExpression"
+                                    },
+                                    {
+                                      "arguments": [
+                                        {
+                                          "computed": false,
+                                          "end": 414,
+                                          "object": {
+                                            "computed": false,
+                                            "end": 405,
+                                            "object": {
+                                              "end": 401,
+                                              "name": "page",
+                                              "start": 397,
+                                              "type": "Identifier"
+                                            },
+                                            "optional": false,
+                                            "property": {
+                                              "end": 405,
+                                              "name": "url",
+                                              "start": 402,
+                                              "type": "Identifier"
+                                            },
+                                            "start": 397,
+                                            "type": "MemberExpression"
+                                          },
+                                          "optional": false,
+                                          "property": {
+                                            "end": 414,
+                                            "name": "pathname",
+                                            "start": 406,
+                                            "type": "Identifier"
+                                          },
+                                          "start": 397,
+                                          "type": "MemberExpression"
+                                        }
+                                      ],
+                                      "callee": {
+                                        "computed": false,
+                                        "end": 396,
+                                        "object": {
+                                          "end": 389,
+                                          "name": "$",
+                                          "start": 388,
+                                          "type": "Identifier"
+                                        },
+                                        "optional": false,
+                                        "property": {
+                                          "end": 396,
+                                          "name": "escape",
+                                          "start": 390,
+                                          "type": "Identifier"
+                                        },
+                                        "start": 388,
+                                        "type": "MemberExpression"
+                                      },
+                                      "end": 415,
+                                      "optional": false,
+                                      "start": 388,
+                                      "type": "CallExpression"
+                                    },
+                                    {
+                                      "arguments": [
+                                        {
+                                          "alternate": {
+                                            "end": 477,
+                                            "raw": "'idle'",
+                                            "start": 471,
+                                            "type": "Literal",
+                                            "value": "idle"
+                                          },
+                                          "consequent": {
+                                            "end": 468,
+                                            "raw": "'navigating'",
+                                            "start": 456,
+                                            "type": "Literal",
+                                            "value": "navigating"
+                                          },
+                                          "end": 477,
+                                          "start": 435,
+                                          "test": {
+                                            "computed": false,
+                                            "end": 453,
+                                            "object": {
+                                              "end": 445,
+                                              "name": "navigating",
+                                              "start": 435,
+                                              "type": "Identifier"
+                                            },
+                                            "optional": false,
+                                            "property": {
+                                              "end": 453,
+                                              "name": "current",
+                                              "start": 446,
+                                              "type": "Identifier"
+                                            },
+                                            "start": 435,
+                                            "type": "MemberExpression"
+                                          },
+                                          "type": "ConditionalExpression"
+                                        }
+                                      ],
+                                      "callee": {
+                                        "computed": false,
+                                        "end": 434,
+                                        "object": {
+                                          "end": 427,
+                                          "name": "$",
+                                          "start": 426,
+                                          "type": "Identifier"
+                                        },
+                                        "optional": false,
+                                        "property": {
+                                          "end": 434,
+                                          "name": "escape",
+                                          "start": 428,
+                                          "type": "Identifier"
+                                        },
+                                        "start": 426,
+                                        "type": "MemberExpression"
+                                      },
+                                      "end": 478,
+                                      "optional": false,
+                                      "start": 426,
+                                      "type": "CallExpression"
+                                    }
+                                  ],
+                                  "quasis": [
+                                    {
+                                      "end": 351,
+                                      "start": 347,
+                                      "tail": false,
+                                      "type": "TemplateElement",
+                                      "value": {
+                                        "cooked": "<h1>",
+                                        "raw": "<h1>"
+                                      }
+                                    },
+                                    {
+                                      "end": 386,
+                                      "start": 377,
+                                      "tail": false,
+                                      "type": "TemplateElement",
+                                      "value": {
+                                        "cooked": "</h1> <p>",
+                                        "raw": "</h1> <p>"
+                                      }
+                                    },
+                                    {
+                                      "end": 424,
+                                      "start": 416,
+                                      "tail": false,
+                                      "type": "TemplateElement",
+                                      "value": {
+                                        "cooked": "</p> <p>",
+                                        "raw": "</p> <p>"
+                                      }
+                                    },
+                                    {
+                                      "end": 503,
+                                      "start": 479,
+                                      "tail": true,
+                                      "type": "TemplateElement",
+                                      "value": {
+                                        "cooked": "</p> <button>go</button>",
+                                        "raw": "</p> <button>go</button>"
+                                      }
+                                    }
+                                  ],
+                                  "start": 346,
+                                  "type": "TemplateLiteral"
+                                }
+                              ],
+                              "callee": {
+                                "computed": false,
+                                "end": 345,
+                                "object": {
+                                  "end": 340,
+                                  "name": "$$renderer",
+                                  "start": 330,
+                                  "type": "Identifier"
+                                },
+                                "optional": false,
+                                "property": {
+                                  "end": 345,
+                                  "name": "push",
+                                  "start": 341,
+                                  "type": "Identifier"
+                                },
+                                "start": 330,
+                                "type": "MemberExpression"
+                              },
+                              "end": 505,
+                              "optional": false,
+                              "start": 330,
+                              "type": "CallExpression"
+                            },
+                            "start": 330,
+                            "type": "ExpressionStatement"
+                          }
+                        ],
+                        "end": 509,
+                        "start": 224,
+                        "type": "BlockStatement"
+                      },
+                      "end": 509,
+                      "expression": false,
+                      "generator": false,
+                      "id": null,
+                      "params": [
+                        {
+                          "end": 219,
+                          "name": "$$renderer",
+                          "start": 209,
+                          "type": "Identifier"
+                        }
+                      ],
+                      "start": 208,
+                      "type": "ArrowFunctionExpression"
+                    }
+                  ],
+                  "callee": {
+                    "computed": false,
+                    "end": 207,
+                    "object": {
+                      "end": 197,
+                      "name": "$$renderer",
+                      "start": 187,
+                      "type": "Identifier"
+                    },
+                    "optional": false,
+                    "property": {
+                      "end": 207,
+                      "name": "component",
+                      "start": 198,
+                      "type": "Identifier"
+                    },
+                    "start": 187,
+                    "type": "MemberExpression"
+                  },
+                  "end": 510,
+                  "optional": false,
+                  "start": 187,
+                  "type": "CallExpression"
+                },
+                "start": 187,
+                "type": "ExpressionStatement"
+              }
+            ],
+            "end": 513,
+            "start": 184,
+            "type": "BlockStatement"
+          },
+          "end": 513,
+          "expression": false,
+          "generator": false,
+          "id": {
+            "end": 162,
+            "name": "_page",
+            "start": 157,
+            "type": "Identifier"
+          },
+          "params": [
+            {
+              "end": 173,
+              "name": "$$renderer",
+              "start": 163,
+              "type": "Identifier"
+            },
+            {
+              "end": 182,
+              "name": "$$props",
+              "start": 175,
+              "type": "Identifier"
+            }
+          ],
+          "start": 148,
+          "type": "FunctionDeclaration"
+        },
+        "end": 513,
+        "start": 133,
+        "type": "ExportDefaultDeclaration"
+      }
+    ],
+    "end": 513,
+    "sourceType": "module",
+    "start": 0,
+    "type": "Program"
+  },
+  "route": "/named-import",
+  "schema": "ssr-json-ast/v1"
+}


### PR DESCRIPTION
## Summary

Fixes #460. Two distinct bugs surfaced as one — the issue's "alias resolution → cycle" hypothesis was wrong; resolution and AST emit are independent failures.

**Bug A — `stableStringify: cycle in AST`** is Acorn's shared-Identifier DAG, not a real cycle. On a non-rename `import { name }`, Acorn 8.16 reuses the same Identifier object for `imported` and `local` on the ImportSpecifier (ESTree allows this DAG shape). The legacy WeakSet detector was add-only — every revisit looked like a cycle. Replaced with an enter/exit ancestor stack: a node is on the stack only while walking through it, so shared sibling refs no longer false-positive while genuine cycles still throw.

**Bug B — runtime fallback sidecar (`--mode=ssr-serve`) couldn't resolve `$app/state` / `$app/navigation`** bare specifiers at `import()` time. Vite's alias map is client-bundle-only. Added server-side shims under `sidecar/shims/{app-state,app-navigation}.mjs` and rewrite import sources in the compiled .mjs to absolute file URLs of those shims before writing the cache file. The shim exports default values matching the runes' shape so `svelte/server` rendering of `page.url.pathname` etc. doesn't crash.

## Acceptance criteria (from #460)

- [x] `$app/state` + `$app/navigation` resolve in BOTH client bundle AND build-time SSR sidecar — satisfied by Bug A fix (build-time AST emit no longer trips on shared-Identifier shape; client bundle was already wired in #463).
- [x] Top-level runtime imports in .svelte templates no longer trigger `stableStringify: cycle in AST` — root-cause fix in `ssr.mjs`. Unblocks `import { page } from '$app/state'`, `import { mount } from 'svelte'`, etc., project-wide.
- [~] **PR #463's workaround annotation removed; appstate route SSRs via Option B** — DEFERRED to #467 (acked with team-lead). Dropping the annotation requires `svelte_js2go` to whitelist `$app/*` imports + add lowering patterns for `page.*`, `navigating.current`, `updated.current` runes + plumb a PageState struct through emitted Render functions. Substantial separate feature beyond "alias fix" scope.
- [x] Test fixture importing `$app/state` builds clean — `testdata/ssr-ast/named-import/_page.svelte` wired into `TestBuildSSRAST_HelloWorld`. Imports both `$app/state` and `$app/navigation` so the regression test exercises the no-rename ImportSpecifier shape both shims target.
- [x] `go test -race ./packages/sveltego/...` ≥1705 baseline — 1712 passing.

## What ships

| File | Purpose |
|---|---|
| `sidecar/ssr.mjs` | `stableStringify` switched from add-only WeakSet to enter/exit ancestor stack |
| `sidecar/ssr_serve.mjs` | `rewriteAppAliases` + per-render rewrite before cache write |
| `sidecar/shims/app-state.mjs` | Server-side `page` / `navigating` / `updated` exports backed by mutable internal state (Proxy reads, `_set*` setters for follow-up wire-shape extension) |
| `sidecar/shims/app-navigation.mjs` | Inert no-op exports for `goto`, `invalidate`, `pushState`, `beforeNavigate`, etc. |
| `testdata/ssr-ast/named-import/{_page.svelte,ast.golden.json}` | Bug A regression fixture |
| `svelterender_test.go` | + `TestSSRServe_AppAliases` — boots the real `--mode=ssr-serve` sidecar and asserts a 200 render for the fixture |

## Verified

- `gofumpt -l .` clean
- `goimports -l -local github.com/binsarjr/sveltego .` clean
- `go vet ./...` clean
- `golangci-lint run ./internal/codegen/svelterender/...` clean
- `go test -race ./packages/sveltego/...` — 1712 passing (above 1705 baseline)
- All 6 svelterender tests pass including new `TestSSRServe_AppAliases` end-to-end smoke

## Follow-up

#467 — `feat(svelte_js2go): lower $app/state runes to Go render-time values`. Covers `recordImport` whitelist + page/navigating/updated lowering patterns + PageState plumbing through Render. Blocks dropping the appstate fixture's fallback annotation.

## Test plan

- [x] `go test -race ./packages/sveltego/internal/codegen/svelterender/...` — all green
- [x] `go test -race ./packages/sveltego/...` — 1712 passing
- [x] `golangci-lint run` clean on touched paths
- [x] gofumpt + goimports + vet clean