### PR TITLE
fix(codegen): SSR-transpile chain mates of fallback routes (#478)

### DIFF
--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -191,17 +191,24 @@ func Build(ctx context.Context, opts BuildOptions) (*BuildResult, error) {
 	// `<script module>` so vite.GenerateRouter wires the snapshot capture
 	// + restore hooks (#84). Empty when no route opts in.
 	clientSnapshotRoutes := make(map[string]bool)
-	// Pre-compute which error boundaries will be SSR-transpiled (#412)
-	// so we can skip the legacy Mustache-Go emit for those packages.
-	// Mustache-Go's `data.code` lowering does not align with the SSR
-	// transpile path's `data.code` → `data.Code` rewrite, so emitting
-	// both side-by-side breaks compilation when templates use lowercase
-	// JS-camelCase fields.
-	ssrPagePlans, _ := planSSR(scan, routeOptions)
-	ssrErrorPlans := planSSRErrors(scan, ssrPagePlans)
+	// Pre-compute which error boundaries and layouts will be
+	// SSR-transpiled (#412, #456, #478) so we can skip the legacy
+	// Mustache-Go emit for those packages. Mustache-Go's literal
+	// expression substitution does not align with pure-Svelte sources:
+	// `data.code` lowering differs (literal vs JSON-tag-mapped), and
+	// inline JS handlers like `onclick={toggleDark}` reference
+	// identifiers that exist only in the .svelte source — Mustache-Go
+	// would emit `WriteEscapeAttr(toggleDark)` against a missing Go
+	// symbol. Emitting both side-by-side breaks compilation.
+	ssrErrorPlans := planSSRErrors(scan, routeOptions)
 	ssrErrorPkgs := make(map[string]struct{}, len(ssrErrorPlans))
 	for _, ep := range ssrErrorPlans {
 		ssrErrorPkgs[ep.pkgPath] = struct{}{}
+	}
+	ssrLayoutPlans := planSSRLayouts(scan, routeOptions)
+	ssrLayoutPkgs := make(map[string]struct{}, len(ssrLayoutPlans))
+	for _, lp := range ssrLayoutPlans {
+		ssrLayoutPkgs[lp.pkgPath] = struct{}{}
 	}
 
 	for _, route := range scan.Routes {
@@ -276,12 +283,20 @@ func Build(ctx context.Context, opts BuildOptions) (*BuildResult, error) {
 			if i < len(route.LayoutServerFiles) {
 				serverFile = route.LayoutServerFiles[i]
 			}
-			hasHead, err := emitLayout(opts.ProjectRoot, outDir, modulePath, layoutDir, pkgPath, pkgName, serverFile, opts.Release, opts.EnvLookup, opts.Provenance, start, imageVariants)
-			if err != nil {
-				return nil, err
-			}
-			if hasHead {
-				layoutHeads[pkgPath] = true
+			// Skip Mustache-Go layout.gen.go emit when the layout will
+			// be SSR-transpiled via #456/#478. The SSR Option B path
+			// emits `.gen/layoutsrc/<pkg>/layout_render.gen.go` and a
+			// `<svelte:head>` is folded into the Render adapter via
+			// `payload.HeadHTML()`; the legacy `Layout{}.Head` adapter
+			// is not needed.
+			if _, isSSRLayout := ssrLayoutPkgs[pkgPath]; !isSSRLayout {
+				hasHead, err := emitLayout(opts.ProjectRoot, outDir, modulePath, layoutDir, pkgPath, pkgName, serverFile, opts.Release, opts.EnvLookup, opts.Provenance, start, imageVariants)
+				if err != nil {
+					return nil, err
+				}
+				if hasHead {
+					layoutHeads[pkgPath] = true
+				}
 			}
 			if serverFile != "" {
 				if err := emitLayoutMirrorAndWire(opts.ProjectRoot, outDir, modulePath, pkgPath, pkgName, serverFile); err != nil {

--- a/packages/sveltego/internal/codegen/build_test.go
+++ b/packages/sveltego/internal/codegen/build_test.go
@@ -6,9 +6,12 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/codegen/svelterender"
 )
 
 func writeFile(t *testing.T, path, content string) {
@@ -18,6 +21,26 @@ func writeFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// requireSSRSidecar skips the test when Node or the svelterender
+// sidecar's node_modules are unavailable. CI workflows that run the
+// SSR pipeline install both before the gate; the lint-and-test job
+// installs nothing JS-side, so codegen tests that drive a live
+// _layout.svelte / _page.svelte through the SSR transpile must skip
+// rather than fail. Mirrors svelterender.requireSidecarReady.
+func requireSSRSidecar(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not on PATH; skipping SSR-transpile codegen test")
+	}
+	dir, err := svelterender.SidecarRoot()
+	if err != nil {
+		t.Skipf("sidecar tree not found: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node_modules", "acorn")); err != nil {
+		t.Skipf("sidecar node_modules missing; run `npm install` in %s", dir)
 	}
 }
 
@@ -299,6 +322,7 @@ func TestBuild_EmitsLayoutChain(t *testing.T) {
 // wire wrapper, manifest LayoutLoaders entry — is unchanged.
 func TestBuild_EmitsLayoutServer(t *testing.T) {
 	t.Parallel()
+	requireSSRSidecar(t)
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.22\n")
 	writeFile(t, filepath.Join(root, "src", "routes", "_layout.svelte"),
@@ -781,6 +805,7 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
 // dispatch.
 func TestBuild_LayoutDataNamedType(t *testing.T) {
 	t.Parallel()
+	requireSSRSidecar(t)
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/lyt\n\ngo 1.23\n")
 	writeFile(t, filepath.Join(root, "src", "routes", "_layout.svelte"),

--- a/packages/sveltego/internal/codegen/build_test.go
+++ b/packages/sveltego/internal/codegen/build_test.go
@@ -292,12 +292,17 @@ func TestBuild_EmitsLayoutChain(t *testing.T) {
 // adjacent to _layout.svelte produces a layoutsrc mirror, a sibling
 // wire_layout.gen.go in the gen package, a typed LayoutData alias from
 // the inferred Load() return, and a manifest LayoutLoaders entry.
+//
+// Post-#478: layouts SSR-transpile via Option B, so the legacy
+// `.gen/routes/layout.gen.go` Mustache-Go body is no longer emitted.
+// The data-flow contract — typed LayoutData, server-source mirror,
+// wire wrapper, manifest LayoutLoaders entry — is unchanged.
 func TestBuild_EmitsLayoutServer(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.22\n")
 	writeFile(t, filepath.Join(root, "src", "routes", "_layout.svelte"),
-		`<header>root</header><slot />`+"\n")
+		"<header>root</header>{@render children()}\n")
 	writeFile(t, filepath.Join(root, "src", "routes", "_layout.server.go"),
 		`//go:build sveltego
 
@@ -313,7 +318,7 @@ func Load(ctx *kit.LoadCtx) (LayoutData, error) {
 }
 `)
 	writeFile(t, filepath.Join(root, "src", "routes", "dash", "_layout.svelte"),
-		`<nav>dash</nav><slot />`+"\n")
+		"<nav>dash</nav>{@render children()}\n")
 	writeFile(t, filepath.Join(root, "src", "routes", "dash", "_page.svelte"),
 		`<h1>Dash</h1>`+"\n")
 
@@ -321,27 +326,19 @@ func Load(ctx *kit.LoadCtx) (LayoutData, error) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	rootLayout := filepath.Join(root, ".gen", "routes", "layout.gen.go")
 	mirror := filepath.Join(root, ".gen", "layoutsrc", "routes", "layout_server.go")
 	wire := filepath.Join(root, ".gen", "routes", "wire_layout.gen.go")
 	manifest := filepath.Join(root, ".gen", "manifest.gen.go")
-	for _, p := range []string{rootLayout, mirror, wire, manifest} {
+	for _, p := range []string{mirror, wire, manifest} {
 		if _, err := os.Stat(p); err != nil {
 			t.Errorf("expected %s to exist: %v", p, err)
 		}
 	}
 
-	rootBytes, err := os.ReadFile(rootLayout)
-	if err != nil {
-		t.Fatalf("read root layout: %v", err)
-	}
-	for _, want := range []string{
-		"type LayoutData = struct {",
-		"User string",
-	} {
-		if !bytes.Contains(rootBytes, []byte(want)) {
-			t.Errorf("root layout missing %q:\n%s", want, rootBytes)
-		}
+	// The Mustache-Go layout.gen.go is no longer emitted for
+	// SSR-transpiled layouts (#478). Verify it stays out of .gen.
+	if _, err := os.Stat(filepath.Join(root, ".gen", "routes", "layout.gen.go")); err == nil {
+		t.Errorf("legacy layout.gen.go must not be emitted alongside SSR-transpiled layouts")
 	}
 
 	mirrorBytes, err := os.ReadFile(mirror)
@@ -380,7 +377,7 @@ func Load(ctx *kit.LoadCtx) (LayoutData, error) {
 		}
 	}
 
-	for _, p := range []string{rootLayout, mirror, wire, manifest} {
+	for _, p := range []string{mirror, wire, manifest} {
 		assertParsesAsGo(t, p)
 	}
 }
@@ -777,13 +774,18 @@ func Load(ctx *kit.LoadCtx) (PageData, error) {
 
 // TestBuild_LayoutDataNamedType mirrors TestBuild_PageDataNamedType for
 // layouts. A layout.server.go declaring `type LayoutData struct{...}`
-// produces `type LayoutData = usersrc.LayoutData` in layout.gen.go.
+// flows the named type through the SSR layout wire so the manifest
+// bridge can type-assert against `usersrc.LayoutData`. Post-#478 the
+// type lives in the layoutsrc mirror (which is the user's source file
+// with the build tag stripped) and is referenced from the wire's
+// dispatch.
 func TestBuild_LayoutDataNamedType(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/lyt\n\ngo 1.23\n")
 	writeFile(t, filepath.Join(root, "src", "routes", "_layout.svelte"),
-		"<header>{data.Title}</header><slot />\n")
+		"<script lang=\"ts\">let { data, children } = $props();</script>\n"+
+			"<header>{data.title}</header>{@render children()}\n")
 	writeFile(t, filepath.Join(root, "src", "routes", "_layout.server.go"),
 		`//go:build sveltego
 
@@ -795,7 +797,7 @@ import (
 )
 
 type LayoutData struct {
-	Title string
+	Title string `+"`json:\"title\"`"+`
 }
 
 func Load(ctx *kit.LoadCtx) (LayoutData, error) {
@@ -810,22 +812,33 @@ func Load(ctx *kit.LoadCtx) (LayoutData, error) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	layoutGen := filepath.Join(root, ".gen", "routes", "layout.gen.go")
-	body, err := os.ReadFile(layoutGen)
+	mirror := filepath.Join(root, ".gen", "layoutsrc", "routes", "layout_server.go")
+	mirrorBytes, err := os.ReadFile(mirror)
 	if err != nil {
-		t.Fatalf("read layout.gen.go: %v", err)
+		t.Fatalf("read layout mirror: %v", err)
 	}
-	got := string(body)
-	const wantAlias = "type LayoutData = usersrc.LayoutData"
-	if !strings.Contains(got, wantAlias) {
-		t.Errorf("expected %q in layout.gen.go, got:\n%s", wantAlias, got)
+	mirrorSrc := string(mirrorBytes)
+	if !strings.Contains(mirrorSrc, "type LayoutData struct {") {
+		t.Errorf("mirror missing named LayoutData declaration; got:\n%s", mirrorSrc)
 	}
-	if strings.Contains(got, "type LayoutData = struct{}") {
-		t.Errorf("empty alias leaked into named-type branch:\n%s", got)
+	if !strings.Contains(mirrorSrc, "Title string") {
+		t.Errorf("mirror missing Title field; got:\n%s", mirrorSrc)
 	}
-	const wantImport = `usersrc "example.com/lyt/.gen/layoutsrc/routes"`
-	if !strings.Contains(got, wantImport) {
-		t.Errorf("expected import %q, got:\n%s", wantImport, got)
+
+	wire := filepath.Join(root, ".gen", "routes", "wire_layout_render.gen.go")
+	wireBytes, err := os.ReadFile(wire)
+	if err != nil {
+		t.Fatalf("read SSR layout wire: %v", err)
 	}
-	assertParsesAsGo(t, layoutGen)
+	wireSrc := string(wireBytes)
+	const wantWireType = "usersrc.LayoutData"
+	if !strings.Contains(wireSrc, wantWireType) {
+		t.Errorf("expected %q in wire; got:\n%s", wantWireType, wireSrc)
+	}
+	const wantWireImport = `usersrc "example.com/lyt/.gen/layoutsrc/routes"`
+	if !strings.Contains(wireSrc, wantWireImport) {
+		t.Errorf("expected import %q in wire; got:\n%s", wantWireImport, wireSrc)
+	}
+	assertParsesAsGo(t, mirror)
+	assertParsesAsGo(t, wire)
 }

--- a/packages/sveltego/internal/codegen/env_subst_test.go
+++ b/packages/sveltego/internal/codegen/env_subst_test.go
@@ -250,36 +250,20 @@ func TestBuildDefaultEnvLookupUsesOsEnv(t *testing.T) {
 	}
 }
 
-// TestBuildSubstitutesPublicEnvInLayout verifies that env.StaticPublic
-// calls in _layout.svelte are also inlined at build time.
+// TestBuildSubstitutesPublicEnvInLayout verified that
+// env.StaticPublic calls in _layout.svelte mustaches were inlined at
+// build time when the legacy Mustache-Go layout pipeline owned the
+// .svelte body. Post-ADR-0008 (#410, "pivot to pure-Svelte
+// templates") Go expressions in mustaches are out, and post-#478
+// every pure-Svelte layout ssr-transpiles via Option B — which has
+// no equivalent build-time env-substitution pass. The Mustache-Go
+// path that drove `substituteStaticEnv` for layouts is reached by
+// nothing in production.
+//
+// The substitution mechanism itself remains unit-tested in this file
+// (TestSubstituteStaticEnv*); only the integration over a layout
+// .svelte source has nowhere to land. Re-enable once a "Go
+// expressions in pure-Svelte source" RFC introduces a new substrate.
 func TestBuildSubstitutesPublicEnvInLayout(t *testing.T) {
-	root := envSubstRoot(t)
-
-	writeFile(t, filepath.Join(root, "src", "routes", "_layout.svelte"),
-		`<div class={env.StaticPublic("PUBLIC_THEME")}><slot/></div>`)
-	writePlainPage(t, root, `<p>hello</p>`)
-
-	lookup := func(key string) (string, bool) {
-		if key == "PUBLIC_THEME" {
-			return "dark", true
-		}
-		return "", false
-	}
-
-	_, err := Build(context.Background(), BuildOptions{ProjectRoot: root, EnvLookup: lookup})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-
-	b, err := os.ReadFile(filepath.Join(root, ".gen", "routes", "layout.gen.go"))
-	if err != nil {
-		t.Fatalf("read layout.gen.go: %v", err)
-	}
-	src := string(b)
-	if !strings.Contains(src, `"dark"`) {
-		t.Errorf("layout.gen.go missing literal; got:\n%s", src)
-	}
-	if strings.Contains(src, "env.StaticPublic") {
-		t.Errorf("env.StaticPublic not removed from layout; got:\n%s", src)
-	}
+	t.Skip("Mustache-Go layout pipeline retired by #478; env.StaticPublic in pure-Svelte mustaches is out per ADR 0008. Unit coverage stays via TestSubstituteStaticEnv*.")
 }

--- a/packages/sveltego/internal/codegen/ssr.go
+++ b/packages/sveltego/internal/codegen/ssr.go
@@ -119,8 +119,8 @@ type errorPlan struct {
 //     or annotate the route to opt into the sidecar fallback.
 func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string, logger *slog.Logger, scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions) (SSRPlanResult, error) {
 	transpilePlan, fallback := planSSR(scan, routeOptions)
-	layoutPlans := planSSRLayouts(scan, transpilePlan)
-	errorPlans := planSSRErrors(scan, transpilePlan)
+	layoutPlans := planSSRLayouts(scan, routeOptions)
+	errorPlans := planSSRErrors(scan, routeOptions)
 	result := SSRPlanResult{Fallback: fallback}
 	if len(transpilePlan) == 0 && len(fallback) == 0 && len(layoutPlans) == 0 && len(errorPlans) == 0 {
 		return result, nil
@@ -551,26 +551,29 @@ func planSSR(scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions
 }
 
 // planSSRLayouts collects every unique layout package referenced by a
-// route that qualifies for the Phase 6 SSR transpile (#456). Layouts
-// shared between sibling routes are deduplicated by package path; only
-// layouts reachable from a Svelte-SSR-eligible page route are included.
+// pure-Svelte SSR-eligible route (#456, #478). Layouts shared between
+// sibling routes are deduplicated by package path.
+//
+// Eligibility matches planSSR's predicate MINUS the SSRFallback gate:
+// the page may opt out of build-time transpile via
+// `<!-- sveltego:ssr-fallback -->`, but its layout chain still renders
+// Go-side in both Phase 6 (transpile) and Phase 8 (sidecar fallback)
+// paths. Decoupling layout eligibility from page transpile lets blog
+// — where every page is fallback-annotated — still SSR-transpile its
+// root layout instead of falling back to Mustache-Go (#478).
 //
 // A layout with `_layout.server.go` drives shape inference via typegen
 // (KindLayout); a layout without a server file synthesises an empty
 // shape so the Lowerer leaves bare expressions alone but still hard-
 // errors on `data.X` access (matching the page contract).
-func planSSRLayouts(scan *routescan.ScanResult, pagePlans []ssrPlan) []layoutPlan {
+func planSSRLayouts(scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions) []layoutPlan {
 	if scan == nil {
 		return nil
-	}
-	pageRoutes := make(map[string]struct{}, len(pagePlans))
-	for _, p := range pagePlans {
-		pageRoutes[p.route.Pattern] = struct{}{}
 	}
 	seen := make(map[string]struct{})
 	plans := make([]layoutPlan, 0)
 	for _, r := range scan.Routes {
-		if _, ok := pageRoutes[r.Pattern]; !ok {
+		if !routeEligibleForSSRChain(r, routeOptions) {
 			continue
 		}
 		for i, layoutDir := range r.LayoutChain {
@@ -614,31 +617,31 @@ func planSSRLayouts(scan *routescan.ScanResult, pagePlans []ssrPlan) []layoutPla
 	return plans
 }
 
-// planSSRErrors collects every unique error-boundary package referenced
-// by a route that qualifies for the Phase 6 SSR transpile. Boundaries
-// shared between sibling routes are deduplicated by package path; only
-// boundaries reachable from a Svelte-SSR-eligible page route are
-// included so error rendering and page rendering travel the same
-// transpile pipeline (#412).
+// planSSRErrors collects every unique error-boundary package
+// referenced by a pure-Svelte SSR-eligible route (#412, #478).
+// Boundaries shared between sibling routes are deduplicated by package
+// path.
+//
+// Eligibility matches planSSR's predicate MINUS the SSRFallback gate
+// (see planSSRLayouts for the rationale). Error boundaries always
+// render Go-side regardless of how the page itself reached the runtime,
+// so a fallback-annotated page must still surface its boundary through
+// the SSR transpile path.
 //
 // All error templates receive the same synthetic ErrorData shape — an
 // alias to kit.SafeError — so the Lowerer rewrites `data.code` →
 // `data.Code`, `data.message` → `data.Message`, `data.id` → `data.ID`.
 // The shape's field names mirror typegen's lowerFirst-of-Go-field
 // convention so user templates stay JS-camelCase as expected.
-func planSSRErrors(scan *routescan.ScanResult, pagePlans []ssrPlan) []errorPlan {
+func planSSRErrors(scan *routescan.ScanResult, routeOptions map[string]kit.PageOptions) []errorPlan {
 	if scan == nil {
 		return nil
-	}
-	pageRoutes := make(map[string]struct{}, len(pagePlans))
-	for _, p := range pagePlans {
-		pageRoutes[p.route.Pattern] = struct{}{}
 	}
 	shape := errorDataShape()
 	seen := make(map[string]struct{})
 	plans := make([]errorPlan, 0)
 	for _, r := range scan.Routes {
-		if _, ok := pageRoutes[r.Pattern]; !ok {
+		if !routeEligibleForSSRChain(r, routeOptions) {
 			continue
 		}
 		if r.ErrorBoundaryPackagePath == "" || r.ErrorBoundaryDir == "" {
@@ -656,6 +659,29 @@ func planSSRErrors(scan *routescan.ScanResult, pagePlans []ssrPlan) []errorPlan 
 		})
 	}
 	return plans
+}
+
+// routeEligibleForSSRChain reports whether a route's layout chain and
+// error boundary should travel the SSR Option B transpile path. The
+// predicate mirrors planSSR's Templates+SSR/Prerender check but
+// deliberately ignores `r.SSRFallback`: fallback-annotated pages still
+// render their layouts and errors Go-side at request time, so the
+// Phase 6 transpile path must cover their chain-mates too (#478).
+//
+// Returns false for non-page routes (REST endpoints), Mustache-template
+// routes, and routes that opt out of SSR entirely.
+func routeEligibleForSSRChain(r routescan.ScannedRoute, routeOptions map[string]kit.PageOptions) bool {
+	if !r.HasPage {
+		return false
+	}
+	opts, ok := routeOptions[r.Pattern]
+	if !ok {
+		return false
+	}
+	if opts.Templates != kit.TemplatesSvelte {
+		return false
+	}
+	return opts.SSR || opts.Prerender || opts.PrerenderAuto
 }
 
 // errorDataShape returns the synthetic typegen Shape used by the

--- a/packages/sveltego/internal/codegen/ssr_test.go
+++ b/packages/sveltego/internal/codegen/ssr_test.go
@@ -127,8 +127,7 @@ func Load(ctx any) (PageData, error) { return PageData{}, nil }
 		"/foo":     mkSvelteOpts(),
 		"/foo/bar": mkSvelteOpts(),
 	}
-	pagePlans, _ := planSSR(scan, routeOptions)
-	layoutPlans := planSSRLayouts(scan, pagePlans)
+	layoutPlans := planSSRLayouts(scan, routeOptions)
 
 	// /foo and /foo/bar share two layouts (root + /foo); planSSRLayouts
 	// dedupes by package path.
@@ -199,8 +198,7 @@ func Load(ctx any) (PageData, error) { return PageData{}, nil }
 		"/foo":     mkSvelteOpts(),
 		"/foo/bar": mkSvelteOpts(),
 	}
-	pagePlans, _ := planSSR(scan, routeOptions)
-	errorPlans := planSSRErrors(scan, pagePlans)
+	errorPlans := planSSRErrors(scan, routeOptions)
 
 	// Both /foo and /foo/bar resolve to the root _error.svelte boundary;
 	// planSSRErrors dedupes by package path.
@@ -348,11 +346,13 @@ func TestPlanSSR_NonPrerenderNoServerFileSkipped(t *testing.T) {
 	}
 }
 
-// TestPlanSSRErrors_SkipsNonSvelteRoutes verifies that the error
-// planner walks only error boundaries reachable from a Svelte-SSR-
-// eligible page; routes that are pure-Svelte but lack a server-file
-// (so they fall out of planSSR) carry no error transpile.
-func TestPlanSSRErrors_SkipsNonSvelteRoutes(t *testing.T) {
+// TestPlanSSRErrors_CoversRoutesWithoutServerFile verifies #478: the
+// error planner enumerates from the Templates+SSR predicate, NOT from
+// page-transpile eligibility. A pure-Svelte SSR route without a
+// `_page.server.go` still needs its error boundary SSR-transpiled —
+// error templates render against the synthetic `kit.SafeError` shape,
+// so they don't depend on user-authored PageData.
+func TestPlanSSRErrors_CoversRoutesWithoutServerFile(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	mustWrite := func(path, body string) {
@@ -367,8 +367,6 @@ func TestPlanSSRErrors_SkipsNonSvelteRoutes(t *testing.T) {
 	}
 	mustWrite("src/routes/_error.svelte", "<h1>root error</h1>")
 	mustWrite("src/routes/_page.svelte", "<h1>home</h1>")
-	// no _page.server.go; planSSR drops the route, so planSSRErrors
-	// should also drop the boundary.
 
 	scan, err := routescan.Scan(routescan.ScanInput{RoutesDir: filepath.Join(root, "src", "routes")})
 	if err != nil {
@@ -379,8 +377,140 @@ func TestPlanSSRErrors_SkipsNonSvelteRoutes(t *testing.T) {
 	if len(pagePlans) != 0 {
 		t.Fatalf("pagePlans count = %d, want 0 (no server file → planSSR drops)", len(pagePlans))
 	}
-	errorPlans := planSSRErrors(scan, pagePlans)
+	errorPlans := planSSRErrors(scan, routeOptions)
+	if len(errorPlans) != 1 {
+		t.Fatalf("errorPlans count = %d, want 1 (Svelte+SSR route covers boundary regardless of server file)", len(errorPlans))
+	}
+}
+
+// TestPlanSSRErrors_SkipsNonSvelteRoute verifies the predicate filters
+// out Mustache-template routes: planSSRErrors should only emit
+// boundaries reachable from a pure-Svelte SSR-eligible route.
+func TestPlanSSRErrors_SkipsNonSvelteRoute(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("src/routes/_error.svelte", "<h1>root error</h1>")
+	mustWrite("src/routes/_page.svelte", "<h1>home</h1>")
+
+	scan, err := routescan.Scan(routescan.ScanInput{RoutesDir: filepath.Join(root, "src", "routes")})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	nonSvelteOpts := kit.DefaultPageOptions()
+	nonSvelteOpts.Templates = "go-mustache"
+	routeOptions := map[string]kit.PageOptions{"/": nonSvelteOpts}
+
+	errorPlans := planSSRErrors(scan, routeOptions)
 	if len(errorPlans) != 0 {
-		t.Fatalf("errorPlans count = %d, want 0 (no eligible page route)", len(errorPlans))
+		t.Fatalf("errorPlans count = %d, want 0 (Mustache-template route should not enter SSR plan)", len(errorPlans))
+	}
+}
+
+// TestPlanSSRLayouts_CoversFallbackAnnotatedRoute verifies the #478
+// fix: a route whose `_page.svelte` carries the
+// `<!-- sveltego:ssr-fallback -->` annotation still pulls its layout
+// chain through the SSR transpile path. Fallback opts the page body
+// out of build-time transpile (Phase 8 sidecar at request time), but
+// chain-mate layouts and errors render Go-side regardless. Without
+// this fix, blog — where every page is fallback-annotated — would
+// keep its root layout on the legacy Mustache-Go path.
+func TestPlanSSRLayouts_CoversFallbackAnnotatedRoute(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("src/routes/_layout.svelte", "{@render children()}")
+	mustWrite("src/routes/_page.svelte", `<!-- sveltego:ssr-fallback -->
+<h1>home</h1>`)
+	mustWrite("src/routes/_page.server.go", `package routes
+
+type PageData struct{ Name string `+"`json:\"name\"`"+` }
+
+func Load(ctx any) (PageData, error) { return PageData{}, nil }
+`)
+
+	scan, err := routescan.Scan(routescan.ScanInput{RoutesDir: filepath.Join(root, "src", "routes")})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	routeOptions := map[string]kit.PageOptions{"/": mkSvelteOpts()}
+
+	pagePlans, fallback := planSSR(scan, routeOptions)
+	if len(pagePlans) != 0 {
+		t.Fatalf("pagePlans count = %d, want 0 (annotated route → fallback)", len(pagePlans))
+	}
+	if len(fallback) != 1 {
+		t.Fatalf("fallback count = %d, want 1", len(fallback))
+	}
+
+	layoutPlans := planSSRLayouts(scan, routeOptions)
+	if len(layoutPlans) != 1 {
+		t.Fatalf("layoutPlans count = %d, want 1 (fallback annotation must NOT cascade to layouts)", len(layoutPlans))
+	}
+}
+
+// TestPlanSSRErrors_CoversFallbackAnnotatedRoute is the boundary mirror
+// of TestPlanSSRLayouts_CoversFallbackAnnotatedRoute. A fallback-
+// annotated page must still surface its error boundary through the SSR
+// transpile path because the boundary renders Go-side at request time
+// in both Phase 6 (transpile) and Phase 8 (sidecar) execution paths.
+func TestPlanSSRErrors_CoversFallbackAnnotatedRoute(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("src/routes/_error.svelte", "<h1>error</h1>")
+	mustWrite("src/routes/_page.svelte", `<!-- sveltego:ssr-fallback -->
+<h1>home</h1>`)
+	mustWrite("src/routes/_page.server.go", `package routes
+
+type PageData struct{ Name string `+"`json:\"name\"`"+` }
+
+func Load(ctx any) (PageData, error) { return PageData{}, nil }
+`)
+
+	scan, err := routescan.Scan(routescan.ScanInput{RoutesDir: filepath.Join(root, "src", "routes")})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	routeOptions := map[string]kit.PageOptions{"/": mkSvelteOpts()}
+
+	pagePlans, fallback := planSSR(scan, routeOptions)
+	if len(pagePlans) != 0 {
+		t.Fatalf("pagePlans count = %d, want 0 (annotated → fallback)", len(pagePlans))
+	}
+	if len(fallback) != 1 {
+		t.Fatalf("fallback count = %d, want 1", len(fallback))
+	}
+
+	errorPlans := planSSRErrors(scan, routeOptions)
+	if len(errorPlans) != 1 {
+		t.Fatalf("errorPlans count = %d, want 1 (fallback annotation must NOT cascade to errors)", len(errorPlans))
 	}
 }

--- a/packages/sveltego/internal/codegen/svelte_js2go/emitter.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/emitter.go
@@ -723,6 +723,18 @@ func (e *emitter) emitStatement(b *Buf, stmt *Node) error {
 		return e.emitForOf(b, stmt)
 	case "BlockStatement":
 		return e.emitBlock(b, stmt, false)
+	case "FunctionDeclaration":
+		// User-authored `<script>` helpers (DOM event handlers,
+		// computed-value functions, etc.) appear as nested
+		// FunctionDeclarations in Svelte's server output. The
+		// server-mode compiler never *calls* them — DOM event
+		// handlers wire up client-side at hydration; the SSR HTML
+		// just emits the static markup. Treat the declaration as a
+		// no-op so layouts and pages with `<script>` helpers
+		// transpile cleanly. If the declaration is later referenced
+		// from a render-body expression the unknown-shape dispatch
+		// will surface that on the call site, not here.
+		return nil
 	case "ReturnStatement":
 		// ReturnStatement inside helper closures (slot fragments).
 		// At the top level the render function has no return; treat

--- a/packages/sveltego/internal/codegen/svelte_js2go/emitter_test.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/emitter_test.go
@@ -151,6 +151,47 @@ func TestTranspile_Determinism(t *testing.T) {
 	}
 }
 
+// TestTranspile_NestedFunctionDeclaration verifies the #478 fix: a
+// user-authored `<script>` helper that Svelte's server-mode compiler
+// hoists into the render function body must transpile cleanly. The
+// declaration is dropped (server output never calls it — DOM event
+// handlers wire up client-side at hydration), and downstream markup
+// emits as normal. Surfaced when blog playground's _layout.svelte
+// declared `function toggleDark()` for a button onclick handler.
+func TestTranspile_NestedFunctionDeclaration(t *testing.T) {
+	t.Parallel()
+	fnDecl := &Node{
+		Type:   "FunctionDeclaration",
+		ID:     ident("toggleDark"),
+		Params: []*Node{},
+		FuncBody: buildBlock(
+			callStmt(
+				memExpr(memExpr(ident("document"), ident("documentElement")), ident("classList")),
+				strLit("dark"),
+			),
+		),
+	}
+	body := buildBlock(
+		propsDestructure("children"),
+		fnDecl,
+		pushString("<button>toggle</button>"),
+	)
+	got, err := TranspileNode(buildProgram(body), "/test", Options{PackageName: "gen"})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	if _, ferr := format.Source(got); ferr != nil {
+		t.Fatalf("not parseable Go: %v\n%s", ferr, got)
+	}
+	src := string(got)
+	if strings.Contains(src, "toggleDark") {
+		t.Fatalf("nested FunctionDeclaration should not be emitted (would call into JS-only DOM APIs); got:\n%s", src)
+	}
+	if !strings.Contains(src, "<button>toggle</button>") {
+		t.Fatalf("markup downstream of FunctionDeclaration must still emit:\n%s", src)
+	}
+}
+
 func TestTranspile_UnknownShape(t *testing.T) {
 	t.Parallel()
 	// LabeledStatement at top level — outside the v1 closed set.

--- a/playgrounds/blog/src/routes/_layout.svelte
+++ b/playgrounds/blog/src/routes/_layout.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   let { children } = $props();
+
+  function toggleDark() {
+    document.documentElement.classList.toggle('dark');
+  }
 </script>
 
 <!--
@@ -17,7 +21,7 @@
       id="dark-toggle"
       type="button"
       class="rounded-md px-3 py-1.5 text-sm font-medium bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-      onclick="document.documentElement.classList.toggle('dark')"
+      onclick={toggleDark}
     >
       toggle dark
     </button>

--- a/tasks/spikes/2026-05-02-layout-error-gaps.md
+++ b/tasks/spikes/2026-05-02-layout-error-gaps.md
@@ -1,0 +1,130 @@
+# 2026-05-02 — layout/error SSR-transpile gap state (#478)
+
+Re-verification of the gap matrix from #478 against `main` at
+`54a3da4` (PR #482 `$app/state` rune lowering merged on top of PR #477
+LayoutChain retire).
+
+## Method
+
+For each playground:
+
+```sh
+cd playgrounds/<name> && rm -rf .gen build && go run \
+    github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego compile
+```
+
+Then:
+
+- list `.gen/layoutsrc/**` and `.gen/errorsrc/**` — populated means the
+  Option B SSR transpile fired
+- grep `.gen/manifest.gen.go` for `Layout{}.Render` / `ErrorPage{}.Render`
+  — non-zero hits mean the manifest is still calling Mustache-Go output
+- list `.gen/routes/**/layout.gen.go` and `.gen/routes/**/error.gen.go`
+  — present means Mustache-Go is still emitting (potentially dead
+  artifacts even when SSR adapter wins)
+
+## State (post-PR #482)
+
+| Playground | layoutsrc | errorsrc | Mustache refs in manifest | Stale Mustache `.gen` files | Verdict |
+|---|---|---|---|---|---|
+| basic       | populated         | populated | none                       | `routes/layout.gen.go`         | **clean** — chain pulled in via non-annotated `/post/[id]` and `/appstate/[id]` |
+| blog        | EMPTY             | EMPTY     | YES (`Layout{}.Render` x1) | `routes/layout.gen.go`         | **broken** — both routes (`/`, `/[slug]`) ssr-fallback annotated, gap-1 fires |
+| dashboard   | populated         | EMPTY (no `_error.svelte`) | none           | `routes/layout.gen.go`         | **clean** — `/` and `/login` non-annotated cover root layout |
+| ssr-stress  | populated (4 layouts) | populated (1 error) | none                  | 4× stale `layout.gen.go`       | **clean** — all routes non-annotated |
+
+## Findings
+
+### Gap-1 cascade is real, but only fires on blog
+
+Per ssr.go:562/629, `planSSRLayouts(scan, transpilePlan)` and
+`planSSRErrors(scan, transpilePlan)` enumerate from the page-transpile
+plan. A page that is `<!-- sveltego:ssr-fallback -->` annotated routes
+into `fallback`, NOT `transpilePlan`. Their layouts/errors are skipped.
+
+For blog this means BOTH routes are annotated, so the root layout never
+enters the layout plan, the manifest emits the Mustache-Go
+`Layout{}.Render` adapter (manifest.go:743 `!li.hasSSR` branch), and
+`.gen/layoutsrc/` is empty.
+
+For basic the cascade is masked: `/` and `/version-poll` are both
+annotated, but `/post/[id]` and `/appstate/[id]` aren't, so the chain-
+mate route pulls the root layout into `transpilePlan` indirectly.
+
+### Gap-2 (Vite stage cascade) is closed by PR #482
+
+Issue #478 mentioned `$app/state` aborting Vite. PR #482 lowered
+`$app/state` runes through svelte_js2go, so basic now compiles end to
+end without Vite errors. No further action needed.
+
+### Stale Mustache `.gen/routes/<route>/layout.gen.go` artifacts
+
+Even when SSR transpile wins (and the manifest does NOT call
+`Layout{}.Render`), `emitLayout()` in build.go:728 still writes the
+file. Compare with `emitErrorPage()` at build.go:217, which is gated on
+`ssrErrorPkgs`. The gate exists for errors (because lowercase
+`data.code` access would compile-collide), not for layouts.
+
+These stale layout artifacts are dead — the manifest does not import
+them — but they remain on disk. Cleanup is a separate task: deferred
+until the broader Mustache-Go atomic delete (#468 PR2) lands. Including
+it in this PR would conflict with #468 PR2's surface.
+
+## Fix shape
+
+**Decouple layout/error eligibility from page-fallback annotation.**
+
+`planSSRLayouts` / `planSSRErrors` enumerate from a separate eligibility
+predicate, not `transpilePlan`. A route's layouts and error boundaries
+should SSR-transpile when the route is a pure-Svelte SSR-template route
+(Templates=svelte, SSR=true OR Prerender), **regardless of whether the
+page itself routes via the Phase 8 sidecar fallback**. Fallback opts
+the page body out of build-time transpile; chain-mate layouts and
+errors still render Go-side in both Phase 8 and Phase 6 paths.
+
+To implement this, both planners need access to `routeOptions`:
+
+```go
+func planSSRLayouts(scan *routescan.ScanResult,
+    routeOptions map[string]kit.PageOptions) []layoutPlan { ... }
+
+func planSSRErrors(scan *routescan.ScanResult,
+    routeOptions map[string]kit.PageOptions) []errorPlan { ... }
+```
+
+The eligibility predicate inside both functions:
+
+```go
+opts, ok := routeOptions[r.Pattern]
+if !ok || opts.Templates != kit.TemplatesSvelte {
+    continue
+}
+if !(opts.SSR || opts.Prerender || opts.PrerenderAuto) {
+    continue
+}
+// fall through regardless of r.SSRFallback
+```
+
+Existing `pageRoutes` membership filter goes away. Dedup by
+`pkgPath` (layouts) / `ErrorBoundaryPackagePath` (errors) stays.
+
+## Out of scope
+
+- Stale `.gen/routes/<route>/layout.gen.go` cleanup — deferred to #468
+  PR2's atomic Mustache-Go delete.
+- Children-callback ABI for snippets (#443) — current playgrounds use
+  trivial `{@render children()}` which lowers fine without #443.
+- Lowerer per-feature gaps — none surfaced in the four playgrounds.
+  blog's root layout is `let { children } = $props(); {@render children()}`
+  — already passes when chained in.
+
+## Acceptance
+
+Post-fix, blog rebuild produces:
+
+- `.gen/layoutsrc/routes/layout_render.gen.go` with the lowered
+  `Render` body
+- `.gen/manifest.gen.go` with zero `page_routes.Layout{}.Render`
+  references
+- `render__layout__page_routes` adapter calling
+  `page_routes.RenderLayoutSSR(...)` (Option B bridge form)
+- All other 3 playgrounds remain clean


### PR DESCRIPTION
## Summary

Closes #478. Unblocks #468 PR2 (Mustache-Go atomic delete).

Decouples layout/error SSR-transpile eligibility from page-fallback annotation. After this PR, every layout and error in the 4 playgrounds (basic, blog, dashboard, ssr-stress) travels through Option B's SSR transpile, with zero remaining `Layout{}.Render` / `ErrorPage{}.Render` Mustache-Go references in any generated manifest.

## What changed

**Core fix (#478 gap-1):**
- `planSSRLayouts` / `planSSRErrors` (`internal/codegen/ssr.go`) now enumerate from the Templates+SSR/Prerender predicate, **ignoring `r.SSRFallback`**. Fallback opts the page body out of build-time transpile, but its chain-mate layouts and error boundaries still render Go-side at request time — they belong on the SSR transpile path. New helper `routeEligibleForSSRChain` centralises the predicate.
- `build.go:201` updated to pass `routeOptions` into `planSSRErrors` (no more `pagePlans` plumbing).

**Lowerer gap closed (surfaced after the decoupling):**
- `emitStatement` in `svelte_js2go/emitter.go` now drops nested `FunctionDeclaration` as a no-op. Svelte's server-mode compiler hoists user `<script>` helpers (DOM event handlers, computed-value functions) into the render-fn body but never calls them — server HTML emits static markup; handlers wire up client-side at hydration. Test: `TestTranspile_NestedFunctionDeclaration`.

**Mustache-Go layout emit suppression:**
- `build.go` now skips `emitLayout` for SSR-transpiled layouts (mirrors the existing `emitErrorPage` skip at the same site for SSR errors). Required because the dead artifact references JS-only identifiers (e.g. `toggleDark`) that would break `go build`. The `<svelte:head>` body is folded into the SSR Render adapter via `payload.HeadHTML()` so the legacy `Layout{}.Head` adapter is no longer needed.

**Playground source migration:**
- `playgrounds/blog/_layout.svelte`: rewrote inline `onclick="..."` (Svelte 5 rejects legacy DOM-attribute handler strings) to `onclick={toggleDark}` form.

**Test fixture migration (Svelte 4 → 5):**
- `TestBuild_EmitsLayoutServer` and `TestBuild_LayoutDataNamedType` migrated from `<slot />` to `{@render children()}`, added explicit `let { data } = $props()` destructure where the template reads `data.foo`. Assertions retargeted from `.gen/routes/layout.gen.go` (Mustache-Go output, no longer emitted) to the SSR layoutsrc mirror + `wire_layout_render.gen.go` (the Option B artifacts that now carry the same data-flow contract).
- `TestBuildSubstitutesPublicEnvInLayout` skipped with forward-pointer: `env.StaticPublic` in pure-Svelte mustaches is out per ADR 0008 (#410), and the substitution mechanism's unit coverage stays via the `TestSubstituteStaticEnv*` set in the same file.

**New tests:**
- `TestPlanSSRLayouts_CoversFallbackAnnotatedRoute` — pins the gap-1 fix shape.
- `TestPlanSSRErrors_CoversFallbackAnnotatedRoute` — boundary mirror.
- `TestPlanSSRErrors_CoversRoutesWithoutServerFile` — verifies the Templates+SSR predicate now covers errors regardless of page-server-file presence (errors render against `kit.SafeError`, not user `PageData`).
- `TestPlanSSRErrors_SkipsNonSvelteRoute` — predicate filters Mustache-template routes out.

## Re-verification (post-fix)

Per playground, post `sveltego compile` + `go build ./...`:

| Playground | layoutsrc | errorsrc | Mustache refs in manifest | layout.gen.go count | go build |
|---|---|---|---|---|---|
| basic | populated | populated | 0 | 0 | green |
| blog | populated | empty (no `_error.svelte`) | 0 | 0 | green |
| dashboard | populated | empty (no `_error.svelte`) | 0 | 0 | green |
| ssr-stress | populated (4 layouts) | populated (1 error) | 0 | 0 | green |

Spike doc with the full pre-fix gap inventory and reasoning: `tasks/spikes/2026-05-02-layout-error-gaps.md`.

## Local gates

- `gofumpt -l .` — clean
- `goimports -l -local github.com/binsarjr/sveltego .` — clean
- `go vet ./...` — clean
- `go build ./...` — green workspace-wide
- `go test -race ./...` — **1759 passed** (was 1755 pre-fix; net +4 tests from the new pin-tests).
- `golangci-lint run` — same 107 issues across 63 files as pre-fix (depguard / gosec pre-existing).
- All 4 playgrounds: `sveltego compile` + `go build ./...` green.

## Test plan

- [x] Re-verify all 4 playgrounds compile cleanly post-fix
- [x] Verify zero `Layout{}.Render` / `ErrorPage{}.Render` references in any playground manifest
- [x] Verify zero stale `.gen/routes/<route>/layout.gen.go` files in any playground
- [x] Full sveltego test suite green with race detector
- [x] Per-package `go build` green per playground
- [x] Spike doc filed at `tasks/spikes/2026-05-02-layout-error-gaps.md`
- [x] Lint count unchanged (no new violations)
- [ ] CI matrix green
- [ ] Hydration-parity green (basic + ssr-stress)
- [ ] Playground smoke green per playground

## Followups

After merge, #468 PR2 (Mustache-Go atomic delete) becomes safe to ship. The legacy `manifest.go` Mustache-Go branches (`emitLayoutAdapters` `!li.hasSSR`, `emitErrorAdapters` `!ei.hasSSR`, `emitLayoutHeadAdapters`) and the entry points (`Generate`, `GenerateLayout`, `GenerateErrorPage`, `GenerateComponent`) now have zero remaining production callers in the 4 playgrounds.