### PR TITLE
fix(server): decouple streaming cancel test from net/http (#435)

### DIFF
--- a/packages/sveltego/server/streaming_integration_test.go
+++ b/packages/sveltego/server/streaming_integration_test.go
@@ -416,22 +416,32 @@ func TestStreaming_ClientDisconnect_NoErrorSpam(t *testing.T) {
 	}
 }
 
-// TestStreaming_CancelPropagatesWithinDeadline verifies that when a request
-// context is cancelled, the producer goroutine behind a StreamCtx stream
-// receives the cancellation signal and exits within the deadline. The test
-// uses a second gate to confirm the goroutine saw ctx.Done() rather than
-// blocking forever on its own channel.
+// TestStreaming_CancelPropagatesWithinDeadline verifies that when the
+// context passed to StreamCtx is cancelled, the producer goroutine
+// receives the cancellation signal and exits.
+//
+// The test cancels the producer's parent context directly (via a cancel
+// func captured in Load) instead of going through HTTP client disconnect.
+// Disconnect detection in net/http involves a background reader goroutine,
+// kernel I/O, and scheduler hops; under heavy parallel test load that path
+// can take seconds to fire and is not what this test is asserting on. The
+// property we actually care about — "if you give StreamCtx a cancellable
+// parent and that parent dies, the producer exits" — is exercised
+// directly here.
 func TestStreaming_CancelPropagatesWithinDeadline(t *testing.T) {
 	t.Parallel()
 
 	producerExited := make(chan struct{})
+	cancelCh := make(chan context.CancelFunc, 1)
 
 	routes := []router.Route{{
 		Pattern:  "/",
 		Segments: segmentsFor("/"),
 		Load: func(lctx *kit.LoadCtx) (any, error) {
+			producerCtx, cancel := context.WithCancel(lctx.Request.Context())
+			cancelCh <- cancel
 			return streamingPageData{
-				Posts: kit.StreamCtx(lctx.Request.Context(), func(ctx context.Context) ([]string, error) {
+				Posts: kit.StreamCtx(producerCtx, func(ctx context.Context) ([]string, error) {
 					defer close(producerExited)
 					<-ctx.Done()
 					return nil, ctx.Err()
@@ -444,14 +454,8 @@ func TestStreaming_CancelPropagatesWithinDeadline(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/", nil)
-	if err != nil {
-		t.Fatalf("NewRequest: %v", err)
-	}
-
 	go func() {
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := http.Get(ts.URL + "/")
 		if err != nil {
 			return
 		}
@@ -459,14 +463,18 @@ func TestStreaming_CancelPropagatesWithinDeadline(t *testing.T) {
 		resp.Body.Close()
 	}()
 
-	// Give the shell time to flush before cancelling.
-	time.Sleep(30 * time.Millisecond)
+	var cancel context.CancelFunc
+	select {
+	case cancel = <-cancelCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Load did not run within 2s")
+	}
 	cancel()
 
 	select {
 	case <-producerExited:
-	case <-time.After(time.Second):
-		t.Fatalf("producer goroutine did not exit after context cancel within 1s")
+	case <-time.After(2 * time.Second):
+		t.Fatalf("producer goroutine did not exit after context cancel within 2s")
 	}
 }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -6,6 +6,7 @@ To add a new entry, create a new `YYYY-MM-DD-<topic>.md` file there — **do not
 
 Entries newest-first:
 
+- [2026-05-03: TestStreaming_CancelPropagatesWithinDeadline flake — test net/http transport, not our cancel path (#435)](lessons/2026-05-03-streaming-flake.md)
 - [2026-05-02: formatConditional must route ternary tests through formatTruthy so non-bool refs compile (#466)](lessons/2026-05-02-conditional-truthy-wrap.md)
 - [2026-05-02: Reproduce both halves before assuming bug coupling (PR #470, #460 → #467 split)](lessons/2026-05-02-bug-conflation-decoupling.md)
 - [2026-05-01: SSR Option B execution journey — 9 phases shipped end-to-end (RFC #421 closed via #422)](lessons/2026-05-01-ssr-option-b-execution.md)

--- a/tasks/lessons/2026-05-03-streaming-flake.md
+++ b/tasks/lessons/2026-05-03-streaming-flake.md
@@ -1,0 +1,69 @@
+# 2026-05-03 — TestStreaming_CancelPropagatesWithinDeadline flake (#435)
+
+## Insight
+
+The test asserted that a `kit.StreamCtx` producer goroutine exits within
+1 second after the request context is cancelled. The cancel was
+delivered indirectly: the test cancelled the **client** request context,
+relied on `net/http`'s client transport to close the TCP connection,
+relied on `net/http`'s server-side connection state poller to detect the
+EOF on its background reader goroutine, then waited for the resulting
+server `r.Context()` cancel to propagate through the kit context tree
+to the producer goroutine.
+
+Under heavy parallel test load (CI shared runners; locally reproducible
+with `GOMAXPROCS=1 -parallel=64 -count=200 ./server/`), the slow link in
+that chain is `net/http`'s background reader goroutine. It competes for
+CPU with dozens of other tests' goroutines and may take well over a
+second to be scheduled, observe the EOF, and fire the per-request
+cancel. The producer is blameless — the parent context never ticks
+inside the deadline.
+
+The "1s deadline" was therefore measuring `net/http` connection-teardown
+latency under contention, not the cancel-propagation property the test
+name claims. Hypothesis in #435 ("bump to 2-3s or use synctest") would
+have masked the misdirection without fixing it: any deadline is still
+gated by net/http scheduling under enough load.
+
+## Fix
+
+Decouple the test from the HTTP transport. The Load handler now derives
+a cancellable child of `lctx.Request.Context()`, sends the cancel func
+to the test over a channel, and uses that derived context as the
+`StreamCtx` parent. The test cancels via the captured func — direct
+context cancel, no transport hop. The deadline still applies (2s, with
+margin for goroutine scheduling jitter); a producer that ignores its
+context will still hang and fail the test.
+
+The HTTP request still runs in the background to drive Load through the
+real pipeline, but its disconnect timing is no longer load-bearing.
+
+Verified: `go test -race -count=100` passes 100/100 on the focused test.
+Full server-package run (`-count=300` default GOMAXPROCS) shows zero
+failures of this test.
+
+## Self-rules
+
+1. When asserting a property of code we own (here: parent-context cancel
+   propagating to a child goroutine), construct the test so the
+   stimulus reaches the code-under-test directly. Going through a
+   stdlib transport (`net/http` client → server disconnect detection)
+   adds steps whose latency is bounded only by the host scheduler
+   and OS. Those steps are not what the test claims to measure.
+
+2. Time-bounded "did the goroutine exit?" assertions in `-parallel=N`
+   integration tests need a budget that absorbs scheduler jitter for
+   the goroutines they actually depend on. 1s is fine for a direct
+   context cancel; 1s is **not** fine when the cancel path crosses
+   net/http connection teardown under CI contention.
+
+3. Bumping a flaky test's deadline without naming the slow path in the
+   chain is a band-aid. The slow path may not be in the code-under-test
+   at all — bumping hides that misattribution and the test keeps
+   "asserting" something it doesn't actually exercise.
+
+4. When a flake reproduces only under `-parallel=N` with high N, the
+   bug is rarely in the test's nominal subject. It is usually in some
+   off-path goroutine the test silently depends on (background readers,
+   accept loops, finalizers). Trace the *actual* wakeup chain before
+   adjusting timeouts.


### PR DESCRIPTION
## Summary

- Closes #435 — `TestStreaming_CancelPropagatesWithinDeadline` 1s flake.
- Root cause: the 1s deadline was measuring `net/http` connection-teardown latency under load, not the cancel-propagation property the test name claims. Under heavy parallel load (CI shared runners; locally `GOMAXPROCS=1 -parallel=64`), the server-side `r.Context()` cancel after a client disconnect can take seconds because it depends on `net/http`'s background reader goroutine being scheduled to observe the EOF.
- Fix: cancel the producer's parent ctx directly via a captured cancel func in Load. The HTTP request still drives Load through the real pipeline, but its disconnect timing is no longer load-bearing. A producer that ignores its context still hangs and fails (2s deadline preserves real bug detection).

## Why not bump the deadline

The issue's hypothesis suggested bumping to 2-3s. That would have masked a misattribution: the test name claims to assert "cancel propagates", but the slowest link in the chain (net/http background reader scheduling under contention) is not in our cancel path at all. Any deadline is bounded only by host scheduler and OS scheduling. See autopsy in `tasks/lessons/2026-05-03-streaming-flake.md`.

## Test plan

- [x] `go test -race -count=100 -run '^TestStreaming_CancelPropagatesWithinDeadline$' ./packages/sveltego/server/` — 100/100 pass
- [x] `go test -race ./packages/sveltego/server/` — 245/245 pass
- [x] `go test -race -count=300 ./packages/sveltego/server/` — zero failures of the cancel test
- [x] `gofumpt -l`, `goimports -l`, `go vet ./packages/sveltego/server/` clean
- [x] `go build ./...` workspace-wide green
- [x] Autopsy doc + lessons.md index entry added per CLAUDE.md self-rule

## Files

- `packages/sveltego/server/streaming_integration_test.go` — refactored test
- `tasks/lessons/2026-05-03-streaming-flake.md` — autopsy + self-rules
- `tasks/lessons.md` — index pointer