### PR TITLE
fix(infra,ci): permit comma-separated scopes in commit-lint regex

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,9 +311,10 @@ Conventional Commits per [RFC #99](https://github.com/binsarjr/sveltego/issues/9
 | `rfc` | RFC document or amendment. |
 
 `<scope>` is the package name (`sveltego`, `adapter-cloudflare`, `codegen`,
-`router`, ...) or `repo` for cross-cutting changes. Subject is imperative,
-no trailing period, ≤ 72 characters. Breaking changes go in the footer:
-`BREAKING CHANGE: <description>`.
+`router`, ...) or `repo` for cross-cutting changes. For changes that touch
+multiple packages, comma-separate the scopes: `feat(codegen,server): ...`.
+Subject is imperative, no trailing period, ≤ 72 characters. Breaking
+changes go in the footer: `BREAKING CHANGE: <description>`.
 
 `release-please` (RFC #100) reads these commits to compute per-package
 version bumps and CHANGELOG entries.

--- a/scripts/validate-commits.sh
+++ b/scripts/validate-commits.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 range="${1:-origin/main..HEAD}"
 
-pattern='^(Merge .*|Revert .*|fixup!.*|squash!.*|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|rfc)(\([a-z0-9/_-]+\))?!?: .{1,72})$'
+pattern='^(Merge .*|Revert .*|fixup!.*|squash!.*|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|rfc)(\([a-z0-9/,_-]+\))?!?: .{1,72})$'
 
 # -E (POSIX ERE) is portable across BSD grep (macOS) and GNU grep (Linux CI).
 # The pattern uses no PCRE-only features.


### PR DESCRIPTION
## Summary

- Loosen scope regex in `scripts/validate-commits.sh` from `[a-z0-9/_-]+` to `[a-z0-9/,_-]+`, permitting multi-scope commits like `feat(codegen,server)`.
- Document comma form as canonical multi-package separator in `CONTRIBUTING.md`.
- Dogfood: this PR's own subject uses comma form (`fix(infra,ci): ...`), so a green commit-lint run is itself proof of the fix.

## Why

`scripts/validate-commits.sh` rejected comma scopes, but main history is already full of them — PR #465 `feat(server,adapter-static)`, PR #473 `feat(codegen,server)`, plus `feat(codegen,server)` SSR stack landings. These PRs landed because commit-lint runs against PR commits, not the squash-merge subject. Agents on branches writing the same form they saw on main got rejected and worked around with `/` (PR #479's `feat(client/server)`), splitting main into two scope conventions.

Per `feedback_commit_subject_cap`: 72-char subject cap is the load-bearing rule. Separator pedantry isn't.

## Test plan

- [x] `bash -n scripts/validate-commits.sh` — syntax OK
- [x] `bash scripts/validate-commits.sh "origin/main~30..origin/main"` — all 30 main commits pass under new regex (no false negatives)
- [x] Positive cases pass: `feat(client,server): ...`, `fix(codegen,server): ...`, `feat: bare scope` (no parens still fine)
- [x] Negative cases still rejected: bad separator `(client@server)`, garbage `garbage commit no type`
- [x] PR's own commit subject uses comma form and is 65/72 chars
- [ ] CI commit-lint job green (this is the live test of the fix)

## Surface

- `scripts/validate-commits.sh` — 1 char added to scope class
- `CONTRIBUTING.md` — one sentence noting comma form for multi-package scopes
- `.github/workflows/ci.yml` — calls the script unchanged, no edit needed

Closes #481