### PR TITLE
chore(codegen): collapse always-true hasSSR flag (#494)

### DIFF
--- a/packages/sveltego/internal/codegen/STABILITY.md
+++ b/packages/sveltego/internal/codegen/STABILITY.md
@@ -1,6 +1,14 @@
 # Stability — packages/sveltego/internal/codegen
 
-Last updated: 2026-04-30 · Version: pre-alpha
+Last updated: 2026-05-03 · Version: pre-alpha
+
+## Recent changes
+
+- 2026-05-03 (#494): `ManifestOptions.SSRRenderLayouts` and `SSRRenderErrors`
+  removed. The Mustache-Go pipeline went away in #486, so every layout and
+  error boundary now travels the SSR payload-bridge form unconditionally —
+  the maps had no false-branch consumer left. `SSRPlanResult.Layouts` and
+  `SSRPlanResult.Errors` removed for the same reason.
 
 Tiers per [RFC #97](https://github.com/binsarjr/sveltego/issues/97).
 

--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -293,8 +293,6 @@ func Build(ctx context.Context, opts BuildOptions) (*BuildResult, error) {
 		HasServiceWorker:  hasServiceWorker,
 		SSRRenderRoutes:   ssrPlan.Transpiled,
 		SSRFallbackRoutes: ssrPlan.Fallback,
-		SSRRenderLayouts:  ssrPlan.Layouts,
-		SSRRenderErrors:   ssrPlan.Errors,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("codegen: generate manifest: %w", err)

--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -29,24 +29,15 @@ type layoutImport struct {
 	pkgPath   string
 	alias     string
 	hasServer bool
-	// hasSSR is set for layouts in SSRRenderLayouts: the manifest emits
-	// the payload-bridge form of render__layout__<alias> that dispatches
-	// to <alias>.RenderLayoutSSR (children-callback ABI from #453).
-	hasSSR bool
 }
 
 // errorImport pairs an error-page package path with the import alias
 // used for it inside the generated manifest. The manifest emits one
-// renderError__<alias> adapter per unique error package.
-//
-// hasSSR is set for boundaries in SSRRenderErrors: the manifest emits
-// the payload-bridge form of renderError__<alias> that dispatches to
-// `<alias>.RenderErrorSSR` (the wire shipped per #412) instead of the
-// legacy `ErrorPage{}.Render` adapter.
+// renderError__<alias> adapter per unique error package, dispatching to
+// the wire-emitted RenderErrorSSR (#412).
 type errorImport struct {
 	pkgPath string
 	alias   string
-	hasSSR  bool
 }
 
 // ManifestOptions configures [GenerateManifest].
@@ -89,24 +80,6 @@ type ManifestOptions struct {
 	// that proxies the request to the long-running Node sidecar via the
 	// runtime/svelte/fallback registry.
 	SSRFallbackRoutes []SSRFallbackRoute
-	// SSRRenderLayouts is the set of layout package paths (".gen/..."
-	// prefix preserved) whose `_layout.svelte` received a children-
-	// callback ABI emit under `.gen/layoutsrc/<encoded>/` plus a
-	// `wire_layout_render.gen.go` per route dir (#456). For these
-	// layouts the manifest emits the payload-bridge form of
-	// `render__layout__<alias>` — calling the typed
-	// `RenderLayoutSSR(payload, data, inner)` from the wire — instead of
-	// the legacy `Layout{}.Render(*render.Writer, ..., children)` shape.
-	SSRRenderLayouts map[string]struct{}
-	// SSRRenderErrors is the set of error-boundary package paths
-	// (".gen/..." prefix preserved) whose `_error.svelte` received an
-	// SSR transpile emit under `.gen/errorsrc/<encoded>/` plus a sibling
-	// `wire_error_render.gen.go` (#412). For these boundaries the
-	// manifest emits the payload-bridge form of `renderError__<alias>`
-	// that dispatches `RenderErrorSSR(payload, safe)` instead of the
-	// legacy `ErrorPage{}.Render` Mustache-Go adapter, so SSR error
-	// rendering travels the same Option B transpile path as page bodies.
-	SSRRenderErrors map[string]struct{}
 }
 
 // GenerateManifest emits a deterministic, gofmt-clean Go source file
@@ -189,10 +162,6 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	}
 	for i := range layoutImports {
 		layoutImports[i].hasServer = layoutHasServer[layoutImports[i].pkgPath]
-		if opts.SSRRenderLayouts != nil {
-			_, ok := opts.SSRRenderLayouts[layoutImports[i].pkgPath]
-			layoutImports[i].hasSSR = ok
-		}
 	}
 	sort.Slice(layoutImports, func(i, j int) bool {
 		return layoutImports[i].pkgPath < layoutImports[j].pkgPath
@@ -215,12 +184,6 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 		seenErrorPkg[p] = struct{}{}
 		alias := uniqueAlias(p)
 		errorImports = append(errorImports, errorImport{pkgPath: p, alias: alias})
-	}
-	for i := range errorImports {
-		if opts.SSRRenderErrors != nil {
-			_, ok := opts.SSRRenderErrors[errorImports[i].pkgPath]
-			errorImports[i].hasSSR = ok
-		}
 	}
 	sort.Slice(errorImports, func(i, j int) bool {
 		return errorImports[i].pkgPath < errorImports[j].pkgPath
@@ -274,28 +237,11 @@ func GenerateManifest(scan *routescan.ScanResult, opts ManifestOptions) ([]byte,
 	}
 	hasLayout := len(layoutImports) > 0
 	hasError := len(errorImports) > 0
-	if !hasSvelte {
-		for _, li := range layoutImports {
-			if li.hasSSR {
-				hasSvelte = true
-				break
-			}
-		}
-	}
-	if !hasSvelte {
-		for _, ei := range errorImports {
-			if ei.hasSSR {
-				hasSvelte = true
-				break
-			}
-		}
-	}
-	// $app/state lowering (#466) plumbs server.PageState through every
-	// renderChain__<routeIdent> and renderError__<alias> emit, including
-	// the Mustache-Go legacy adapters. The server import must be present
-	// whenever there's at least one layout (renderChain emit) or one
-	// error boundary (renderErrorChain emit), even on otherwise-pure-
-	// Mustache-Go playgrounds.
+	// Every layout and every error boundary now travels the SSR
+	// payload-bridge adapter, which calls into runtime/svelte/server. The
+	// server import must therefore be present whenever the manifest
+	// contains either, regardless of whether a page route hit the SSR
+	// branch above.
 	if !hasSvelte && (hasLayout || hasError) {
 		hasSvelte = true
 	}
@@ -713,15 +659,14 @@ func emitFallbackInit(b *Builder, fallback []SSRFallbackRoute) {
 }
 
 // emitLayoutAdapters writes one `render__layout__<alias>` function per
-// unique layout package. The default form widens Layout{}.Render's typed
-// LayoutData to the `any`-shaped router.LayoutHandler (legacy mustache
-// path). Layouts in SSRRenderLayouts swap to the payload-bridge form
-// from #456: dispatch to the wire-emitted RenderLayoutSSR through a
-// fresh server.Payload, bridge the writer-shape `children` callback
-// into the payload, and copy payload.Body() into the outer writer at
-// the end. Layout packages with a sibling layout.server.go additionally
-// receive a load adapter `loadLayout__<alias>` that wraps the wire-
-// emitted LayoutLoad to satisfy router.LayoutLoadHandler.
+// unique layout package. Every layout now travels the children-callback
+// payload-bridge form from #456: dispatch to the wire-emitted
+// RenderLayoutSSR through a fresh server.Payload, bridge the writer-
+// shape `children` callback into the payload, and copy payload.Body()
+// into the outer writer. Layout packages with a sibling
+// layout.server.go additionally receive a load adapter
+// `loadLayout__<alias>` that wraps the wire-emitted LayoutLoad to
+// satisfy router.LayoutLoadHandler.
 func emitLayoutAdapters(b *Builder, imports []layoutImport) {
 	for _, li := range imports {
 		emitSSRLayoutAdapter(b, li)

--- a/packages/sveltego/internal/codegen/manifest_fmt_import_test.go
+++ b/packages/sveltego/internal/codegen/manifest_fmt_import_test.go
@@ -173,11 +173,11 @@ func TestGenerateManifest_FmtImportGated(t *testing.T) {
 
 	t.Run("svelte_layout_no_ssr_marker_no_fmt", func(t *testing.T) {
 		t.Parallel()
-		// Svelte SSR page + a layout NOT listed in SSRRenderLayouts.
-		// emitLayoutAdapters always uses the SSR payload-bridge form
-		// regardless of the hasSSR flag, so no fmt.Errorf lands in the
-		// emitted body. The `usesFmt` accumulator must agree —
-		// otherwise the import is "fmt imported and not used" again.
+		// Svelte SSR page + a layout. emitLayoutAdapters always uses
+		// the SSR payload-bridge form (#494 collapsed the always-true
+		// hasSSR flag), so no fmt.Errorf lands in the emitted body.
+		// The `usesFmt` accumulator must agree — otherwise the import
+		// is "fmt imported and not used" again.
 		scan := &routescan.ScanResult{
 			Routes: []routescan.ScannedRoute{
 				{
@@ -213,13 +213,12 @@ func TestGenerateManifest_FmtImportGated(t *testing.T) {
 
 	t.Run("svelte_layout_chain_no_fmt", func(t *testing.T) {
 		t.Parallel()
-		// Layout chain on a Svelte SSR route, layout properly listed
-		// in SSRRenderLayouts: layout adapters use the SSR payload-
-		// bridge form (no fmt.Errorf), and renderChain__ emit also
-		// stays fmt-free. Asserts the layout case from the #485
-		// acceptance criteria — fmt only when an emitted layout
-		// bridge actually writes fmt.Errorf, which the SSR form never
-		// does.
+		// Layout chain on a Svelte SSR route: layout adapters now use
+		// the SSR payload-bridge form unconditionally (#494 collapsed
+		// the always-true hasSSR flag), and renderChain__ emit stays
+		// fmt-free. Asserts the layout case from the #485 acceptance
+		// criteria — fmt only when an emitted layout bridge actually
+		// writes fmt.Errorf, which the SSR form never does.
 		scan := &routescan.ScanResult{
 			Routes: []routescan.ScannedRoute{
 				{
@@ -241,8 +240,7 @@ func TestGenerateManifest_FmtImportGated(t *testing.T) {
 			RouteOptions: map[string]kit.PageOptions{
 				"/": {Templates: kit.TemplatesSvelte, SSR: true, CSR: true},
 			},
-			SSRRenderRoutes:  map[string]string{"/": "usersrc/routes"},
-			SSRRenderLayouts: map[string]struct{}{".gen/layouts/_root_": {}},
+			SSRRenderRoutes: map[string]string{"/": "usersrc/routes"},
 		})
 		if err != nil {
 			t.Fatalf("GenerateManifest: %v", err)

--- a/packages/sveltego/internal/codegen/ssr.go
+++ b/packages/sveltego/internal/codegen/ssr.go
@@ -44,24 +44,9 @@ type ssrPlan struct {
 // Fallback holds routes that explicitly opted out via the
 // `<!-- sveltego:ssr-fallback -->` comment; those route through the
 // long-running Node sidecar at request time (Phase 8, #430).
-//
-// Layouts holds layout package paths (with the ".gen/" prefix, matching
-// LayoutPackagePaths) that received a wire_layout_render.gen.go emit so
-// the manifest can swap their adapter from the legacy
-// `Layout{}.Render(*render.Writer, ...)` form to the children-callback
-// payload bridge wired via #453 (issue #456).
-//
-// Errors holds error-boundary package paths (".gen/" prefix preserved)
-// that received an error_render.gen.go emit and a sibling
-// wire_error_render.gen.go (#412). The manifest swaps the legacy
-// `ErrorPage{}.Render(...)` adapter for the payload-bridge form that
-// dispatches `RenderErrorSSR(payload, safe)` so SSR error rendering
-// runs through Option B's transpile path instead of Mustache-Go.
 type SSRPlanResult struct {
 	Transpiled map[string]string
 	Fallback   []SSRFallbackRoute
-	Layouts    map[string]struct{}
-	Errors     map[string]struct{}
 }
 
 // SSRFallbackRoute names one route the runtime must dispatch to the
@@ -259,7 +244,6 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 	if len(layoutPlans) == 0 {
 		return result, nil
 	}
-	layoutsByPkg := make(map[string]struct{}, len(layoutPlans))
 	for _, lp := range layoutPlans {
 		jobKey := layoutJobKey(lp.pkgPath)
 		astPath, ok := resultsByRoute[jobKey]
@@ -326,15 +310,11 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 		}); err != nil {
 			return result, err
 		}
-
-		layoutsByPkg[lp.pkgPath] = struct{}{}
 	}
-	result.Layouts = layoutsByPkg
 
 	if len(errorPlans) == 0 {
 		return result, nil
 	}
-	errorsByPkg := make(map[string]struct{}, len(errorPlans))
 	for _, ep := range errorPlans {
 		jobKey := errorJobKey(ep.pkgPath)
 		astPath, ok := resultsByRoute[jobKey]
@@ -398,10 +378,7 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 		}); err != nil {
 			return result, err
 		}
-
-		errorsByPkg[ep.pkgPath] = struct{}{}
 	}
-	result.Errors = errorsByPkg
 	return result, nil
 }
 

--- a/packages/sveltego/internal/codegen/svelte_mode_test.go
+++ b/packages/sveltego/internal/codegen/svelte_mode_test.go
@@ -94,11 +94,11 @@ func TestGenerateManifest_SvelteMode_SSRRender(t *testing.T) {
 	}
 }
 
-// TestGenerateManifest_SvelteMode_SSRLayout verifies #456: when a
-// layout package is in SSRRenderLayouts, the manifest swaps its
-// `render__layout__<alias>` adapter from the legacy
-// `Layout{}.Render(*render.Writer, ...)` call to the children-callback
-// payload bridge that dispatches `<alias>.RenderLayoutSSR`.
+// TestGenerateManifest_SvelteMode_SSRLayout verifies #456 / #494: layout
+// adapters always emit the children-callback payload bridge that
+// dispatches `<alias>.RenderLayoutSSR`. After #494 the manifest no
+// longer accepts a `SSRRenderLayouts` toggle — every layout takes the
+// SSR path unconditionally because the Mustache-Go pipeline is gone.
 func TestGenerateManifest_SvelteMode_SSRLayout(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -120,7 +120,6 @@ func TestGenerateManifest_SvelteMode_SSRLayout(t *testing.T) {
 		t.Fatalf("Scan: %v", err)
 	}
 	pattern := scan.Routes[0].Pattern
-	pkgPath := scan.Routes[0].PackagePath
 	routeOpts := map[string]kit.PageOptions{
 		pattern: {SSR: true, CSR: true, CSRF: true, TrailingSlash: kit.TrailingSlashNever, Templates: kit.TemplatesSvelte},
 	}
@@ -132,9 +131,6 @@ func TestGenerateManifest_SvelteMode_SSRLayout(t *testing.T) {
 		SSRRenderRoutes: map[string]string{
 			pattern: "routes",
 		},
-		SSRRenderLayouts: map[string]struct{}{
-			pkgPath: {},
-		},
 	})
 	if err != nil {
 		t.Fatalf("GenerateManifest: %v", err)
@@ -144,18 +140,18 @@ func TestGenerateManifest_SvelteMode_SSRLayout(t *testing.T) {
 		t.Errorf("expected RenderLayoutSSR call inside layout bridge with pageState:\n%s", s)
 	}
 	if bytes.Contains(out, []byte(".Layout{}.Render(w, ctx, typed, children)")) {
-		t.Errorf("legacy Layout{}.Render call should not appear when layout is SSR-bridged:\n%s", s)
+		t.Errorf("legacy Layout{}.Render call should not appear:\n%s", s)
 	}
 	if !bytes.Contains(out, []byte("inner := func(p *server.Payload) {")) {
 		t.Errorf("expected children-bridge closure:\n%s", s)
 	}
 }
 
-// TestGenerateManifest_SvelteMode_SSRError verifies #412: when an
-// error-boundary package is in SSRRenderErrors, the manifest swaps its
-// `renderError__<alias>` adapter from the legacy
-// `<alias>.ErrorPage{}.Render(...)` call to the payload bridge that
-// dispatches `<alias>.RenderErrorSSR(&payload, safe)`.
+// TestGenerateManifest_SvelteMode_SSRError verifies #412 / #494: error
+// boundary adapters always emit the payload bridge that dispatches
+// `<alias>.RenderErrorSSR(&payload, safe, pageState)`. After #494 the
+// manifest no longer accepts a `SSRRenderErrors` toggle — every error
+// boundary takes the SSR path unconditionally.
 func TestGenerateManifest_SvelteMode_SSRError(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -177,8 +173,7 @@ func TestGenerateManifest_SvelteMode_SSRError(t *testing.T) {
 		t.Fatalf("Scan: %v", err)
 	}
 	pattern := scan.Routes[0].Pattern
-	errorPkg := scan.Routes[0].ErrorBoundaryPackagePath
-	if errorPkg == "" {
+	if scan.Routes[0].ErrorBoundaryPackagePath == "" {
 		t.Fatalf("expected ErrorBoundaryPackagePath to be set")
 	}
 	routeOpts := map[string]kit.PageOptions{
@@ -192,9 +187,6 @@ func TestGenerateManifest_SvelteMode_SSRError(t *testing.T) {
 		SSRRenderRoutes: map[string]string{
 			pattern: "routes",
 		},
-		SSRRenderErrors: map[string]struct{}{
-			errorPkg: {},
-		},
 	})
 	if err != nil {
 		t.Fatalf("GenerateManifest: %v", err)
@@ -204,7 +196,7 @@ func TestGenerateManifest_SvelteMode_SSRError(t *testing.T) {
 		t.Errorf("expected RenderErrorSSR call inside error bridge with pageState:\n%s", s)
 	}
 	if bytes.Contains(out, []byte(".ErrorPage{}.Render(w, ctx, safe)")) {
-		t.Errorf("legacy ErrorPage{}.Render call should not appear when boundary is SSR-bridged:\n%s", s)
+		t.Errorf("legacy ErrorPage{}.Render call should not appear:\n%s", s)
 	}
 	if !bytes.Contains(out, []byte("var payload server.Payload")) {
 		t.Errorf("expected payload allocation in error bridge:\n%s", s)


### PR DESCRIPTION
## Summary

Closes #494.

After PR #486 atomically deleted the Mustache-Go template emitter, the `hasSSR` field on `layoutImport`/`errorImport` is always-true in production — the false branch has no caller. Collapses the dead surface end-to-end.

## Changes

- `packages/sveltego/internal/codegen/manifest.go`
  - Drop `layoutImport.hasSSR` and `errorImport.hasSSR`.
  - Drop `ManifestOptions.SSRRenderLayouts` and `ManifestOptions.SSRRenderErrors`.
  - Drop the conditional emit branches keyed off these flags.
  - Drop the now-redundant `hasSvelte` collection over layoutImports/errorImports — the existing `(hasLayout || hasError)` fallback already covers it.
  - Refresh `emitLayoutAdapters` godoc (no more legacy Mustache fork to describe).
- `packages/sveltego/internal/codegen/build.go` — drop the two now-unsupported map plumbings.
- `packages/sveltego/internal/codegen/ssr.go` — drop `SSRPlanResult.Layouts` and `SSRPlanResult.Errors`; only manifest read them, so `runSSRTranspile` stops building the (unused) bookkeeping maps.
- Tests
  - `svelte_mode_test.go`: `TestGenerateManifest_SvelteMode_SSRLayout` + `TestGenerateManifest_SvelteMode_SSRError` now exercise `GenerateManifest` WITHOUT setting the removed maps and still assert the SSR adapter form emits — that's the regression test the issue asked for.
  - `manifest_fmt_import_test.go`: refresh stale comments referencing the removed `SSRRenderLayouts` flag.
- `packages/sveltego/internal/codegen/STABILITY.md` — log the surface trim.

## Verification

- `gofumpt -l .` clean
- `goimports -l -local github.com/binsarjr/sveltego .` clean
- `go vet ./packages/sveltego/...` clean
- `go test -race ./packages/sveltego/...` — 1509 passed in 26 packages
- `go build ./...` clean
- All 8 manifest goldens stay byte-identical (no `-update` flag used).

## Test plan

- [x] Goldens unchanged (verified locally).
- [x] Race tests green.
- [ ] CI matrix green.