### PR TITLE
feat(client/server): version-poll endpoint + updated rune flip

### DIFF
--- a/packages/sveltego/exports/kit/version.go
+++ b/packages/sveltego/exports/kit/version.go
@@ -1,0 +1,44 @@
+package kit
+
+import "time"
+
+// DefaultVersionPollInterval is the cadence the client poller uses when
+// VersionPollConfig.PollInterval is the zero value. Mirrors the figure
+// most SvelteKit apps land on once they enable polling — short enough
+// to surface a deploy within a working session, long enough that an
+// idle tab does not generate meaningful traffic.
+const DefaultVersionPollInterval = 60 * time.Second
+
+// MinVersionPollInterval is the floor enforced when normalizing a
+// caller-provided interval. Anything smaller — including negative or
+// sub-second values — is clamped to this floor so a config typo cannot
+// hammer the endpoint.
+const MinVersionPollInterval = time.Second
+
+// VersionPollConfig configures the client-side version poller. The
+// poller fetches /_app/version.json on PollInterval, compares the
+// returned hash to the build version baked into the hydration payload,
+// and flips the `updated.current` rune to true on drift. Disabled true
+// suppresses the poller entirely, matching SvelteKit's pollInterval=0
+// default.
+type VersionPollConfig struct {
+	// Disabled turns the poller off. The /_app/version.json endpoint
+	// is still served so user code calling `updated.check()` works.
+	Disabled bool
+	// PollInterval is the cadence between background polls. Zero
+	// resolves to DefaultVersionPollInterval; values below
+	// MinVersionPollInterval are clamped up.
+	PollInterval time.Duration
+}
+
+// Resolve returns a copy of c with zero/sub-floor values normalized to
+// the package defaults. Always returns a usable config.
+func (c VersionPollConfig) Resolve() VersionPollConfig {
+	if c.PollInterval <= 0 {
+		c.PollInterval = DefaultVersionPollInterval
+	}
+	if c.PollInterval < MinVersionPollInterval {
+		c.PollInterval = MinVersionPollInterval
+	}
+	return c
+}

--- a/packages/sveltego/exports/kit/version_test.go
+++ b/packages/sveltego/exports/kit/version_test.go
@@ -1,0 +1,48 @@
+package kit
+
+import (
+	"testing"
+	"time"
+)
+
+// TestVersionPollConfig_ResolveZero pins the default interval — a
+// caller that omits the field gets 60s polling, matching the Issue
+// #461 acceptance criterion.
+func TestVersionPollConfig_ResolveZero(t *testing.T) {
+	t.Parallel()
+
+	got := VersionPollConfig{}.Resolve()
+	if got.PollInterval != DefaultVersionPollInterval {
+		t.Errorf("zero interval resolved to %v, want %v", got.PollInterval, DefaultVersionPollInterval)
+	}
+	if got.Disabled {
+		t.Errorf("Disabled flipped on resolve, want false")
+	}
+}
+
+// TestVersionPollConfig_ResolveClampsBelowFloor ensures a misconfigured
+// 100ms interval cannot escape onto the wire — anything below the
+// 1-second floor is clamped up so a typo does not hammer the endpoint.
+func TestVersionPollConfig_ResolveClampsBelowFloor(t *testing.T) {
+	t.Parallel()
+
+	got := VersionPollConfig{PollInterval: 100 * time.Millisecond}.Resolve()
+	if got.PollInterval != MinVersionPollInterval {
+		t.Errorf("100ms resolved to %v, want %v", got.PollInterval, MinVersionPollInterval)
+	}
+}
+
+// TestVersionPollConfig_ResolvePreservesValid checks the pass-through:
+// a sane interval resolves to itself unchanged.
+func TestVersionPollConfig_ResolvePreservesValid(t *testing.T) {
+	t.Parallel()
+
+	in := VersionPollConfig{PollInterval: 30 * time.Second, Disabled: true}
+	got := in.Resolve()
+	if got.PollInterval != 30*time.Second {
+		t.Errorf("PollInterval = %v, want 30s", got.PollInterval)
+	}
+	if !got.Disabled {
+		t.Errorf("Disabled lost on resolve, want true")
+	}
+}

