### PR TITLE
fix(codegen): drop stale layout branch from manifest fmt-import gate

### DIFF
--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -299,10 +299,13 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	if !hasSvelte && (hasLayout || hasError) {
 		hasSvelte = true
 	}
-	// usesFmt reports whether any emitted adapter actually references
-	// fmt.Errorf. Only the legacy Mustache-Go page+layout adapters
-	// (typed-data type-assert error path) use it; the SSR payload-bridge
-	// adapters introduced in Phase 6 (#428) and #456 do not.
+	// usesFmt gates the emitted `"fmt"` import on whether any adapter
+	// actually references fmt.Errorf. The only emit site is the
+	// legacy Mustache-Go page adapter's typed-data type-assert error
+	// path (see emitRenderAdapters); the SSR payload-bridge adapters
+	// introduced in Phase 6 (#428) and #456 do not. Without this gate
+	// trivial single-route Svelte projects fail `go build` with
+	// `"fmt" imported and not used` (#485).
 	usesFmt := false
 	for _, e := range entries {
 		if !e.route.HasPage {
@@ -311,14 +314,6 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 		if !isSvelteRoute(e.route.Pattern, opts.RouteOptions) {
 			usesFmt = true
 			break
-		}
-	}
-	if !usesFmt {
-		for _, li := range layoutImports {
-			if !li.hasSSR {
-				usesFmt = true
-				break
-			}
 		}
 	}
 

--- a/packages/sveltego/internal/codegen/manifest_fmt_import_test.go
+++ b/packages/sveltego/internal/codegen/manifest_fmt_import_test.go
@@ -1,0 +1,254 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/routescan"
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
+)
+
+// TestGenerateManifest_FmtImportGated locks in the gating from #485:
+// the `"fmt"` import line lives behind `usesFmt` and only the legacy
+// Mustache-Go page adapter (typed-data type-assert error path) emits
+// `fmt.Errorf` into the manifest body. The Svelte-mode payload-bridge
+// adapters introduced by Phase 6 (#428) and #456 do not. A trivial
+// single-route Svelte project must compile to a manifest with NO `fmt`
+// import — `goimports` post-pass becomes optional, not a hard
+// requirement.
+func TestGenerateManifest_FmtImportGated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("svelte_single_route_no_fmt", func(t *testing.T) {
+		t.Parallel()
+		scan := &routescan.ScanResult{
+			Routes: []routescan.ScannedRoute{
+				{
+					Pattern:       "/",
+					Dir:           "/tmp/routes",
+					PackageName:   "routes",
+					PackagePath:   ".gen/routes",
+					HasPage:       true,
+					HasPageServer: true,
+				},
+			},
+		}
+		out, err := GenerateManifest(scan, ManifestOptions{
+			PackageName: "gen",
+			ModulePath:  "example.com/repro",
+			GenRoot:     ".gen",
+			RouteOptions: map[string]kit.PageOptions{
+				"/": {Templates: kit.TemplatesSvelte, SSR: true, CSR: true},
+			},
+			SSRRenderRoutes: map[string]string{"/": "usersrc/routes"},
+		})
+		if err != nil {
+			t.Fatalf("GenerateManifest: %v", err)
+		}
+		s := string(out)
+		if strings.Contains(s, `"fmt"`) {
+			t.Errorf("manifest imports fmt for a Svelte-only route; output:\n%s", s)
+		}
+		if strings.Contains(s, "fmt.") {
+			t.Errorf("manifest body references fmt.; output:\n%s", s)
+		}
+	})
+
+	t.Run("svelte_no_ssr_emit_no_fmt", func(t *testing.T) {
+		t.Parallel()
+		// Same Svelte route but the SSR transpile plan is empty (e.g.
+		// PageData has no fields, so planSSR skipped it). The route
+		// gets no Page wire and no render__ adapter; the manifest
+		// must still leave fmt out.
+		scan := &routescan.ScanResult{
+			Routes: []routescan.ScannedRoute{
+				{
+					Pattern:       "/",
+					Dir:           "/tmp/routes",
+					PackageName:   "routes",
+					PackagePath:   ".gen/routes",
+					HasPage:       true,
+					HasPageServer: true,
+				},
+			},
+		}
+		out, err := GenerateManifest(scan, ManifestOptions{
+			PackageName: "gen",
+			ModulePath:  "example.com/repro",
+			GenRoot:     ".gen",
+			RouteOptions: map[string]kit.PageOptions{
+				"/": {Templates: kit.TemplatesSvelte, SSR: true, CSR: true},
+			},
+		})
+		if err != nil {
+			t.Fatalf("GenerateManifest: %v", err)
+		}
+		if strings.Contains(string(out), `"fmt"`) {
+			t.Errorf("manifest imports fmt without an emit site; output:\n%s", out)
+		}
+	})
+
+	t.Run("mustache_route_keeps_fmt", func(t *testing.T) {
+		t.Parallel()
+		// Regression check on the legacy path: a non-Svelte route DOES
+		// emit `fmt.Errorf` for the typed-data assertion bridge, so the
+		// `fmt` import must stay.
+		scan := &routescan.ScanResult{
+			Routes: []routescan.ScannedRoute{
+				{
+					Pattern:       "/",
+					Dir:           "/tmp/routes",
+					PackageName:   "routes",
+					PackagePath:   ".gen/routes",
+					HasPage:       true,
+					HasPageServer: true,
+				},
+			},
+		}
+		out, err := GenerateManifest(scan, ManifestOptions{
+			PackageName: "gen",
+			ModulePath:  "example.com/repro",
+			GenRoot:     ".gen",
+		})
+		if err != nil {
+			t.Fatalf("GenerateManifest: %v", err)
+		}
+		s := string(out)
+		if !strings.Contains(s, `"fmt"`) {
+			t.Errorf("Mustache-Go route should keep fmt import; output:\n%s", s)
+		}
+		if !strings.Contains(s, `fmt.Errorf("sveltego: route`) {
+			t.Errorf("Mustache-Go route should emit fmt.Errorf for typed-data assert; output:\n%s", s)
+		}
+	})
+
+	t.Run("svelte_multi_route_no_fmt", func(t *testing.T) {
+		t.Parallel()
+		// Multi-route Svelte project: every route is the SSR Render
+		// emit, so still no fmt anywhere. Confirms the gating scales
+		// past a single route.
+		about := router.Segment{Kind: router.SegmentStatic, Value: "about"}
+		scan := &routescan.ScanResult{
+			Routes: []routescan.ScannedRoute{
+				{
+					Pattern:       "/",
+					Dir:           "/tmp/routes",
+					PackageName:   "routes",
+					PackagePath:   ".gen/routes",
+					HasPage:       true,
+					HasPageServer: true,
+				},
+				{
+					Pattern:       "/about",
+					Segments:      []router.Segment{about},
+					Dir:           "/tmp/routes/about",
+					PackageName:   "about",
+					PackagePath:   ".gen/routes/about",
+					HasPage:       true,
+					HasPageServer: true,
+				},
+			},
+		}
+		out, err := GenerateManifest(scan, ManifestOptions{
+			PackageName: "gen",
+			ModulePath:  "example.com/repro",
+			GenRoot:     ".gen",
+			RouteOptions: map[string]kit.PageOptions{
+				"/":      {Templates: kit.TemplatesSvelte, SSR: true, CSR: true},
+				"/about": {Templates: kit.TemplatesSvelte, SSR: true, CSR: true},
+			},
+			SSRRenderRoutes: map[string]string{
+				"/":      "usersrc/routes",
+				"/about": "usersrc/routes/about",
+			},
+		})
+		if err != nil {
+			t.Fatalf("GenerateManifest: %v", err)
+		}
+		if strings.Contains(string(out), `"fmt"`) {
+			t.Errorf("multi-route Svelte project should not import fmt; output:\n%s", out)
+		}
+	})
+
+	t.Run("svelte_layout_no_ssr_marker_no_fmt", func(t *testing.T) {
+		t.Parallel()
+		// Svelte SSR page + a layout NOT listed in SSRRenderLayouts.
+		// emitLayoutAdapters always uses the SSR payload-bridge form
+		// regardless of the hasSSR flag, so no fmt.Errorf lands in the
+		// emitted body. The `usesFmt` accumulator must agree —
+		// otherwise the import is "fmt imported and not used" again.
+		scan := &routescan.ScanResult{
+			Routes: []routescan.ScannedRoute{
+				{
+					Pattern:            "/",
+					Dir:                "/tmp/routes",
+					PackageName:        "routes",
+					PackagePath:        ".gen/routes",
+					HasPage:            true,
+					HasPageServer:      true,
+					LayoutPackagePaths: []string{".gen/layouts/_root_"},
+					LayoutServerFiles:  []string{""},
+				},
+			},
+		}
+		out, err := GenerateManifest(scan, ManifestOptions{
+			PackageName: "gen",
+			ModulePath:  "example.com/repro",
+			GenRoot:     ".gen",
+			RouteOptions: map[string]kit.PageOptions{
+				"/": {Templates: kit.TemplatesSvelte, SSR: true, CSR: true},
+			},
+			SSRRenderRoutes: map[string]string{"/": "usersrc/routes"},
+			// SSRRenderLayouts intentionally omitted.
+		})
+		if err != nil {
+			t.Fatalf("GenerateManifest: %v", err)
+		}
+		s := string(out)
+		if strings.Contains(s, `"fmt"`) && !strings.Contains(s, "fmt.") {
+			t.Errorf("manifest imports fmt but never references it; output:\n%s", s)
+		}
+	})
+
+	t.Run("svelte_layout_chain_no_fmt", func(t *testing.T) {
+		t.Parallel()
+		// Layout chain on a Svelte SSR route, layout properly listed
+		// in SSRRenderLayouts: layout adapters use the SSR payload-
+		// bridge form (no fmt.Errorf), and renderChain__ emit also
+		// stays fmt-free. Asserts the layout case from the #485
+		// acceptance criteria — fmt only when an emitted layout
+		// bridge actually writes fmt.Errorf, which the SSR form never
+		// does.
+		scan := &routescan.ScanResult{
+			Routes: []routescan.ScannedRoute{
+				{
+					Pattern:            "/",
+					Dir:                "/tmp/routes",
+					PackageName:        "routes",
+					PackagePath:        ".gen/routes",
+					HasPage:            true,
+					HasPageServer:      true,
+					LayoutPackagePaths: []string{".gen/layouts/_root_"},
+					LayoutServerFiles:  []string{""},
+				},
+			},
+		}
+		out, err := GenerateManifest(scan, ManifestOptions{
+			PackageName: "gen",
+			ModulePath:  "example.com/repro",
+			GenRoot:     ".gen",
+			RouteOptions: map[string]kit.PageOptions{
+				"/": {Templates: kit.TemplatesSvelte, SSR: true, CSR: true},
+			},
+			SSRRenderRoutes:  map[string]string{"/": "usersrc/routes"},
+			SSRRenderLayouts: map[string]struct{}{".gen/layouts/_root_": {}},
+		})
+		if err != nil {
+			t.Fatalf("GenerateManifest: %v", err)
+		}
+		if strings.Contains(string(out), `"fmt"`) {
+			t.Errorf("Svelte SSR layout-chain should not import fmt; output:\n%s", out)
+		}
+	})
+}

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
@@ -2,8 +2,6 @@
 package gen
 
 import (
-	"fmt"
-
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 	"github.com/binsarjr/sveltego/packages/sveltego/render"
 	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -6,6 +6,7 @@ To add a new entry, create a new `YYYY-MM-DD-<topic>.md` file there — **do not
 
 Entries newest-first:
 
+- [2026-05-03: stale `usesFmt` layout branch in manifest emitter dropped only because production cascade always set the flag (#485)](lessons/2026-05-03-fmt-import-gate-stale-branch.md)
 - [2026-05-03: TestStreaming_CancelPropagatesWithinDeadline flake — test net/http transport, not our cancel path (#435)](lessons/2026-05-03-streaming-flake.md)
 - [2026-05-02: formatConditional must route ternary tests through formatTruthy so non-bool refs compile (#466)](lessons/2026-05-02-conditional-truthy-wrap.md)
 - [2026-05-02: Reproduce both halves before assuming bug coupling (PR #470, #460 → #467 split)](lessons/2026-05-02-bug-conflation-decoupling.md)

--- a/tasks/lessons/2026-05-03-fmt-import-gate-stale-branch.md
+++ b/tasks/lessons/2026-05-03-fmt-import-gate-stale-branch.md
@@ -1,0 +1,59 @@
+# 2026-05-03 — Stale `usesFmt` layout branch in manifest emitter (#485)
+
+## Insight
+
+`internal/codegen/manifest.go` had an `usesFmt` accumulator that gated
+the emitted `"fmt"` import on whether any adapter actually wrote
+`fmt.Errorf` into the generated body. The page-side check correctly
+tracked the only remaining emit site (the legacy Mustache-Go typed-data
+type-assert bridge at `emitRenderAdapters`). The layout-side check —
+"set `usesFmt=true` if any layout has `!hasSSR`" — was a leftover from
+an earlier era when `emitLayoutAdapters` switched between a Mustache-Go
+form (`fmt.Errorf` for type-assert) and an SSR payload-bridge form
+(no fmt) based on the per-layout `hasSSR` flag.
+
+When the SSR layout-chain wiring (#456 / commit `e876b66`) unified the
+emitter so `emitLayoutAdapters` always calls `emitSSRLayoutAdapter`
+regardless of `li.hasSSR`, the Mustache-Go layout branch disappeared.
+The accumulator that fed off `!li.hasSSR` was never rewired and stayed
+as the only path through `usesFmt` whenever the page-side check missed.
+In production the dead branch did not fire because `planSSRLayouts`
+always marks every Svelte SSR route's layouts with `hasSSR=true` —
+but any direct `GenerateManifest` caller that omits `SSRRenderLayouts`
+(unit tests, future codegen paths, hand-rolled fixtures) hits the bug:
+`fmt` is imported, no `fmt.` reference lands, `gofmt` does not strip
+unused imports (`goimports` does), and `go build` fails with `"fmt"
+imported and not used`.
+
+The page-options golden was carrying the dead `"fmt"` import line for
+this reason — it had no fmt reference but the layout-side branch tripped
+the gate.
+
+## Self-rules
+
+1. When unifying two emitter forms into one (e.g. `emitLayoutAdapters`
+   collapsing Mustache-Go + SSR into a single SSR call), audit every
+   import-gate accumulator that the dropped form fed. Stale `if`
+   branches over removed flags are silent producers of wrong imports.
+   Follow the chain: removed emit site → removed `fmt.X` reference →
+   accumulator branch that tracked it must also be removed.
+
+2. Rule of thumb for codegen import gates: a "X imports Y" decision
+   is correct iff every branch that sets the gate corresponds to an
+   actual `b.Line(...)` call that writes a `Y.` reference into the
+   buffer. After a refactor, scan each accumulator branch and trace
+   back to the emit site it claims to track. If the emit site is
+   gone, the branch is dead — delete it.
+
+3. `gofmt` (and `go/format.Source`) does NOT strip unused imports,
+   only `goimports` does. Codegen that runs through `format.Source`
+   alone must be import-correct on its own — no compensating
+   post-pass. Any reliance on `goimports -w .gen` as a build step is
+   a foot-gun: pin the test fixture to bare `go build` to catch this.
+
+4. Direct `GenerateManifest` test callers exercise import gates with
+   inputs the production cascade may never produce. Keep at least one
+   regression test per import-block branch that sets up a
+   "production-impossible but locally-broken" combination — these
+   catch latent gate bugs before they migrate into the production
+   path via a future cascade change.


### PR DESCRIPTION
## Summary

- Drops the dead `usesFmt` layout branch in `manifest.go` that fired on `!li.hasSSR` even after the SSR layout-chain rewrite (#456) unified `emitLayoutAdapters` to always emit the SSR payload-bridge form (no `fmt.Errorf`).
- Adds a regression test (`TestGenerateManifest_FmtImportGated`) covering five shapes — single-route Svelte, no-SSR-emit Svelte, mustache-keeps-fmt, multi-route Svelte, layout-chain with and without the SSR marker.
- Regenerates `page-options.golden` (one stale `\"fmt\"` line dropped).
- Logs a lesson at `tasks/lessons/2026-05-03-fmt-import-gate-stale-branch.md` so the same category of \"unify emitter, forget to update import gate\" bug is prevented.

## Context

#485 reports trivial single-route Svelte projects fail `go build` with `\"fmt\" imported and not used` after `sveltego compile`. End-to-end repro from the issue (`sveltego compile && go build ./.gen/`) was actually fixed when #456 landed `usesFmt` — the page-side check correctly skips fmt for Svelte routes. But the layout-side check in the same accumulator was a stale leftover that produced the same symptom in any direct `GenerateManifest` caller that omitted `SSRRenderLayouts`. `go/format.Source` does not strip unused imports (only `goimports` does), so the stale gate would surface as a build break. This PR closes the latent path.

## Test plan

- [x] `go test -race ./packages/sveltego/...` green locally
- [x] `gofumpt -l . && goimports -l -local github.com/binsarjr/sveltego .` clean
- [x] `golangci-lint run` clean (exit 0; only pre-existing depguard warnings remain)
- [x] End-to-end: `sveltego compile && go build ./.gen/` on a trivial single-route Svelte project (no Actions, no PageData fields) builds clean without a `goimports` post-pass
- [ ] CI playground-smoke 4× green

Closes #485