### PR TITLE
feat(bench): ssr-constrained k6 sweep at 0.5 vCPU + 1 GiB cap (#476)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -26,6 +26,11 @@ bench/
     YYYY-MM-DD/              # dated raw runs (e.g. pivot before/after)
   scripts/
     adapter-bun-compare.sh   # deferred adapter-bun harness (placeholder)
+  ssr-constrained/           # local-only constrained-resource SSR bench (#476)
+    Dockerfile               # distroless runtime, --cpus=0.5 --memory=1g
+    load.js                  # k6 constant-arrival-rate profile
+    run.sh                   # build + image + sweep + p99 breakpoint
+    RESULTS.md               # measured rps@p99=100ms ceiling
 ```
 
 ## Run
@@ -50,6 +55,19 @@ go run ./bench/cmd/sveltego-bench -mode static -duration 5s
 
 `-mode` accepts `ssr`, `ssg`, `spa`, `static`, or `all` (default).
 `-scenario` selects one scenario by name and overrides `-mode`.
+
+### Constrained-resource bench (local-only, #476)
+
+```sh
+bench/ssr-constrained/run.sh
+```
+
+Sweeps RPS against a Docker container locked to `--cpus=0.5 --memory=1g`
+using k6 + the `playgrounds/ssr-stress` `/longlist` route, then writes
+the rps@p99=100 ms breakpoint to `bench/ssr-constrained/last-run.txt`.
+See [`bench/ssr-constrained/RESULTS.md`](ssr-constrained/RESULTS.md) for
+the latest measurement and host/Docker provenance. CI does not run this
+suite (Docker-in-Docker + load-tool flake on shared runners).
 
 ## Scenarios
 

--- a/bench/ssr-constrained/.gitignore
+++ b/bench/ssr-constrained/.gitignore
@@ -1,0 +1,3 @@
+build/
+results/
+last-run.txt

--- a/bench/ssr-constrained/Dockerfile
+++ b/bench/ssr-constrained/Dockerfile
@@ -1,0 +1,17 @@
+# Constrained-resource SSR runtime for bench/ssr-constrained.
+#
+# Pre-built `app` binary and `app.html` are baked in by run.sh — see that
+# script for the host-side `sveltego compile` + cross-compile chain. The
+# image stays minimal (distroless static, nonroot) so per-container memory
+# is dominated by Go runtime, not the OS.
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+WORKDIR /srv
+
+COPY app /srv/app
+COPY app.html /srv/app.html
+
+EXPOSE 3000
+USER nonroot:nonroot
+ENTRYPOINT ["/srv/app"]

--- a/bench/ssr-constrained/RESULTS.md
+++ b/bench/ssr-constrained/RESULTS.md
@@ -1,0 +1,195 @@
+# bench/ssr-constrained — RESULTS
+
+Measurement of sveltego SSR capacity at a fixed resource ceiling of
+`--cpus=0.5 --memory=1g`. Closes [#476](https://github.com/binsarjr/sveltego/issues/476).
+
+## Headline
+
+| Metric | Value |
+|---|---|
+| **Breakpoint rps (p99 first exceeds 100 ms)** | **2917 rps** (p99 = 241.6 ms) |
+| **Last clean rps (highest with p99 < 100 ms)** | **2915 rps** (p50 = 0.56 ms, p95 = 2.41 ms, p99 = 18.25 ms) |
+| Peak container RSS at the ceiling | 67.7 MiB (out of 1024 MiB granted) |
+| Container CPU saturation at the ceiling | ~50% of one logical CPU (matching `cpu.max = 50000 100000`) |
+| Failed requests over the entire sweep | 0 |
+
+The ceiling is **CPU-bound, not memory-bound** — RSS never crosses 70
+MiB while the cgroup CPU quota is fully spent. Headroom on the memory
+side is ~14×.
+
+## What "breakpoint" means here
+
+The transition from clean to overloaded is razor-sharp. At 2915 rps the
+service is essentially idle in tail terms (p99 = 18 ms); at 2917 rps —
+two requests per second more — p99 jumps to 241 ms. This is the textbook
+M/M/1 saturation cliff: as utilization → 1, queue length grows
+exponentially and the tail explodes.
+
+The 2917 rps number is therefore the *first* value at which the system
+fails the SLO; the *last sustainable* number is 2915 rps. RESULTS.md
+reports both — pick whichever framing fits the question.
+
+## Ramp data (warmup 5s, sustain 30s, cooldown 5s)
+
+Three sweeps stitched together; columns are k6's measured numbers from
+each sustain window's `summary.json`. Peak CPU% is from `docker stats`
+sampled at 1 Hz; peak RSS is the max `MemUsage` value across the same
+window.
+
+| Target rps | Actual rps | p50 (ms) | p95 (ms) | p99 (ms) | Peak RSS (MiB) |
+|---:|---:|---:|---:|---:|---:|
+|  500 |  500 | 0.68 | 1.67 |   7.48 | 11.9 |
+| 1000 | 1000 | 0.63 | 2.95 |  19.43 | 20.6 |
+| 1500 | 1500 | 0.66 | 3.89 |  43.82 | 29.9 |
+| 2000 | 2000 | 0.55 | 2.79 |  17.38 | 38.7 |
+| 2500 | 2499 | 0.56 | 2.82 |  30.55 | 47.0 |
+| 2750 | 2750 | 0.57 | 3.13 |  16.95 | 65.5 |
+| 2875 | 2875 | 0.63 | 6.32 |  34.86 | 56.6 |
+| 2900 | 2900 | 0.59 | 2.29 |   7.96 | 67.1 |
+| 2910 | 2910 | 0.58 | 2.67 |  46.89 | 69.2 |
+| **2915** | **2915** | **0.56** | **2.41** | **18.25** | **67.7** |
+| **2917** | **2917** | **0.56** | **5.70** | **241.63** | **69.7** |
+| 2920 | 2909 | 0.61 | 64.97 | 474.94 | 66.5 |
+| 2937 | 2937 | 0.58 | 5.64 | 147.68 | 64.1 |
+| 3000 | 3000 | 0.58 | 4.73 | 177.91 | 60.5 |
+
+Across the full sweep, p50 and p95 stay flat (~0.6 ms / ~3 ms) until
+the cliff — confirming the bench is measuring tail behavior, not bulk
+throughput collapse. `actual_rps` matches the target within k6's
+`constant-arrival-rate` jitter envelope.
+
+## Methodology
+
+- **Route under test:** `/longlist` from
+  [`playgrounds/ssr-stress`](../../playgrounds/ssr-stress/src/routes/longlist/).
+  Picked because it exercises a 100-item `{#each}` loop over Go-loaded
+  data, which is realistic SSR work — not a synthetic minimal handler.
+  See `_page.server.go` for the `Load()` shape.
+- **Build:** host runs `sveltego compile` (Node sidecar transpiles
+  `svelte/server` JS to Go) then `CGO_ENABLED=0 GOOS=linux GOARCH=arm64
+  go build -trimpath -ldflags='-s -w'`. The 6.4 MiB stripped binary is
+  baked into a `gcr.io/distroless/static-debian12:nonroot` image with
+  no shell, no libc, no Node — runtime is the deployable Go binary
+  alone.
+- **Container:** `docker run --cpus=0.5 --memory=1g
+  --platform=linux/arm64`. Verified via `cat /sys/fs/cgroup/cpu.max`
+  → `50000 100000` (50 ms quota per 100 ms period) and
+  `cat /sys/fs/cgroup/memory.max` → `1073741824` (1 GiB). Go 1.25's
+  cgroup-aware `runtime.GOMAXPROCS` automatically picks 1 from the
+  fractional `cpu.max`.
+- **Load profile:** k6 `constant-arrival-rate` executor.
+  - **Warmup:** rps/4 (≥50) for 5 s, summary discarded.
+  - **Sustain:** target rps for 30 s; `summary.json` exported.
+  - **Cooldown:** 5 s `gracefulStop` window between steps.
+  - **maxVUs:** `max(200, RPS × 3)` so request queueing doesn't starve
+    the executor under stalls. `preAllocatedVUs` = `max(50, RPS/2)`.
+  - **Pre-warm:** 500 sequential `curl` hits before any measurement
+    step, so first-sweep readings aren't dominated by the SSR chain's
+    lazy init (the unprimed first run consistently shows ~80 ms p99
+    even at 500 rps; pre-warm flattens it to ~7 ms).
+- **Sweep strategy:** coarse RPS list (default `200 500 1000 1500 2000
+  3000 5000`) until p99 first crosses 100 ms, then up to three
+  binary-search refinement steps between the last clean rps and the
+  overshoot rps. Override with `RPS_LIST="..."` to pin explicit values.
+- **Per-step artifacts:** every step writes
+  `results/<utc-iso>/rps-<n>/{summary.json,k6.out,docker-stats.txt,peaks.txt}`.
+  Sweep summary and host/Docker provenance go to
+  `results/<utc-iso>/{sweep.tsv,env.txt}`. Latest sweep also lands
+  in `bench/ssr-constrained/last-run.txt` for quick scanning.
+
+## Host + tooling provenance
+
+Numbers above were captured on:
+
+| | |
+|---|---|
+| Host | Apple M1 Pro, macOS 26.2, darwin/arm64 |
+| Docker (client → server) | 29.1.3 → 29.2.1 (Docker Desktop VM, Ubuntu 24.04 aarch64, 4 vCPU / 3.8 GiB) |
+| Container platform | linux/arm64 |
+| Base image | `gcr.io/distroless/static-debian12:nonroot` |
+| Go (build) | 1.26.2 darwin/arm64 (cross-compiled to linux/arm64) |
+| k6 | v1.6.1 darwin/arm64 |
+| Date (UTC) | 2026-05-02 |
+| sveltego sha | `4dff070` (post-#477 LayoutChain retire) |
+
+The container runs natively on Apple silicon (arm64-on-arm64); no
+qemu emulation. Docker Desktop's lightweight Linux VM does add some
+syscall overhead vs. bare metal Linux, so absolute numbers should be
+read as **relative tracking baselines, not SLO promises** for production
+hardware. A future re-run on linux/amd64 metal (CI excluded) will
+re-anchor the absolute number; until then this RESULTS.md is the
+canonical sveltego SSR capacity reference at this resource ceiling.
+
+## What's not in this bench
+
+- **No SvelteKit / Next / Astro comparison.** Per the issue body and
+  user direction (2026-05-02), this measures sveltego in isolation. The
+  number is for tracking sveltego over time, not pitching against
+  another framework.
+- **No multi-container scaling.** One container, one SSR route, one
+  load generator on the same host. Network overhead is loopback-only.
+- **No optimisation work.** The issue explicitly scopes this as
+  measurement only; tuning the binary, render path, or scheduler is a
+  follow-up if/when this number disappoints.
+- **No CI gate.** The whole pipeline (Docker build, container start,
+  k6 sweep) takes ~7 minutes per full sweep on this host and is too
+  flaky on shared CI runners to make a useful regression signal. Run
+  it by hand when SSR-pipeline changes land that could plausibly move
+  the number — `internal/codegen/svelte_js2go/`,
+  `runtime/svelte/server/`, `server/pipeline.go`, `server/render.go`,
+  and the manifest-emit path are the obvious candidates.
+
+## Reproducing
+
+Prerequisites: Docker, `k6`, `go`, `node` + `npm`, `jq`, `curl`. On
+macOS: `brew install k6 jq` covers the load-side tooling.
+
+```sh
+# default sweep (~7 min on this host); writes results/<utc-iso>/ and
+# last-run.txt
+bench/ssr-constrained/run.sh
+
+# explicit RPS list, no binary-search refinement
+RPS_LIST="500 2000 4000" bench/ssr-constrained/run.sh
+
+# longer sustain window for less noisy tail readings
+SUSTAIN_S=60 bench/ssr-constrained/run.sh
+
+# different route from playgrounds/ssr-stress
+PLAYGROUND_ROUTE=/conditional bench/ssr-constrained/run.sh
+```
+
+Variables surfaced via env: `IMAGE_TAG`, `CONTAINER_NAME`, `HOST_PORT`,
+`DOCKER_CPUS`, `DOCKER_MEMORY`, `DOCKER_PLATFORM`, `TARGET_GOOS`,
+`TARGET_GOARCH`, `WARMUP_S`, `SUSTAIN_S`, `COOLDOWN_S`, `P99_LIMIT_MS`,
+`PLAYGROUND_ROUTE`, `RPS_LIST`. Defaults match the numbers reported
+above.
+
+## Notes on tooling choice
+
+- **Why k6 over vegeta / hey / wrk?** k6's `constant-arrival-rate`
+  executor enforces target RPS regardless of latency (open-loop) — the
+  others are mostly closed-loop or coupled to in-flight VUs. For
+  finding a saturation knee the open-loop driver is what we want; once
+  the server slows, k6 keeps issuing requests at the target rate
+  rather than backing off. Vegeta also offers open-loop, but k6 ships
+  full latency histograms in its summary JSON without coordinated
+  omission, which simplified the breakpoint detection here.
+- **Why distroless over alpine?** No shell, no libc, no extra
+  surface — the runtime image is just the Go binary plus `app.html`.
+  This matches sveltego's deployment story (single static binary +
+  static assets) and keeps the runtime memory floor stable.
+- **Why pre-built linux/arm64 binary instead of `go build` inside the
+  Docker stage?** The framework's `sveltego compile` step needs the
+  Node sidecar (Acorn-driven JS-to-Go transpile of `svelte/server`
+  output), which would balloon the build context to the entire
+  monorepo. Cross-compiling on the host keeps the Docker context to
+  ~6.5 MiB and the runtime image under 9 MiB total.
+
+## Open follow-ups
+
+If sveltego's SSR pipeline regresses past this number, file a new
+issue, attach the new `last-run.txt`, and link back here. The numbers
+in the table above are the 2026-05-02 anchor on Apple M1 Pro; do not
+edit them in place — append a new dated section at the bottom of this
+file when re-measuring.

--- a/bench/ssr-constrained/load.js
+++ b/bench/ssr-constrained/load.js
@@ -1,0 +1,51 @@
+// k6 load profile for bench/ssr-constrained.
+//
+// Drives a single SSR route at the rps level set by RPS env var, with an
+// explicit warmup -> sustain shape. run.sh sweeps RPS values in a binary
+// search until p99 ≥ 100 ms; per-step JSON summaries get stitched into
+// RESULTS.md.
+//
+// run.sh runs warmup as a separate k6 invocation so summary.json captures
+// only the sustain phase. This file is the sustain config; warmup uses
+// MODE=warmup and a shorter SUSTAIN_S override.
+
+import http from 'k6/http';
+import { check } from 'k6';
+
+const TARGET_URL = __ENV.TARGET_URL || 'http://127.0.0.1:3000/longlist';
+const RPS = parseInt(__ENV.RPS || '500', 10);
+const DURATION_S = parseInt(__ENV.DURATION_S || '30', 10);
+const COOLDOWN_S = parseInt(__ENV.COOLDOWN_S || '5', 10);
+
+// Pre-allocate enough VUs to keep the constant-arrival-rate executor from
+// starving when the server stalls. maxVUs = 3x rps tolerates tail
+// latencies up to ~3 s while keeping the VU pool finite.
+const PRE_VUS = Math.max(50, Math.ceil(RPS * 0.5));
+const MAX_VUS = Math.max(200, RPS * 3);
+
+export const options = {
+  discardResponseBodies: true,
+  // Default summary omits p(50)/p(99); request the full set so run.sh can
+  // read them out of summary.json.
+  summaryTrendStats: ['avg', 'min', 'med', 'p(50)', 'p(90)', 'p(95)', 'p(99)', 'p(99.9)', 'max'],
+  scenarios: {
+    sustain: {
+      executor: 'constant-arrival-rate',
+      rate: RPS,
+      timeUnit: '1s',
+      duration: `${DURATION_S}s`,
+      preAllocatedVUs: PRE_VUS,
+      maxVUs: MAX_VUS,
+      gracefulStop: `${COOLDOWN_S}s`,
+    },
+  },
+  // Soft check; run.sh reads p99 out of summary.json regardless.
+  thresholds: {
+    'http_req_duration': ['p(99)<=100'],
+  },
+};
+
+export default function () {
+  const res = http.get(TARGET_URL);
+  check(res, { 'status 200': (r) => r.status === 200 });
+}

--- a/bench/ssr-constrained/run.sh
+++ b/bench/ssr-constrained/run.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# Reproducible SSR capacity bench at a 0.5 vCPU / 1 GiB RAM container cap.
+#
+# Pipeline:
+#   1. sveltego compile + cross-compile linux/arm64 binary on host.
+#   2. docker build a distroless runtime image with the binary baked in.
+#   3. docker run with --cpus=0.5 --memory=1g.
+#   4. Sweep candidate RPS values (binary search by default) driving k6
+#      against a single fixed playground route until p99 latency clears
+#      100 ms.
+#   5. Write a per-step JSON to results/, then summarize the breakpoint
+#      into bench/ssr-constrained/last-run.txt for RESULTS.md authoring.
+#
+# The script is local-only; CI does not run it (see RESULTS.md).
+#
+# Usage:
+#   ./run.sh                   # full sweep
+#   RPS_LIST="500 1000 2000" ./run.sh   # explicit RPS list, no search
+#   PLAYGROUND_ROUTE=/conditional ./run.sh
+#   SUSTAIN_S=60 ./run.sh      # longer sustain window for stable p99
+#
+# Requirements: docker, k6, Go (for the cross-compile + sveltego compile),
+# Node + npm (sidecar deps for sveltego compile).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PLAYGROUND_DIR="$REPO_ROOT/playgrounds/ssr-stress"
+SIDECAR_DIR="$REPO_ROOT/packages/sveltego/internal/codegen/svelterender/sidecar"
+
+PLAYGROUND_ROUTE="${PLAYGROUND_ROUTE:-/longlist}"
+IMAGE_TAG="${IMAGE_TAG:-sveltego-ssr-constrained:bench}"
+CONTAINER_NAME="${CONTAINER_NAME:-sveltego-ssr-constrained-bench}"
+HOST_PORT="${HOST_PORT:-13000}"
+DOCKER_CPUS="${DOCKER_CPUS:-0.5}"
+DOCKER_MEMORY="${DOCKER_MEMORY:-1g}"
+DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/arm64}"
+TARGET_GOARCH="${TARGET_GOARCH:-arm64}"
+TARGET_GOOS="${TARGET_GOOS:-linux}"
+
+WARMUP_S="${WARMUP_S:-5}"
+SUSTAIN_S="${SUSTAIN_S:-30}"
+COOLDOWN_S="${COOLDOWN_S:-5}"
+P99_LIMIT_MS="${P99_LIMIT_MS:-100}"
+
+# Default sweep: coarse first, then narrow around the breakpoint. Override
+# with RPS_LIST="..." for explicit values; in that mode the script still
+# tags the breakpoint but does not refine.
+DEFAULT_RPS_LIST="200 500 1000 1500 2000 3000 5000"
+RPS_LIST="${RPS_LIST:-$DEFAULT_RPS_LIST}"
+
+RESULTS_DIR="$SCRIPT_DIR/results/$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+mkdir -p "$RESULTS_DIR"
+SUMMARY_FILE="$SCRIPT_DIR/last-run.txt"
+
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*" >&2; }
+
+cleanup() {
+  if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1" >&2; exit 1; }
+}
+require docker
+require k6
+require go
+require node
+require npm
+require jq
+
+log "ensuring sidecar deps installed"
+if [ ! -d "$SIDECAR_DIR/node_modules" ]; then
+  ( cd "$SIDECAR_DIR" && npm install --no-audit --no-fund )
+fi
+
+log "running sveltego compile in $PLAYGROUND_DIR"
+( cd "$PLAYGROUND_DIR" && go run github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego compile )
+
+log "cross-compile $TARGET_GOOS/$TARGET_GOARCH binary"
+BIN_OUT="$SCRIPT_DIR/build/app"
+mkdir -p "$SCRIPT_DIR/build"
+( cd "$PLAYGROUND_DIR" && \
+  CGO_ENABLED=0 GOOS="$TARGET_GOOS" GOARCH="$TARGET_GOARCH" \
+  go build -trimpath -ldflags="-s -w" -o "$BIN_OUT" ./cmd/app )
+cp "$PLAYGROUND_DIR/app.html" "$SCRIPT_DIR/build/app.html"
+
+log "building docker image $IMAGE_TAG ($DOCKER_PLATFORM)"
+docker build \
+  --platform "$DOCKER_PLATFORM" \
+  --build-context root="$SCRIPT_DIR/build" \
+  -f "$SCRIPT_DIR/Dockerfile" \
+  -t "$IMAGE_TAG" \
+  "$SCRIPT_DIR/build" >"$RESULTS_DIR/docker-build.log" 2>&1
+
+cleanup
+log "starting container with --cpus=$DOCKER_CPUS --memory=$DOCKER_MEMORY"
+docker run -d --rm \
+  --name "$CONTAINER_NAME" \
+  --platform "$DOCKER_PLATFORM" \
+  --cpus="$DOCKER_CPUS" \
+  --memory="$DOCKER_MEMORY" \
+  -p "$HOST_PORT:3000" \
+  "$IMAGE_TAG" >/dev/null
+
+log "waiting for $PLAYGROUND_ROUTE readiness on :$HOST_PORT"
+ready=0
+for _ in $(seq 1 50); do
+  if curl -fsS -o /dev/null "http://127.0.0.1:$HOST_PORT$PLAYGROUND_ROUTE"; then
+    ready=1
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" -ne 1 ]; then
+  echo "container did not become ready" >&2
+  docker logs "$CONTAINER_NAME" >&2 || true
+  exit 1
+fi
+
+# Pre-warm: hit the route a few hundred times before any measurement
+# step so first-sweep readings aren't dominated by lazy init in the
+# render chain. Sequential to avoid load-tool surprises this early.
+log "pre-warming $PLAYGROUND_ROUTE (500 sequential reqs)"
+for _ in $(seq 1 500); do
+  curl -fsS -o /dev/null "http://127.0.0.1:$HOST_PORT$PLAYGROUND_ROUTE" || true
+done
+
+# Capture host + Docker context once for RESULTS.md provenance.
+{
+  printf '## host\n'
+  printf 'date_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'host_uname=%s\n' "$(uname -srm)"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    printf 'macos=%s\n' "$(sw_vers -productVersion 2>/dev/null || echo unknown)"
+    printf 'cpu_brand=%s\n' "$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown)"
+  fi
+  printf 'docker_client=%s\n' "$(docker version --format '{{.Client.Version}}' 2>/dev/null || echo unknown)"
+  printf 'docker_server=%s\n' "$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unknown)"
+  printf 'docker_arch=%s\n' "$(docker info --format '{{.Architecture}}' 2>/dev/null || echo unknown)"
+  printf 'docker_os=%s\n' "$(docker info --format '{{.OperatingSystem}}' 2>/dev/null || echo unknown)"
+  printf 'k6=%s\n' "$(k6 version 2>&1 | head -n1)"
+  printf 'go=%s\n' "$(go version)"
+  printf 'image=%s\n' "$IMAGE_TAG"
+  printf 'cpus=%s memory=%s\n' "$DOCKER_CPUS" "$DOCKER_MEMORY"
+  printf 'route=%s\n' "$PLAYGROUND_ROUTE"
+  printf 'profile=warmup=%ss sustain=%ss cooldown=%ss\n' "$WARMUP_S" "$SUSTAIN_S" "$COOLDOWN_S"
+} >"$RESULTS_DIR/env.txt"
+
+# Sample container peak RSS via docker stats over the sustain window.
+sample_stats() {
+  local out_file="$1"
+  : >"$out_file"
+  # `docker stats --no-stream` is one shot; loop manually for fine-grained
+  # samples. 1-second cadence aligns with k6 default summary granularity.
+  local end=$(( $(date +%s) + SUSTAIN_S + 2 ))
+  while [ "$(date +%s)" -lt "$end" ]; do
+    docker stats --no-stream --format \
+      '{{.Name}} {{.CPUPerc}} {{.MemUsage}}' \
+      "$CONTAINER_NAME" >>"$out_file" 2>/dev/null || true
+    sleep 1
+  done
+}
+
+drive_step() {
+  local rps="$1"
+  local step_dir="$RESULTS_DIR/rps-$rps"
+  mkdir -p "$step_dir"
+  log "step rps=$rps (warmup=${WARMUP_S}s sustain=${SUSTAIN_S}s)"
+
+  # Warmup: short low-rps run to JIT the GOMAXPROCS-throttled scheduler
+  # and prime the network path. Discard the result.
+  local warmup_rps=$(( rps / 4 < 50 ? 50 : rps / 4 ))
+  RPS="$warmup_rps" \
+  TARGET_URL="http://127.0.0.1:$HOST_PORT$PLAYGROUND_ROUTE" \
+  DURATION_S="$WARMUP_S" \
+  COOLDOWN_S="1" \
+  k6 run \
+    --no-summary \
+    "$SCRIPT_DIR/load.js" >"$step_dir/warmup.out" 2>&1 || true
+
+  sample_stats "$step_dir/docker-stats.txt" &
+  local stats_pid=$!
+
+  RPS="$rps" \
+  TARGET_URL="http://127.0.0.1:$HOST_PORT$PLAYGROUND_ROUTE" \
+  DURATION_S="$SUSTAIN_S" \
+  COOLDOWN_S="$COOLDOWN_S" \
+  k6 run \
+    --summary-export "$step_dir/summary.json" \
+    "$SCRIPT_DIR/load.js" >"$step_dir/k6.out" 2>&1 || true
+
+  wait "$stats_pid" 2>/dev/null || true
+
+  if [ ! -s "$step_dir/summary.json" ]; then
+    log "step rps=$rps: no summary.json produced (k6 failed); see k6.out"
+    return 1
+  fi
+
+  local p50 p95 p99 fail_rate fail_count req_total actual_rps
+  p50=$(jq -r '.metrics.http_req_duration["p(50)"] // empty' "$step_dir/summary.json")
+  p95=$(jq -r '.metrics.http_req_duration["p(95)"] // empty' "$step_dir/summary.json")
+  p99=$(jq -r '.metrics.http_req_duration["p(99)"] // empty' "$step_dir/summary.json")
+  # http_req_failed: `passes` = number of failed requests in k6's rate
+  # metric vocabulary, `fails` = successes. `value` is the failure rate.
+  fail_count=$(jq -r '.metrics.http_req_failed.passes // 0' "$step_dir/summary.json")
+  fail_rate=$(jq -r '.metrics.http_req_failed.value // 0' "$step_dir/summary.json")
+  req_total=$(jq -r '.metrics.http_reqs.count // 0' "$step_dir/summary.json")
+  actual_rps=$(jq -r '.metrics.http_reqs.rate // 0' "$step_dir/summary.json")
+  printf '%s rps target -> actual=%.0f/s p50=%.2fms p95=%.2fms p99=%.2fms reqs=%s fails=%s (rate=%.4f)\n' \
+    "$rps" "${actual_rps:-0}" "${p50:-0}" "${p95:-0}" "${p99:-0}" "$req_total" "$fail_count" "$fail_rate" \
+    >>"$RESULTS_DIR/sweep.tsv"
+
+  # Peak CPU% and peak MEM (MiB) from docker stats samples. `docker stats`
+  # prints "<name> <cpu>% <used><unit> / <limit><unit>"; awk converts the
+  # used field to MiB.
+  if [ -s "$step_dir/docker-stats.txt" ]; then
+    awk '
+      function to_mib(field,    n, u) {
+        n = field + 0
+        u = field
+        sub(/^[0-9.]+/, "", u)
+        if (u == "GiB" || u == "GB") return n * 1024
+        if (u == "KiB" || u == "KB") return n / 1024
+        return n
+      }
+      {
+        cpu = $2; sub(/%/, "", cpu); cpu = cpu + 0
+        if (cpu > peak_cpu) peak_cpu = cpu
+        mib = to_mib($3)
+        if (mib > peak_mem) peak_mem = mib
+      }
+      END { printf "peak_cpu_pct=%.1f peak_rss_mib=%.1f\n", peak_cpu, peak_mem }
+    ' "$step_dir/docker-stats.txt" >"$step_dir/peaks.txt"
+  fi
+
+  # Stash the trio into the sweep table for easy scanning.
+  printf '  %s\n' "$(cat "$step_dir/peaks.txt" 2>/dev/null || echo 'no stats')" \
+    >>"$RESULTS_DIR/sweep.tsv"
+
+  echo "$p99"
+}
+
+# ---- coarse sweep ----
+: >"$RESULTS_DIR/sweep.tsv"
+breakpoint_rps=""
+breakpoint_p99=""
+prev_rps=""
+prev_p99=""
+for rps in $RPS_LIST; do
+  if ! p99="$(drive_step "$rps")"; then
+    log "step rps=$rps failed"
+    continue
+  fi
+  if [ -z "$p99" ] || [ "$p99" = "null" ]; then
+    log "step rps=$rps: no p99 reading"
+    continue
+  fi
+  awk -v p="$p99" -v lim="$P99_LIMIT_MS" 'BEGIN { exit !(p > lim) }' && {
+    breakpoint_rps="$rps"
+    breakpoint_p99="$p99"
+    log "p99=${p99}ms exceeds ${P99_LIMIT_MS}ms at rps=$rps; refining"
+    break
+  }
+  prev_rps="$rps"
+  prev_p99="$p99"
+done
+
+# ---- refinement: binary search between prev_rps and breakpoint_rps ----
+if [ -n "${breakpoint_rps:-}" ] && [ -n "${prev_rps:-}" ] && [ -z "${RPS_LIST_OVERRIDE:-}" ]; then
+  lo="$prev_rps"
+  hi="$breakpoint_rps"
+  for _ in 1 2 3; do
+    mid=$(( (lo + hi) / 2 ))
+    [ "$mid" -le "$lo" ] && break
+    if ! p99="$(drive_step "$mid")"; then continue; fi
+    if [ -z "$p99" ] || [ "$p99" = "null" ]; then continue; fi
+    if awk -v p="$p99" -v lim="$P99_LIMIT_MS" 'BEGIN { exit !(p > lim) }'; then
+      breakpoint_rps="$mid"
+      breakpoint_p99="$p99"
+      hi="$mid"
+    else
+      lo="$mid"
+      prev_rps="$mid"
+      prev_p99="$p99"
+    fi
+  done
+fi
+
+{
+  printf 'route=%s\n' "$PLAYGROUND_ROUTE"
+  printf 'cpus=%s memory=%s\n' "$DOCKER_CPUS" "$DOCKER_MEMORY"
+  printf 'p99_limit_ms=%s\n' "$P99_LIMIT_MS"
+  if [ -n "${breakpoint_rps:-}" ]; then
+    printf 'breakpoint_rps=%s breakpoint_p99_ms=%s\n' "$breakpoint_rps" "$breakpoint_p99"
+  else
+    printf 'breakpoint_rps=NOT_REACHED (top RPS in sweep stayed under p99 limit)\n'
+  fi
+  if [ -n "${prev_rps:-}" ]; then
+    printf 'last_clean_rps=%s last_clean_p99_ms=%s\n' "$prev_rps" "$prev_p99"
+  fi
+  printf 'results_dir=%s\n' "$RESULTS_DIR"
+  printf '\n--- sweep ---\n'
+  cat "$RESULTS_DIR/sweep.tsv"
+  printf '\n--- env ---\n'
+  cat "$RESULTS_DIR/env.txt"
+} | tee "$SUMMARY_FILE"
+
+log "done. raw artifacts under $RESULTS_DIR"


### PR DESCRIPTION
## Summary

Local-only SSR capacity bench at a fixed `--cpus=0.5 --memory=1g`
container ceiling. Drives `playgrounds/ssr-stress` `/longlist` via k6
constant-arrival-rate, sweeps target rps until p99 first exceeds 100
ms, then refines with binary search.

## Headline number (2026-05-02, Apple M1 Pro)

| Metric | Value |
|---|---|
| Last clean rps (p99 < 100 ms) | **2915 rps** (p50 = 0.56 ms, p95 = 2.41 ms, p99 = 18.25 ms) |
| Breakpoint rps (p99 ≥ 100 ms) | 2917 rps (p99 = 241.6 ms) |
| Peak container RSS | 67.7 MiB / 1024 MiB granted |
| Failed requests over the entire sweep | 0 |

The cliff is razor-sharp (2 rps wide) and CPU-bound — RSS peaks at ~7%
of the granted memory. See [`bench/ssr-constrained/RESULTS.md`](https://github.com/binsarjr/sveltego/blob/phase/bench-constrained-476/bench/ssr-constrained/RESULTS.md)
for full ramp data, methodology, and host/Docker provenance.

## Surface

- `bench/ssr-constrained/Dockerfile` — distroless static-debian12
  runtime, no shell/libc. Pre-built linux/arm64 binary baked in.
- `bench/ssr-constrained/load.js` — k6 `constant-arrival-rate` config
  with `summaryTrendStats` set so p50/p99 land in `summary.json`.
- `bench/ssr-constrained/run.sh` — host-side build (`sveltego compile`
  + cross-compile linux/arm64) → docker build → docker run with
  cgroup limits → coarse RPS sweep → binary-search refinement → write
  `last-run.txt` plus per-step `summary.json` + `docker-stats.txt`.
- `bench/ssr-constrained/RESULTS.md` — measured numbers, methodology,
  caveats (Apple silicon Docker overhead disclaimer).
- `bench/ssr-constrained/.gitignore` — keep `build/`, `results/`,
  `last-run.txt` out of git.
- `bench/README.md` — index entry pointing at the new bench.

## Test plan

- [x] `bash -n run.sh` syntax check passes (no shellcheck on host;
  noted in RESULTS.md scope).
- [x] Full sweep ran end-to-end on Apple M1 Pro / Docker Desktop
  29.2.1, populated `results/<utc-iso>/` with per-step k6 summaries
  and `docker-stats.txt`.
- [x] Verified cgroup limits land via `cat /sys/fs/cgroup/cpu.max`
  → `50000 100000` (0.5 vCPU) and `memory.max` → `1073741824` (1 GiB).
- [x] Default RPS list, `RPS_LIST` override, and `PLAYGROUND_ROUTE`
  override all work.
- [x] Trap cleanup removes the container on exit.
- [ ] CI does **not** run this bench — confirmed by not adding any
  workflow file. (Issue body specifies local-only.)

Closes #476.