--- a/packages/sveltego/internal/vite/cliententry.go
+++ b/packages/sveltego/internal/vite/cliententry.go
@@ -43,14 +43,17 @@ func GenerateClientEntry(opts ClientEntryOptions) string {
 	// state module through vite-plugin-svelte so its `$state` runes
 	// compile rather than shipping raw to the browser (#471).
 	relStatePath := strings.TrimSuffix(opts.RelRouterPath, "/router") + "/state.svelte"
-	fmt.Fprintf(&b, "import { _setPage } from %q;\n\n", relStatePath)
+	fmt.Fprintf(&b, "import { _setPage, _startVersionPoller } from %q;\n\n", relStatePath)
 	b.WriteString("const el = document.getElementById('sveltego-data');\n")
 	b.WriteString("const payload = el ? JSON.parse(el.textContent ?? '{}') : {};\n")
 	b.WriteString("(window as any).__sveltego__ = { ...payload, enhance };\n")
 	// Seed $app/state before mount so user scripts that read
 	// page.url / page.params / etc. on first render see the
-	// hydration values rather than the initial defaults.
-	b.WriteString("_setPage(payload);\n\n")
+	// hydration values rather than the initial defaults. Also kick
+	// off the version poller — only the first call has effect, so it
+	// is safe to inline in every per-route entry script.
+	b.WriteString("_setPage(payload);\n")
+	b.WriteString("if (payload.appVersion) _startVersionPoller(payload.appVersion, payload.versionPoll);\n\n")
 	b.WriteString("const component = mount(Page, {\n")
 	b.WriteString("  target: document.body,\n")
 	b.WriteString("  props: { data: payload.data, form: payload.form ?? null },\n")

--- a/packages/sveltego/internal/vite/router_test.go
+++ b/packages/sveltego/internal/vite/router_test.go
@@ -493,6 +493,8 @@ func TestGenerateStateModule_emitsSurface(t *testing.T) {
 		"export function _setPage",
 		"export function _setNavigating",
 		"export function _setUpdated",
+		"export function _startVersionPoller",
+		"VERSION_ENDPOINT = '/_app/version.json'",
 		"get url()",
 		"get params()",
 		"get route()",
@@ -540,8 +542,9 @@ func TestGenerateClientEntry_seedsState(t *testing.T) {
 		RelRouterPath: "../__router/router",
 	})
 	for _, want := range []string{
-		`import { _setPage } from "../__router/state.svelte"`,
+		`import { _setPage, _startVersionPoller } from "../__router/state.svelte"`,
 		"_setPage(payload);",
+		"_startVersionPoller(payload.appVersion, payload.versionPoll)",
 	} {
 		if !strings.Contains(src, want) {
 			t.Errorf("entry missing %q:\n%s", want, src)

--- a/packages/sveltego/internal/vite/state.go
+++ b/packages/sveltego/internal/vite/state.go
@@ -68,6 +68,8 @@ export type HydrationPayload = {
   params: Record<string, string>;
   status: number;
   error: AppError;
+  appVersion?: string;
+  versionPoll?: { intervalMs: number; disabled?: boolean };
 };
 
 const initialPage: Page = {
@@ -118,11 +120,43 @@ export const navigating = {
   },
 };
 
+// VERSION_ENDPOINT mirrors the server-side path served by
+// Server.serveVersion. Kept inline rather than threaded through the
+// payload because the path is a hard-wired contract: the SvelteKit
+// equivalent sits at the same spot, and clients running an older bundle
+// against a newer server (or vice versa) still need to agree on it.
+const VERSION_ENDPOINT = '/_app/version.json';
+
+let buildVersion = '';
+
+// updatedCheck is the on-demand check called by updated.check(). It
+// fetches VERSION_ENDPOINT once, compares to buildVersion, flips the
+// rune on drift, and returns whether the version differs. Errors and
+// non-2xx responses resolve to false rather than throwing — matches
+// SvelteKit's swallow-and-return behavior so user UI does not need a
+// try/catch around updated.check().
+async function updatedCheck(): Promise<boolean> {
+  if (typeof fetch === 'undefined' || !buildVersion) return updatedFlag;
+  try {
+    const res = await fetch(VERSION_ENDPOINT, {
+      headers: { pragma: 'no-cache', 'cache-control': 'no-cache' },
+      cache: 'no-store',
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { version?: string };
+    const drifted = typeof data.version === 'string' && data.version !== buildVersion;
+    if (drifted) updatedFlag = true;
+    return drifted;
+  } catch {
+    return false;
+  }
+}
+
 export const updated = {
   get current() {
     return updatedFlag;
   },
-  check: async (): Promise<boolean> => updatedFlag,
+  check: updatedCheck,
 };
 
 // _setPage hydrates pageState from a server payload. routeId, params,
@@ -162,6 +196,62 @@ export function _setNavigating(nav: Navigation | null): void {
 // a poll detects a new app version.
 export function _setUpdated(value: boolean): void {
   updatedFlag = value;
+}
+
+// _startVersionPoller boots the background poller against
+// VERSION_ENDPOINT on the cadence supplied by the server (defaults to
+// 60s, see kit.DefaultVersionPollInterval). Polling stops permanently
+// once the rune flips to true so a stale tab never spams the endpoint.
+//
+// Errors and non-2xx responses retry with exponential backoff —
+// doubling the interval on every consecutive failure up to MAX_BACKOFF
+// — so a flapping endpoint or transient network drop does not produce
+// a tight retry loop. A successful (2xx) response resets the backoff
+// to the configured interval. SvelteKit's upstream poller uses a
+// fixed cadence; we deviate intentionally per acceptance criteria
+// (see issue #461).
+//
+// Idempotent: calling it twice is a no-op the second time. The poller
+// runs only in browser contexts (the typeof guards below keep the SSR
+// build-time evaluation pass from crashing on missing globals).
+let pollerStarted = false;
+const MAX_BACKOFF_MULT = 32;
+
+export function _startVersionPoller(version: string, opts?: { intervalMs?: number; disabled?: boolean }): void {
+  if (pollerStarted) return;
+  pollerStarted = true;
+  buildVersion = version;
+  if (!version) return;
+  if (opts?.disabled) return;
+  if (typeof window === 'undefined' || typeof fetch === 'undefined') return;
+  const baseInterval = Math.max(1000, opts?.intervalMs ?? 60000);
+  let backoffMult = 1;
+  const tick = async () => {
+    let success = false;
+    try {
+      const res = await fetch(VERSION_ENDPOINT, {
+        headers: { pragma: 'no-cache', 'cache-control': 'no-cache' },
+        cache: 'no-store',
+      });
+      if (res.ok) {
+        success = true;
+        const data = (await res.json()) as { version?: string };
+        if (typeof data.version === 'string' && data.version !== buildVersion) {
+          updatedFlag = true;
+          return;
+        }
+      }
+    } catch {
+      // network error; fall through to backoff path below
+    }
+    if (success) {
+      backoffMult = 1;
+    } else if (backoffMult < MAX_BACKOFF_MULT) {
+      backoffMult *= 2;
+    }
+    window.setTimeout(tick, baseInterval * backoffMult);
+  };
+  window.setTimeout(tick, baseInterval);
 }
 
 // _readState extracts the user portion of history.state, mirroring

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -353,16 +353,29 @@ func (s *Server) renderEmptyShell() *kit.Response {
 // navigations; __data.json fetches omit it because the client already
 // has it from the first paint.
 type clientPayload struct {
-	RouteID    string                `json:"routeId"`
-	Data       any                   `json:"data"`
-	LayoutData []any                 `json:"layoutData,omitempty"`
-	Form       any                   `json:"form"`
-	URL        string                `json:"url"`
-	Params     map[string]string     `json:"params"`
-	Status     int                   `json:"status"`
-	PageError  *clientPageError      `json:"error"`
-	Manifest   []clientManifestEntry `json:"manifest,omitempty"`
-	Deps       []string              `json:"deps,omitempty"`
+	RouteID     string                `json:"routeId"`
+	Data        any                   `json:"data"`
+	LayoutData  []any                 `json:"layoutData,omitempty"`
+	Form        any                   `json:"form"`
+	URL         string                `json:"url"`
+	Params      map[string]string     `json:"params"`
+	Status      int                   `json:"status"`
+	PageError   *clientPageError      `json:"error"`
+	Manifest    []clientManifestEntry `json:"manifest,omitempty"`
+	Deps        []string              `json:"deps,omitempty"`
+	AppVersion  string                `json:"appVersion,omitempty"`
+	VersionPoll *clientVersionPoll    `json:"versionPoll,omitempty"`
+}
+
+// clientVersionPoll mirrors kit.VersionPollConfig on the wire. Emitted
+// only when an AppVersion is known (ViteManifest supplied) so the
+// client never spins a poller against a 404 endpoint. IntervalMS is
+// the resolved cadence in milliseconds — matches the typed primitive
+// JS expects from setTimeout/setInterval without a unit conversion on
+// the client.
+type clientVersionPoll struct {
+	IntervalMS int64 `json:"intervalMs"`
+	Disabled   bool  `json:"disabled,omitempty"`
 }
 
 // clientPageError mirrors SvelteKit's App.Error wire shape — a safe
@@ -484,6 +497,23 @@ func buildClientPayload(r *http.Request, route *router.Route, data any, layoutDa
 		}
 	}
 	return p
+}
+
+// applyInitialPayloadFields stamps the per-build SPA manifest, the
+// build-version digest, and the resolved version-poll config onto an
+// initial-render hydration payload. These fields belong on the very
+// first paint only; subsequent __data.json fetches reuse the values
+// already cached by the running client. Callers populate p.Deps
+// separately because Deps comes from the per-request load context.
+func (s *Server) applyInitialPayloadFields(p *clientPayload) {
+	p.Manifest = s.clientManifest
+	if s.appVersion != "" {
+		p.AppVersion = s.appVersion
+		p.VersionPoll = &clientVersionPoll{
+			IntervalMS: s.versionPoll.PollInterval.Milliseconds(),
+			Disabled:   s.versionPoll.Disabled,
+		}
+	}
 }
 
 // emitPayloadScriptTag writes the hydration payload as a JSON <script>
@@ -673,7 +703,7 @@ func (s *Server) renderSvelteShell(r *http.Request, ev *kit.RequestEvent, route 
 	buf.WriteString(s.shellMid)
 	buf.WriteString(`<div id="app"></div>`)
 	payload := buildClientPayload(r, route, data, layoutDatas, ev.Params, form)
-	payload.Manifest = s.clientManifest
+	s.applyInitialPayloadFields(&payload)
 	if lctx != nil {
 		payload.Deps = lctx.CollectDeps()
 	}
@@ -803,7 +833,7 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 			}
 		}
 		payload := buildClientPayload(r, route, data, layoutDatas, ev.Params, form)
-		payload.Manifest = s.clientManifest
+		s.applyInitialPayloadFields(&payload)
 		if lctx != nil {
 			payload.Deps = lctx.CollectDeps()
 		}
@@ -847,7 +877,7 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 		return nil, err
 	}
 	payload := buildClientPayload(r, route, data, layoutDatas, ev.Params, form)
-	payload.Manifest = s.clientManifest
+	s.applyInitialPayloadFields(&payload)
 	if lctx != nil {
 		payload.Deps = lctx.CollectDeps()
 	}

--- a/packages/sveltego/server/server.go
+++ b/packages/sveltego/server/server.go
@@ -126,6 +126,14 @@ type Config struct {
 	// configuration gap. When no route opted in, the entire field is
 	// ignored and Node is never spawned.
 	SSRFallback SSRFallbackConfig
+	// VersionPoll configures the SvelteKit-style `updated` rune. When
+	// ViteManifest is non-empty the server hashes it at boot and
+	// serves the digest at /_app/version.json. The generated client
+	// poller compares the digest against the hydrated build version
+	// on Resolve().PollInterval and flips `updated.current` on drift.
+	// Disabled true keeps the endpoint alive (so updated.check() still
+	// works) but suppresses the background poll.
+	VersionPoll kit.VersionPollConfig
 }
 
 // Server is the http.Handler implementation that drives a sveltego app.
@@ -193,6 +201,16 @@ type Server struct {
 	// Stop calls for it).
 	fallbackConfig     SSRFallbackConfig
 	fallbackSupervisor *fallback.Supervisor
+
+	// appVersion is the build version digest served at
+	// /_app/version.json and seeded into the client hydration payload
+	// so the poller knows what to compare against. Empty string when
+	// no ViteManifest was supplied — the endpoint then reports 404 so
+	// a client never flips on the absence of a hash.
+	appVersion string
+	// versionPoll is the resolved poller config (zero values filled in
+	// from kit defaults).
+	versionPoll kit.VersionPollConfig
 }
 
 // New validates cfg and returns a Server ready for use as an http.Handler.
@@ -279,6 +297,8 @@ func New(cfg Config) (*Server, error) {
 		prerender:       cfg.Prerender,
 		prerenderAuth:   cfg.PrerenderAuth,
 		fallbackConfig:  cfg.SSRFallback,
+		appVersion:      computeAppVersion(cfg.ViteManifest),
+		versionPoll:     cfg.VersionPoll.Resolve(),
 	}
 	// Start as ready so that callers using httptest.NewServer directly
 	// (without ListenAndServe or Init) see normal pipeline behavior.
@@ -321,6 +341,9 @@ func (s *Server) startInit() chan struct{} {
 // PrerenderAuth, falling through to the live SSR pipeline (with the
 // normal init checks) on deny.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.serveVersion(w, r) {
+		return
+	}
 	if s.prerender != nil && s.servePrerendered(w, r) {
 		return
 	}

--- a/packages/sveltego/server/version.go
+++ b/packages/sveltego/server/version.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+)
+
+// versionEndpointPath is the URL the client poller fetches. Matches
+// SvelteKit's default `${assets}/${__SVELTEKIT_APP_VERSION_FILE__}`
+// shape so user code reading /_app/version.json behaves the same way
+// across both frameworks.
+const versionEndpointPath = "/_app/version.json"
+
+// computeAppVersion returns a deterministic short digest of the Vite
+// manifest JSON. The manifest changes any time a route chunk's hashed
+// filename changes, which is exactly the signal a deploy is fresh, so
+// hashing it gives a per-build identifier without requiring the user
+// to thread a build hash through their config.
+//
+// Empty input yields an empty string; callers treat that as "no
+// version known" and skip serving the endpoint. SHA-256 truncated to
+// 16 hex chars (64 bits) is overkill for collision avoidance but
+// keeps the wire payload small.
+func computeAppVersion(manifest string) string {
+	if manifest == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(manifest))
+	return hex.EncodeToString(sum[:8])
+}
+
+// serveVersion writes the JSON {"version":"<hash>"} body the client
+// poller compares against the build version baked into the hydration
+// payload. Returns true iff the request was handled here so the
+// caller can short-circuit the rest of the pipeline. Any non-GET on
+// the same path receives 405; this matches the SvelteKit handler's
+// read-only contract.
+//
+// When appVersion is empty (no ViteManifest supplied at construction)
+// the endpoint reports 404. A client hydrated without a version then
+// keeps `updated.current` at false even if it manages to fetch the
+// path through some other route.
+func (s *Server) serveVersion(w http.ResponseWriter, r *http.Request) bool {
+	if r.URL.Path != versionEndpointPath {
+		return false
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return true
+	}
+	if s.appVersion == "" {
+		http.NotFound(w, r)
+		return true
+	}
+	body := `{"version":"` + s.appVersion + `"}`
+	h := w.Header()
+	h.Set("Content-Type", "application/json; charset=utf-8")
+	h.Set("Cache-Control", "no-store, no-cache, must-revalidate")
+	h.Set("Pragma", "no-cache")
+	h.Set("Content-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(http.StatusOK)
+	if r.Method == http.MethodHead {
+		return true
+	}
+	_, _ = w.Write([]byte(body))
+	return true
+}

--- a/packages/sveltego/server/version_test.go
+++ b/packages/sveltego/server/version_test.go
@@ -1,0 +1,254 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit/params"
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
+)
+
+// TestComputeAppVersion_deterministic checks the same manifest input
+// always produces the same digest — the whole feature collapses if a
+// rebuild with identical bytes flips the hash.
+func TestComputeAppVersion_deterministic(t *testing.T) {
+	t.Parallel()
+
+	src := `{"src/main.ts":{"file":"main.abc.js","isEntry":true}}`
+	a := computeAppVersion(src)
+	b := computeAppVersion(src)
+	if a != b {
+		t.Fatalf("computeAppVersion not deterministic: %q vs %q", a, b)
+	}
+	if a == "" {
+		t.Fatalf("computeAppVersion returned empty for non-empty input")
+	}
+	if len(a) != 16 {
+		t.Errorf("digest length = %d, want 16 hex chars", len(a))
+	}
+}
+
+// TestComputeAppVersion_changesWithInput pins the drift signal: any
+// manifest change must alter the digest, otherwise the client poller
+// can never see a deploy.
+func TestComputeAppVersion_changesWithInput(t *testing.T) {
+	t.Parallel()
+
+	a := computeAppVersion(`{"src/main.ts":{"file":"main.abc.js"}}`)
+	b := computeAppVersion(`{"src/main.ts":{"file":"main.def.js"}}`)
+	if a == b {
+		t.Fatalf("digest should differ for different manifests, got %q", a)
+	}
+}
+
+// TestComputeAppVersion_emptyInput documents the no-manifest path: an
+// empty manifest yields no version, and the endpoint will 404 rather
+// than serve a hash that no client can ever match.
+func TestComputeAppVersion_emptyInput(t *testing.T) {
+	t.Parallel()
+
+	if got := computeAppVersion(""); got != "" {
+		t.Fatalf("computeAppVersion(\"\") = %q, want empty", got)
+	}
+}
+
+// TestServeVersion_okResponse exercises the happy path: GET against
+// the canonical SvelteKit-shape endpoint returns 200 with the
+// {"version":"<hash>"} body and no-cache headers.
+func TestServeVersion_okResponse(t *testing.T) {
+	t.Parallel()
+
+	manifest := `{"src/main.ts":{"file":"main.abc.js","isEntry":true}}`
+	srv := newTestServerWithManifest(t, manifest)
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/_app/version.json", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+	var body struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Version != computeAppVersion(manifest) {
+		t.Errorf("body.version = %q, want %q", body.Version, computeAppVersion(manifest))
+	}
+}
+
+// TestServeVersion_notFoundWithoutManifest covers the bootstrap path:
+// when no Vite manifest is supplied the build version is unknown, so
+// the endpoint reports 404 instead of serving a meaningless hash.
+func TestServeVersion_notFoundWithoutManifest(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithManifest(t, "")
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/_app/version.json", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// TestServeVersion_methodNotAllowed pins the read-only contract: a
+// POST against the endpoint must respond 405 with an Allow header
+// listing the supported methods.
+func TestServeVersion_methodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithManifest(t, `{"src/main.ts":{"file":"x.js"}}`)
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_app/version.json", nil))
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); !strings.Contains(got, "GET") {
+		t.Errorf("Allow = %q, want to include GET", got)
+	}
+}
+
+// TestServeVersion_headRequest is a smoke for HEAD support — load
+// balancers and uptime probes default to HEAD, so a 200 with no body
+// is the right answer rather than 405.
+func TestServeVersion_headRequest(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServerWithManifest(t, `{"src/main.ts":{"file":"x.js"}}`)
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/_app/version.json", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("HEAD body length = %d, want 0", rec.Body.Len())
+	}
+}
+
+func newTestServerWithManifest(t *testing.T, manifest string) *Server {
+	t.Helper()
+	srv, err := New(Config{
+		Routes: []router.Route{{
+			Pattern:  "/",
+			Segments: []router.Segment{},
+			Page:     staticPage("hello"),
+		}},
+		Matchers:     params.DefaultMatchers(),
+		Shell:        testShell,
+		Logger:       quietLogger(),
+		ViteManifest: manifest,
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	return srv
+}
+
+// TestServeVersion_payloadCarriesAppVersion exercises the hydration
+// path end-to-end: the SSR script tag must carry both appVersion
+// and the resolved versionPoll so the client poller boots without
+// fetching auxiliary config. Asserting through the rendered HTML
+// catches regressions where the field is added to the struct but
+// dropped on JSON encode (omitempty / wire shape drift).
+func TestServeVersion_payloadCarriesAppVersion(t *testing.T) {
+	t.Parallel()
+
+	manifest := `{"src/main.ts":{"file":"main.abc.js","isEntry":true}}`
+	srv, err := New(Config{
+		Routes: []router.Route{{
+			Pattern:  "/",
+			Segments: []router.Segment{},
+			Page:     staticPage("hello"),
+		}},
+		Matchers:     params.DefaultMatchers(),
+		Shell:        testShell,
+		Logger:       quietLogger(),
+		ViteManifest: manifest,
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	const tag = `<script id="sveltego-data" type="application/json">`
+	i := strings.Index(body, tag)
+	if i < 0 {
+		t.Fatalf("payload tag missing in body=%s", body)
+	}
+	raw := body[i+len(tag):]
+	end := strings.Index(raw, "</script>")
+	if end < 0 {
+		t.Fatalf("payload tag unterminated")
+	}
+	var p struct {
+		AppVersion  string `json:"appVersion"`
+		VersionPoll struct {
+			IntervalMS int64 `json:"intervalMs"`
+			Disabled   bool  `json:"disabled"`
+		} `json:"versionPoll"`
+	}
+	if err := json.Unmarshal([]byte(raw[:end]), &p); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if p.AppVersion != computeAppVersion(manifest) {
+		t.Errorf("appVersion = %q, want %q", p.AppVersion, computeAppVersion(manifest))
+	}
+	wantInterval := kit.DefaultVersionPollInterval.Milliseconds()
+	if p.VersionPoll.IntervalMS != wantInterval {
+		t.Errorf("intervalMs = %d, want %d", p.VersionPoll.IntervalMS, wantInterval)
+	}
+}
+
+// TestServeVersion_payloadOmitsWhenManifestEmpty pins the no-manifest
+// case: with no Vite manifest the SSR payload must omit both
+// appVersion and versionPoll so the client never starts a poller
+// against a 404 endpoint.
+func TestServeVersion_payloadOmitsWhenManifestEmpty(t *testing.T) {
+	t.Parallel()
+
+	srv, err := New(Config{
+		Routes: []router.Route{{
+			Pattern:  "/",
+			Segments: []router.Segment{},
+			Page:     staticPage("hello"),
+		}},
+		Matchers: params.DefaultMatchers(),
+		Shell:    testShell,
+		Logger:   quietLogger(),
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+	if strings.Contains(body, `"appVersion"`) {
+		t.Errorf("payload should omit appVersion when manifest is empty; body=%s", body)
+	}
+	if strings.Contains(body, `"versionPoll"`) {
+		t.Errorf("payload should omit versionPoll when manifest is empty; body=%s", body)
+	}
+}

--- a/playgrounds/basic/src/routes/version-poll/_page.svelte
+++ b/playgrounds/basic/src/routes/version-poll/_page.svelte
@@ -1,0 +1,18 @@
+<!-- sveltego:ssr-fallback -->
+<script lang="ts">
+  import { updated } from '$app/state';
+
+  async function checkNow() {
+    await updated.check();
+  }
+</script>
+
+<h1>updated rune fixture</h1>
+<p data-testid="updated-current">updated.current = {String(updated.current)}</p>
+<button data-testid="check-now" type="button" onclick={checkNow}>updated.check()</button>
+<p>
+  This page exercises the SvelteKit-equivalent <code>updated</code> rune. The
+  background poller fetches <code>/_app/version.json</code> on the server's
+  configured cadence and flips the value above to <code>true</code> when the
+  build version drifts. Click the button to force an immediate check.
+</p>


### PR DESCRIPTION
## Summary

- Implements SvelteKit-equivalent version polling so `$app/state`'s `updated` rune actually flips when a new build is deployed (closes #461).
- Server hashes the Vite manifest at boot and serves the digest at `/_app/version.json`. Generated client poller fetches on the configured cadence (default 60s, 1s floor), flips `updated.current` to `true` on drift, with exponential backoff (capped at 32×) on errors.
- Configurable via new `kit.VersionPollConfig` field on `server.Config`. Disabled true keeps `updated.check()` working but suppresses the background poll.

## Surface

| Layer | Files |
|---|---|
| Config | `packages/sveltego/exports/kit/version.go` (new) — `kit.VersionPollConfig`, defaults, `Resolve()` |
| Endpoint | `packages/sveltego/server/version.go` (new) — `computeAppVersion`, `serveVersion` |
| Server wire | `packages/sveltego/server/server.go` — fields + `New()` plumb; `ServeHTTP()` short-circuit |
| Hydration payload | `packages/sveltego/server/pipeline.go` — `clientPayload.{AppVersion,VersionPoll}` + `applyInitialPayloadFields` helper |
| Client rune | `packages/sveltego/internal/vite/state.go` — real `updated.check()`; `_startVersionPoller` with exponential backoff |
| Client entry | `packages/sveltego/internal/vite/cliententry.go` — boots `_startVersionPoller` after `_setPage` |
| Fixture | `playgrounds/basic/src/routes/version-poll/_page.svelte` (new) |

## Behavior parity vs SvelteKit

- Endpoint path `/_app/version.json` matches `${assets}/${__SVELTEKIT_APP_VERSION_FILE__}`.
- Response shape `{"version":"<hash>"}` matches.
- `pragma: no-cache` and `cache-control: no-cache` request headers match upstream.
- After flip to true, polling stops permanently — same as upstream.

Deviations (per acceptance criteria, issue #461):
- Default `PollInterval` is 60s rather than SvelteKit's 0 (off by default). Sveltego defaults polling on so the rune is useful out of the box; opt out via `VersionPoll.Disabled = true`.
- Exponential backoff on errors rather than upstream's fixed cadence. Reduces traffic when an endpoint flaps without changing the steady-state cadence.

## Test plan

- [x] `gofumpt -l .` clean
- [x] `goimports -l -local github.com/binsarjr/sveltego .` clean
- [x] `go vet ./...` across all workspace modules — no issues
- [x] `go test -race ./...` across all 16 workspace modules — 2032 passed
- [x] 9 new tests in `packages/sveltego/server/` covering endpoint shape, headers, method enforcement, HEAD support, no-manifest 404, hydration-payload plumbing
- [x] 3 new tests in `packages/sveltego/exports/kit/` covering `Resolve()` defaults + clamping
- [x] Existing `internal/vite/router_test.go` extended to pin the new state-module + entry-script exports
- [ ] Manual flip test in `playgrounds/basic/version-poll`: build, navigate, force a manifest hash change, observe `updated.current = true` (deferred to post-merge — requires running playground end-to-end which is currently blocked by an unrelated `playground-smoke` regression on `main`)

## Notes

- `playground-smoke (basic)` is currently red on `main` due to a pre-existing codegen bug (`+page.svelte` resolution path mismatch from RFC #379 phase 1b). Not introduced by this PR; flagging for the team-lead's CI audit.
- `depguard` lint flags new test imports of `exports/kit`, `exports/kit/params`, `runtime/router`. Same imports exist in many merged-and-passing test files (`server_test.go`, `options_integration_test.go`, etc.) — appears to be a CI tolerance, not a hard gate. Not introducing a new violation pattern.