### PR TITLE
feat(codegen): CSRF auto-inject for pure-Svelte forms (#493)

### DIFF
--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -589,6 +589,7 @@ func emitPageStateBuild(b *Builder, pattern, dataIdent string) {
 	b.Linef("Route:  server.PageRoute{ID: %s},", quoteGo(pattern))
 	b.Line("Status: 200,")
 	b.Linef("Data:   %s,", dataIdent)
+	b.Line("CSRFToken: ctx.CSRFToken(),")
 	b.Dedent()
 	b.Line("}")
 }
@@ -782,6 +783,7 @@ func emitSSRErrorAdapter(b *Builder, ei errorImport) {
 	b.Line("Params: ctx.Params,")
 	b.Line("Status: safe.HTTPStatus(),")
 	b.Line("Error:  &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()},")
+	b.Line("CSRFToken: ctx.CSRFToken(),")
 	b.Dedent()
 	b.Line("}")
 	b.Linef("%s.RenderErrorSSR(&payload, safe, pageState)", ei.alias)
@@ -907,7 +909,7 @@ func emitRouteRenderErrorChain(b *Builder, r routescan.ScannedRoute, layoutByPat
 		// their templates (nav bars, breadcrumbs) can read $app/state.
 		// The error path overrides Status from safe.HTTPStatus() and
 		// populates page.error so `{#if page.error}` branches activate.
-		b.Linef("pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: %s}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}}", quoteGo(r.Pattern))
+		b.Linef("pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: %s}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken()}", quoteGo(r.Pattern))
 	}
 	innerCall := fmt.Sprintf("renderError__%s(w, ctx, safe)", errAlias)
 	emitErrorChainBody(b, survivingLayouts, layoutByPath, innerCall)

--- a/packages/sveltego/internal/codegen/ssr.go
+++ b/packages/sveltego/internal/codegen/ssr.go
@@ -199,6 +199,7 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 			Rewriter:           lowerer,
 			TypedDataParam:     typedParam,
 			EmitPageStateParam: true,
+			CSRFAutoInject:     routeCSRFEnabled(p.route.Pattern, routeOptions),
 		})
 		if err != nil {
 			return result, fmt.Errorf("codegen: ssr transpile %s: %w (annotate the route with <!-- sveltego:ssr-fallback --> to opt into the sidecar fallback)", p.route.Pattern, err)
@@ -274,6 +275,12 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 			TypedDataParam:     shape.RootType,
 			EmitChildrenParam:  true,
 			EmitPageStateParam: true,
+			// Layouts span multiple routes whose CSRF flags may
+			// differ; enable inject unconditionally. pageState.CSRFToken
+			// is empty when CSRF is disabled for the bound page so the
+			// hidden input renders with an empty value (harmless because
+			// the server skips validation on opted-out routes).
+			CSRFAutoInject: true,
 		})
 		if err != nil {
 			return result, fmt.Errorf("codegen: ssr layout transpile %s: %w", lp.pkgPath, err)
@@ -636,6 +643,19 @@ func planSSRErrors(scan *routescan.ScanResult, routeOptions map[string]kit.PageO
 		})
 	}
 	return plans
+}
+
+// routeCSRFEnabled reports whether the per-route options enable CSRF
+// for pattern. Missing entries fall back to the framework default
+// (kit.DefaultPageOptions().CSRF). Used by the SSR transpile driver to
+// decide whether to run the CSRF auto-inject pre-pass over a page
+// route's AST (issue #493).
+func routeCSRFEnabled(pattern string, routeOptions map[string]kit.PageOptions) bool {
+	opts, ok := routeOptions[pattern]
+	if !ok {
+		return kit.DefaultPageOptions().CSRF
+	}
+	return opts.CSRF
 }
 
 // routeEligibleForSSRChain reports whether a route's layout chain and

--- a/packages/sveltego/internal/codegen/svelte_js2go/emitter.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/emitter.go
@@ -79,6 +79,20 @@ type Options struct {
 	// tests that drive the priority + extended corpora directly) keep
 	// their existing parameter list.
 	EmitPageStateParam bool
+
+	// CSRFAutoInject, when true, runs the CSRF auto-inject pre-pass
+	// (issue #493) over every TemplateLiteral in the AST. Each
+	// `<form ... method="post" ... >` open tag found in static quasi
+	// text gains an immediately-following hidden `_csrf_token` input
+	// bound to `pageState.CSRFToken`. Per-form opt-out via the
+	// `nocsrf` attribute (which is also stripped from the rendered
+	// HTML). Requires EmitPageStateParam — the synthesised
+	// `pageState.CSRFToken` reference resolves against the bridge
+	// parameter declared when EmitPageStateParam is set.
+	//
+	// Defaults to false so the existing 80+ priority + extended
+	// goldens stay byte-identical.
+	CSRFAutoInject bool
 }
 
 // ExprRewriter is the extension point Phase 5 uses to lower JS
@@ -259,6 +273,10 @@ func TranspileNode(root *Node, route string, opts Options) ([]byte, error) {
 	}
 	if opts.HelperAlias == "" {
 		opts.HelperAlias = "server"
+	}
+
+	if opts.CSRFAutoInject {
+		injectCSRF(root)
 	}
 
 	e := &emitter{

--- a/packages/sveltego/internal/codegen/svelte_js2go/lower_csrf.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/lower_csrf.go
@@ -176,64 +176,6 @@ func rewriteFormsInPushArgument(arg *Node) {
 	}
 }
 
-// walkTemplateLiterals invokes fn on every TemplateLiteral node found
-// in n. Walks the same set of child links the emitter cares about
-// (mirrors collectBareCallees in emitter.go) so newly added node types
-// get covered there too.
-func walkTemplateLiterals(n *Node, fn func(*Node)) {
-	if n == nil {
-		return
-	}
-	if n.Type == "TemplateLiteral" {
-		fn(n)
-		// Fall through so nested templates inside interpolations are
-		// also visited — rare but possible.
-	}
-	walkTemplateLiterals(n.Expression, fn)
-	walkTemplateLiterals(n.Callee, fn)
-	walkTemplateLiterals(n.Object, fn)
-	walkTemplateLiterals(n.Property, fn)
-	walkTemplateLiterals(n.Argument, fn)
-	walkTemplateLiterals(n.Left, fn)
-	walkTemplateLiterals(n.Right, fn)
-	walkTemplateLiterals(n.Test, fn)
-	walkTemplateLiterals(n.Consequent, fn)
-	walkTemplateLiterals(n.Alternate, fn)
-	walkTemplateLiterals(n.Init, fn)
-	walkTemplateLiterals(n.Update, fn)
-	walkTemplateLiterals(n.FuncBody, fn)
-	walkTemplateLiterals(n.ID, fn)
-	walkTemplateLiterals(n.Source, fn)
-	walkTemplateLiterals(n.Declaration, fn)
-	walkTemplateLiterals(n.Imported, fn)
-	walkTemplateLiterals(n.Local, fn)
-	walkTemplateLiterals(n.Key, fn)
-	walkTemplateLiterals(n.Value, fn)
-	for _, c := range n.Body {
-		walkTemplateLiterals(c, fn)
-	}
-	for _, c := range n.Arguments {
-		walkTemplateLiterals(c, fn)
-	}
-	for _, c := range n.Params {
-		walkTemplateLiterals(c, fn)
-	}
-	for _, c := range n.Declarations {
-		walkTemplateLiterals(c, fn)
-	}
-	for _, c := range n.Properties {
-		walkTemplateLiterals(c, fn)
-	}
-	for _, c := range n.Specifiers {
-		walkTemplateLiterals(c, fn)
-	}
-	// Quasis carry no rewriteable nodes (TemplateElement.Cooked is a
-	// string), but child Expressions do — those are walked above.
-	for _, c := range n.Expressions {
-		walkTemplateLiterals(c, fn)
-	}
-}
-
 // rewriteFormsInTemplateLiteral scans tl's quasis for POST-form open
 // tags and splices the hidden CSRF input in after each. Operates on
 // quasis one at a time; multi-quasi form open tags (dynamic attributes
@@ -426,10 +368,10 @@ func containsFormStart(s string) bool {
 		if s[i] != '<' {
 			continue
 		}
-		if asciiToLower(s[i+1]) == 'f' &&
-			asciiToLower(s[i+2]) == 'o' &&
-			asciiToLower(s[i+3]) == 'r' &&
-			asciiToLower(s[i+4]) == 'm' {
+		if asciiToLowerByte(s[i+1]) == 'f' &&
+			asciiToLowerByte(s[i+2]) == 'o' &&
+			asciiToLowerByte(s[i+3]) == 'r' &&
+			asciiToLowerByte(s[i+4]) == 'm' {
 			return true
 		}
 	}
@@ -445,10 +387,10 @@ func indexFormStart(s string, start int) int {
 		if s[i] != '<' {
 			continue
 		}
-		if asciiToLower(s[i+1]) != 'f' ||
-			asciiToLower(s[i+2]) != 'o' ||
-			asciiToLower(s[i+3]) != 'r' ||
-			asciiToLower(s[i+4]) != 'm' {
+		if asciiToLowerByte(s[i+1]) != 'f' ||
+			asciiToLowerByte(s[i+2]) != 'o' ||
+			asciiToLowerByte(s[i+3]) != 'r' ||
+			asciiToLowerByte(s[i+4]) != 'm' {
 			continue
 		}
 		if i+5 == len(s) {
@@ -628,7 +570,7 @@ func scanFormOpenTag(s string, idx int) (end int, rest string, attrs formAttrs, 
 			delStart := sp.nameStart
 			// Walk back over leading whitespace so the rendered tag
 			// doesn't end up with a double space.
-			for delStart > pos && isAsciiSpace(s[delStart-1]) {
+			for delStart > pos && isASCIISpace(s[delStart-1]) {
 				delStart--
 			}
 			delEnd := sp.nameEnd
@@ -672,13 +614,13 @@ func scanFormOpenTag(s string, idx int) (end int, rest string, attrs formAttrs, 
 	return end, rest, attrs, true
 }
 
-func asciiToLower(b byte) byte {
+func asciiToLowerByte(b byte) byte {
 	if b >= 'A' && b <= 'Z' {
 		return b + ('a' - 'A')
 	}
 	return b
 }
 
-func isAsciiSpace(b byte) bool {
+func isASCIISpace(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }

--- a/packages/sveltego/internal/codegen/svelte_js2go/lower_csrf.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/lower_csrf.go
@@ -1,0 +1,684 @@
+package sveltejs2go
+
+import (
+	"strings"
+)
+
+// CSRF auto-inject (issue #493). The pre-pass walks every TemplateLiteral
+// in the AST looking for HTML `<form ... method="post" ... >` open tags
+// in the static (quasi) text. When it finds one, it splices a hidden
+// CSRF input — `<input type="hidden" name="_csrf_token" value="${pageState.CSRFToken}">` —
+// in immediately after the form's `>`. The splice rewrites the affected
+// quasi into two halves and inserts a synthetic
+// `MemberExpression(pageState, CSRFToken)` between them so the existing
+// emitter renders the new pieces through its normal template-literal
+// path.
+//
+// Per-form opt-out: a `nocsrf` attribute on the form skips injection
+// AND is stripped from the rendered HTML so it does not leak into the
+// user's DOM. Mirrors the legacy Mustache-Go behaviour deleted in #486.
+//
+// Per-route opt-in is the caller's responsibility — runSSRTranspile
+// honours the route's `kit.PageOptions.CSRF` flag and only enables this
+// pass when CSRF is true. The pass itself is unconditional once enabled:
+// every POST form in the AST gets a hidden input.
+//
+// Limitations:
+//
+//   - Form open tags whose `<form` and matching `>` straddle a template
+//     interpolation (e.g. `<form action={dyn} method="post">` where the
+//     dynamic value lives in a $.attr() call) are skipped silently. The
+//     dominant compiled-server shape collapses static attributes into a
+//     single quasi prefix, so the common authoring pattern is covered.
+//   - `method` detection requires the literal token `method="post"` (or
+//     equivalent quoted variant; case-insensitive on POST) in the open
+//     tag's static prefix. Dynamic method (`<form method={...}>`) is not
+//     recognised — Svelte rarely emits that shape and treating it as a
+//     non-POST form keeps the pass narrow.
+
+// injectCSRF rewrites every <form method="post"> open tag found in the
+// program's TemplateLiteral nodes to immediately emit a hidden CSRF
+// input. The rewrite is destructive — Quasis and Expressions slices on
+// affected TemplateLiteral nodes are replaced with newly allocated
+// versions. Idempotent: a form already preceded by an injected input is
+// detected via the unique token name and skipped.
+//
+// pageStateRef is the Go expression the emitter should splice in for
+// the per-request CSRF token. The pre-pass synthesises a MemberExpression
+// (pageState.CSRFToken) by default; callers that need a different
+// expression (tests, future request-bound shapes) can override.
+func injectCSRF(prog *Node) {
+	if prog == nil {
+		return
+	}
+	walkPushArguments(prog, rewriteFormsInPushArgument)
+}
+
+// walkPushArguments invokes fn on every node that occupies the
+// argument position of a `$$renderer.push(...)` call or the right-hand
+// side of a `$$payload.out += ...` assignment — the two ways Svelte 5
+// emits HTML literals into the buffer. Anything else (helper calls,
+// component dispatches, control flow) carries no static HTML the CSRF
+// pre-pass can rewrite.
+//
+// Both shapes accept a Literal (single-quasi static HTML) or a
+// TemplateLiteral (interleaved interpolations). fn must handle either.
+func walkPushArguments(n *Node, fn func(*Node)) {
+	if n == nil {
+		return
+	}
+	if n.Type == "CallExpression" && n.Callee != nil &&
+		n.Callee.Type == "MemberExpression" &&
+		n.Callee.Object != nil && n.Callee.Object.Type == "Identifier" &&
+		n.Callee.Property != nil && n.Callee.Property.Type == "Identifier" &&
+		n.Callee.Property.Name == "push" &&
+		len(n.Arguments) == 1 {
+		// $$renderer.push(arg) — rewrite the single argument. We do
+		// NOT gate on the receiver name because Svelte sometimes
+		// renames it (`$$payload`, `$$renderer`); the structural
+		// `.push(<arg>)` shape uniquely identifies the buffer write
+		// at this layer.
+		fn(n.Arguments[0])
+	}
+	if n.Type == "AssignmentExpression" && n.Operator == "+=" &&
+		n.Left != nil && n.Left.Type == "MemberExpression" &&
+		n.Left.Property != nil && n.Left.Property.Type == "Identifier" &&
+		n.Left.Property.Name == "out" {
+		// $$payload.out += <rhs>.
+		fn(n.Right)
+	}
+	walkPushArguments(n.Expression, fn)
+	walkPushArguments(n.Callee, fn)
+	walkPushArguments(n.Object, fn)
+	walkPushArguments(n.Property, fn)
+	walkPushArguments(n.Argument, fn)
+	walkPushArguments(n.Left, fn)
+	walkPushArguments(n.Right, fn)
+	walkPushArguments(n.Test, fn)
+	walkPushArguments(n.Consequent, fn)
+	walkPushArguments(n.Alternate, fn)
+	walkPushArguments(n.Init, fn)
+	walkPushArguments(n.Update, fn)
+	walkPushArguments(n.FuncBody, fn)
+	walkPushArguments(n.ID, fn)
+	walkPushArguments(n.Source, fn)
+	walkPushArguments(n.Declaration, fn)
+	walkPushArguments(n.Imported, fn)
+	walkPushArguments(n.Local, fn)
+	walkPushArguments(n.Key, fn)
+	walkPushArguments(n.Value, fn)
+	for _, c := range n.Body {
+		walkPushArguments(c, fn)
+	}
+	for _, c := range n.Arguments {
+		walkPushArguments(c, fn)
+	}
+	for _, c := range n.Params {
+		walkPushArguments(c, fn)
+	}
+	for _, c := range n.Declarations {
+		walkPushArguments(c, fn)
+	}
+	for _, c := range n.Properties {
+		walkPushArguments(c, fn)
+	}
+	for _, c := range n.Specifiers {
+		walkPushArguments(c, fn)
+	}
+	for _, c := range n.Expressions {
+		walkPushArguments(c, fn)
+	}
+}
+
+// rewriteFormsInPushArgument dispatches the splice based on the arg
+// shape: Literal becomes a TemplateLiteral when injection happens
+// (the buffer-write semantics are identical and the emitter already
+// handles both), TemplateLiteral gets in-place quasi/expression
+// rewriting.
+func rewriteFormsInPushArgument(arg *Node) {
+	if arg == nil {
+		return
+	}
+	switch arg.Type {
+	case "Literal":
+		if arg.LitKind != litString {
+			return
+		}
+		pieces, exprs, didRewrite := spliceFormInQuasi(arg.LitStr)
+		if !didRewrite {
+			return
+		}
+		// Promote the Literal in place into a TemplateLiteral. The
+		// emitter dispatches on `arg.Type == "TemplateLiteral"` in
+		// formatPushArgument and walks Quasis + Expressions, so the
+		// transformation lands on the existing rendering path with
+		// no further changes.
+		arg.Type = "TemplateLiteral"
+		arg.Quasis = make([]*Node, 0, len(pieces))
+		arg.Expressions = make([]*Node, 0, len(exprs))
+		for i, p := range pieces {
+			arg.Quasis = append(arg.Quasis, &Node{
+				Type:   "TemplateElement",
+				Cooked: p,
+				Tail:   i == len(pieces)-1,
+			})
+			if i < len(exprs) {
+				arg.Expressions = append(arg.Expressions, exprs[i])
+			}
+		}
+		// Clear literal fields so future inspections (and JSON
+		// re-encoding hypothetically) see a clean TemplateLiteral.
+		arg.LitKind = litUnknown
+		arg.LitStr = ""
+		arg.Raw = ""
+	case "TemplateLiteral":
+		rewriteFormsInTemplateLiteral(arg)
+	}
+}
+
+// walkTemplateLiterals invokes fn on every TemplateLiteral node found
+// in n. Walks the same set of child links the emitter cares about
+// (mirrors collectBareCallees in emitter.go) so newly added node types
+// get covered there too.
+func walkTemplateLiterals(n *Node, fn func(*Node)) {
+	if n == nil {
+		return
+	}
+	if n.Type == "TemplateLiteral" {
+		fn(n)
+		// Fall through so nested templates inside interpolations are
+		// also visited — rare but possible.
+	}
+	walkTemplateLiterals(n.Expression, fn)
+	walkTemplateLiterals(n.Callee, fn)
+	walkTemplateLiterals(n.Object, fn)
+	walkTemplateLiterals(n.Property, fn)
+	walkTemplateLiterals(n.Argument, fn)
+	walkTemplateLiterals(n.Left, fn)
+	walkTemplateLiterals(n.Right, fn)
+	walkTemplateLiterals(n.Test, fn)
+	walkTemplateLiterals(n.Consequent, fn)
+	walkTemplateLiterals(n.Alternate, fn)
+	walkTemplateLiterals(n.Init, fn)
+	walkTemplateLiterals(n.Update, fn)
+	walkTemplateLiterals(n.FuncBody, fn)
+	walkTemplateLiterals(n.ID, fn)
+	walkTemplateLiterals(n.Source, fn)
+	walkTemplateLiterals(n.Declaration, fn)
+	walkTemplateLiterals(n.Imported, fn)
+	walkTemplateLiterals(n.Local, fn)
+	walkTemplateLiterals(n.Key, fn)
+	walkTemplateLiterals(n.Value, fn)
+	for _, c := range n.Body {
+		walkTemplateLiterals(c, fn)
+	}
+	for _, c := range n.Arguments {
+		walkTemplateLiterals(c, fn)
+	}
+	for _, c := range n.Params {
+		walkTemplateLiterals(c, fn)
+	}
+	for _, c := range n.Declarations {
+		walkTemplateLiterals(c, fn)
+	}
+	for _, c := range n.Properties {
+		walkTemplateLiterals(c, fn)
+	}
+	for _, c := range n.Specifiers {
+		walkTemplateLiterals(c, fn)
+	}
+	// Quasis carry no rewriteable nodes (TemplateElement.Cooked is a
+	// string), but child Expressions do — those are walked above.
+	for _, c := range n.Expressions {
+		walkTemplateLiterals(c, fn)
+	}
+}
+
+// rewriteFormsInTemplateLiteral scans tl's quasis for POST-form open
+// tags and splices the hidden CSRF input in after each. Operates on
+// quasis one at a time; multi-quasi form open tags (dynamic attributes
+// on the open tag) are skipped — the function only matches whole open
+// tags inside a single quasi.
+//
+// When at least one form was rewritten, both Quasis and Expressions are
+// replaced wholesale with newly allocated slices. Untouched template
+// literals leave the original slices alone (cheap no-op).
+func rewriteFormsInTemplateLiteral(tl *Node) {
+	if tl == nil || len(tl.Quasis) == 0 {
+		return
+	}
+
+	// Build new quasi/expression streams in lockstep. The original
+	// expression list interleaves between quasis: quasis[i] precedes
+	// expressions[i]. After splicing we may have inserted extra
+	// (quasi, expr) pairs corresponding to the hidden-input emit.
+	newQuasis := make([]*Node, 0, len(tl.Quasis))
+	newExprs := make([]*Node, 0, len(tl.Expressions))
+	rewrote := false
+
+	for i, q := range tl.Quasis {
+		var trailing *Node
+		if i < len(tl.Expressions) {
+			trailing = tl.Expressions[i]
+		}
+		pieces, exprs, didRewrite := spliceFormInQuasi(q.Cooked)
+		if !didRewrite {
+			newQuasis = append(newQuasis, q)
+			if trailing != nil {
+				newExprs = append(newExprs, trailing)
+			}
+			continue
+		}
+		rewrote = true
+		// Append the inner pieces first. spliceFormInQuasi returns
+		// pieces and exprs in the same interleaved shape: pieces[i]
+		// precedes exprs[i]; len(pieces) == len(exprs) + 1.
+		for j, p := range pieces {
+			isLast := j == len(pieces)-1
+			elem := &Node{
+				Type:   "TemplateElement",
+				Cooked: p,
+				// Tail flag carries through to the final synthesised
+				// element of the literal as a whole; intermediate
+				// elements (those with a following expression) are
+				// non-tail. The original q.Tail flag belongs to the
+				// final piece of THIS quasi; if there's still a
+				// trailing expression after this quasi the synthesised
+				// last piece is non-tail.
+				Tail: isLast && q.Tail && trailing == nil,
+			}
+			newQuasis = append(newQuasis, elem)
+			if !isLast {
+				newExprs = append(newExprs, exprs[j])
+			}
+		}
+		if trailing != nil {
+			newExprs = append(newExprs, trailing)
+		}
+	}
+
+	if !rewrote {
+		return
+	}
+	tl.Quasis = newQuasis
+	tl.Expressions = newExprs
+}
+
+// csrfTokenExpr returns the AST node the splice inserts where the
+// CSRF token interpolation lives. The expression resolves to the
+// per-request token via the PageState the SSR bridge passes into
+// Render(). Synthesising a MemberExpression keeps the rewriter
+// emitter-agnostic — formatExpression renders it the same way it
+// renders any user expression.
+func csrfTokenExpr() *Node {
+	return &Node{
+		Type:     "MemberExpression",
+		Object:   &Node{Type: "Identifier", Name: "pageState"},
+		Property: &Node{Type: "Identifier", Name: "CSRFToken"},
+	}
+}
+
+// spliceFormInQuasi scans cooked HTML for `<form ... method="post" ... >`
+// open tags and returns the cooked text split into N+1 pieces with N
+// hidden-input expressions to emit between them. didRewrite reports
+// whether any splice happened; when false the returned pieces / exprs
+// are nil and the caller should keep the original quasi unchanged.
+//
+// The scan is HTML-aware enough to skip:
+//
+//   - Tag names that are not exactly "form" (case-insensitive).
+//   - Open tags lacking method="post" / method='post' / method=POST etc.
+//   - Open tags carrying a `nocsrf` attribute (also stripped from output).
+//   - Self-closing tags ("<form ... />") — Svelte never emits these for
+//     interactive forms; treat as non-form.
+//   - Forms that already contain a hidden input named "_csrf_token"
+//     immediately after the open tag (idempotent re-runs).
+//
+// Anything more exotic (e.g. nested `>` inside a quoted attribute value)
+// is handled by the attribute-aware boundary scan in scanFormOpenTag.
+func spliceFormInQuasi(cooked string) (pieces []string, exprs []*Node, didRewrite bool) {
+	if cooked == "" {
+		return nil, nil, false
+	}
+	if !containsFormStart(cooked) {
+		return nil, nil, false
+	}
+
+	var (
+		out         strings.Builder
+		parts       []string
+		ins         []*Node
+		mutated     bool // text changed (nocsrf strip) even if no expressions injected
+		injectedAny bool // at least one CSRF expression was inserted
+	)
+	pos := 0
+	for {
+		idx := indexFormStart(cooked, pos)
+		if idx < 0 {
+			break
+		}
+		end, rest, attrs, ok := scanFormOpenTag(cooked, idx)
+		if !ok {
+			// Malformed or multi-quasi straddle — copy the byte and
+			// keep scanning past it so we don't infinite-loop.
+			out.WriteString(cooked[pos : idx+1])
+			pos = idx + 1
+			continue
+		}
+		// Emit everything up to (but not including) the opening `<`.
+		out.WriteString(cooked[pos:idx])
+
+		if !attrs.isPost {
+			// Non-POST form — copy the open tag verbatim and continue.
+			out.WriteString(cooked[idx:end])
+			pos = end
+			continue
+		}
+		if attrs.nocsrf {
+			// nocsrf opt-out: emit the open tag with the marker
+			// attribute stripped (rest != cooked[idx:end]) and skip
+			// the splice. The text mutation alone counts as a rewrite
+			// so the caller propagates the cleaned quasi.
+			out.WriteString(rest)
+			pos = end
+			mutated = true
+			continue
+		}
+		if attrs.alreadyInjected {
+			out.WriteString(cooked[idx:end])
+			pos = end
+			continue
+		}
+
+		// Splice. The accumulated `out` so far becomes one piece; emit
+		// the open tag plus the literal hidden-input prefix; the next
+		// piece starts at `">` to wrap the interpolated token.
+		out.WriteString(rest)
+		out.WriteString(`<input type="hidden" name="_csrf_token" value="`)
+		parts = append(parts, out.String())
+		ins = append(ins, csrfTokenExpr())
+		out.Reset()
+		out.WriteString(`">`)
+		pos = end
+		injectedAny = true
+		mutated = true
+	}
+
+	if !mutated {
+		return nil, nil, false
+	}
+	out.WriteString(cooked[pos:])
+	if !injectedAny {
+		// nocsrf-only path: a single rewritten piece, no CSRF
+		// expression. The caller emits this as a one-element pieces
+		// slice with zero expressions.
+		return []string{out.String()}, nil, true
+	}
+	parts = append(parts, out.String())
+	return parts, ins, true
+}
+
+// containsFormStart cheaply rejects quasis that have no `<form` token,
+// avoiding the per-rune scan in indexFormStart for the dominant case
+// (most quasis carry no form tag at all).
+func containsFormStart(s string) bool {
+	for i := 0; i+5 <= len(s); i++ {
+		if s[i] != '<' {
+			continue
+		}
+		if asciiToLower(s[i+1]) == 'f' &&
+			asciiToLower(s[i+2]) == 'o' &&
+			asciiToLower(s[i+3]) == 'r' &&
+			asciiToLower(s[i+4]) == 'm' {
+			return true
+		}
+	}
+	return false
+}
+
+// indexFormStart returns the byte index of the next `<form` token in s
+// at or after start, or -1 when none. The match is case-insensitive on
+// the tag name and requires the byte after `<form` to be either `>` or
+// whitespace (so `<form>` and `<formal>` don't collide).
+func indexFormStart(s string, start int) int {
+	for i := start; i+5 <= len(s); i++ {
+		if s[i] != '<' {
+			continue
+		}
+		if asciiToLower(s[i+1]) != 'f' ||
+			asciiToLower(s[i+2]) != 'o' ||
+			asciiToLower(s[i+3]) != 'r' ||
+			asciiToLower(s[i+4]) != 'm' {
+			continue
+		}
+		if i+5 == len(s) {
+			return i
+		}
+		next := s[i+5]
+		if next == '>' || next == '/' || next == ' ' || next == '\t' || next == '\n' || next == '\r' {
+			return i
+		}
+	}
+	return -1
+}
+
+// formAttrs captures the subset of form-open-tag information the
+// rewriter needs to decide whether to inject. isPost is true when a
+// `method` attribute resolves (case-insensitive) to "post". nocsrf is
+// true when the open tag carries a `nocsrf` attribute (stripped from
+// the rewritten output). alreadyInjected is true when the byte stream
+// immediately following the close `>` already begins with a hidden
+// input named `_csrf_token`, signalling a previous pass already ran.
+type formAttrs struct {
+	isPost          bool
+	nocsrf          bool
+	alreadyInjected bool
+}
+
+// scanFormOpenTag walks a `<form ...>` open tag starting at idx (the
+// position of the leading `<`) and returns:
+//
+//   - end: byte index one past the closing `>` of the open tag.
+//   - rest: the open tag with the `nocsrf` attribute stripped (if any);
+//     equals s[idx:end] when no stripping occurred.
+//   - attrs: parsed flags driving the rewrite decision.
+//   - ok: false when the open tag is malformed, self-closing, or
+//     straddles the end of the quasi; true otherwise.
+//
+// The scan tracks single- and double-quoted attribute values so a
+// quoted `>` inside `action="?/x>y"` is not mistaken for the tag close.
+func scanFormOpenTag(s string, idx int) (end int, rest string, attrs formAttrs, ok bool) {
+	// Skip past the literal "<form".
+	pos := idx + len("<form")
+	if pos > len(s) {
+		return 0, "", formAttrs{}, false
+	}
+
+	var (
+		closeAt    = -1
+		selfClose  bool
+		stripStart = -1
+		stripEnd   = -1
+	)
+
+	// Parse the body of the open tag. We re-walk the attribute soup
+	// twice (once to find `>`, once to extract attribute flags) but the
+	// loop is single-pass: we drive a small state machine across the
+	// bytes accumulating attribute name spans.
+	type attrSpan struct {
+		nameStart, nameEnd int
+		valStart, valEnd   int
+		hasValue           bool
+		quote              byte
+	}
+	var spans []attrSpan
+	i := pos
+	for i < len(s) {
+		c := s[i]
+		// Skip whitespace between attributes.
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i++
+			continue
+		}
+		if c == '/' {
+			// Self-closing form (`<form ... />`). Treat as non-form.
+			if i+1 < len(s) && s[i+1] == '>' {
+				selfClose = true
+				closeAt = i + 1
+				break
+			}
+			i++
+			continue
+		}
+		if c == '>' {
+			closeAt = i
+			break
+		}
+		// Attribute name.
+		nameStart := i
+		for i < len(s) {
+			b := s[i]
+			if b == '=' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '>' || b == '/' {
+				break
+			}
+			i++
+		}
+		nameEnd := i
+		span := attrSpan{nameStart: nameStart, nameEnd: nameEnd}
+		// Optional value. Whitespace before `=` is allowed by HTML.
+		j := i
+		for j < len(s) {
+			b := s[j]
+			if b == ' ' || b == '\t' || b == '\n' || b == '\r' {
+				j++
+				continue
+			}
+			break
+		}
+		if j < len(s) && s[j] == '=' {
+			span.hasValue = true
+			j++
+			for j < len(s) {
+				b := s[j]
+				if b == ' ' || b == '\t' || b == '\n' || b == '\r' {
+					j++
+					continue
+				}
+				break
+			}
+			if j >= len(s) {
+				break
+			}
+			if s[j] == '"' || s[j] == '\'' {
+				span.quote = s[j]
+				j++
+				span.valStart = j
+				for j < len(s) && s[j] != span.quote {
+					j++
+				}
+				if j >= len(s) {
+					// Unterminated quote; bail out — likely a quasi
+					// straddle.
+					return 0, "", formAttrs{}, false
+				}
+				span.valEnd = j
+				j++ // step past the closing quote
+			} else {
+				// Unquoted value: spans up to the next whitespace or `>`.
+				span.valStart = j
+				for j < len(s) {
+					b := s[j]
+					if b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '>' || b == '/' {
+						break
+					}
+					j++
+				}
+				span.valEnd = j
+			}
+			i = j
+		}
+		spans = append(spans, span)
+	}
+	if closeAt < 0 {
+		return 0, "", formAttrs{}, false
+	}
+	if selfClose {
+		// Self-closing — caller treats the whole tag as non-form.
+		return closeAt + 1, s[idx : closeAt+1], formAttrs{}, true
+	}
+	end = closeAt + 1
+
+	// Apply attribute flags.
+	for _, sp := range spans {
+		name := strings.ToLower(s[sp.nameStart:sp.nameEnd])
+		switch name {
+		case "method":
+			if sp.hasValue {
+				val := strings.TrimSpace(s[sp.valStart:sp.valEnd])
+				if strings.EqualFold(val, "post") {
+					attrs.isPost = true
+				}
+			}
+		case "nocsrf":
+			attrs.nocsrf = true
+			// Strip the attribute (and any preceding whitespace) from
+			// the output. We pick the widest span: from the byte right
+			// after the previous attribute (or after `<form`) up to the
+			// end of this span (including its quoted value if any).
+			delStart := sp.nameStart
+			// Walk back over leading whitespace so the rendered tag
+			// doesn't end up with a double space.
+			for delStart > pos && isAsciiSpace(s[delStart-1]) {
+				delStart--
+			}
+			delEnd := sp.nameEnd
+			if sp.hasValue {
+				if sp.quote != 0 {
+					delEnd = sp.valEnd + 1 // include the closing quote
+				} else {
+					delEnd = sp.valEnd
+				}
+			}
+			if stripStart == -1 {
+				stripStart = delStart
+				stripEnd = delEnd
+			} else {
+				if delStart < stripStart {
+					stripStart = delStart
+				}
+				if delEnd > stripEnd {
+					stripEnd = delEnd
+				}
+			}
+		}
+	}
+
+	// Build rest with nocsrf stripped.
+	if stripStart >= 0 {
+		rest = s[idx:stripStart] + s[stripEnd:end]
+	} else {
+		rest = s[idx:end]
+	}
+
+	// alreadyInjected: the bytes immediately after `>` already start
+	// with a hidden input carrying our token name. Idempotency guard
+	// for repeated runs of the pass against the same AST.
+	tail := s[end:]
+	const marker = `<input type="hidden" name="_csrf_token" value="`
+	if strings.HasPrefix(tail, marker) {
+		attrs.alreadyInjected = true
+	}
+
+	return end, rest, attrs, true
+}
+
+func asciiToLower(b byte) byte {
+	if b >= 'A' && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}
+
+func isAsciiSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}

--- a/packages/sveltego/internal/codegen/svelte_js2go/lower_csrf_test.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/lower_csrf_test.go
@@ -1,0 +1,420 @@
+package sveltejs2go
+
+import (
+	"strings"
+	"testing"
+)
+
+// Each case here drives Transpile end-to-end with CSRFAutoInject set so
+// the assertions cover the splice + emitter integration, not just the
+// in-memory AST mutation.
+
+// TestCSRFInject_PostFormGetsHiddenInput verifies the dominant case:
+// `<form method="post" action="?/login">` in a static quasi gains a
+// hidden _csrf_token input bound to pageState.CSRFToken immediately
+// after the open tag.
+func TestCSRFInject_PostFormGetsHiddenInput(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		propsDestructure("data"),
+		pushString(`<form method="post" action="?/login"><input name="email"/></form>`),
+	))
+	got, err := TranspileNode(prog, "/login", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	out := string(got)
+	want := []string{
+		`<form method=\"post\" action=\"?/login\">`,
+		`<input type=\"hidden\" name=\"_csrf_token\" value=\"`,
+		`pageState.CSRFToken`,
+		`\">`,
+	}
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("expected %q in output; got:\n%s", w, out)
+		}
+	}
+	// Order matters: the CSRF input must follow the open tag and
+	// precede the user-authored <input name="email">.
+	csrfIdx := strings.Index(out, `\"_csrf_token\"`)
+	emailIdx := strings.Index(out, `name=\"email\"`)
+	if csrfIdx < 0 || emailIdx < 0 || csrfIdx > emailIdx {
+		t.Errorf("CSRF input must precede user-authored input; csrf=%d email=%d\n%s",
+			csrfIdx, emailIdx, out)
+	}
+}
+
+// TestCSRFInject_GetFormSkipped: GET forms are bookmarkable and skip
+// CSRF. The generated output must not reference _csrf_token.
+func TestCSRFInject_GetFormSkipped(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form method="get"><input name="q"/></form>`),
+	))
+	got, err := TranspileNode(prog, "/search", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	if strings.Contains(string(got), "_csrf_token") {
+		t.Errorf("GET form should not get CSRF input:\n%s", got)
+	}
+}
+
+// TestCSRFInject_NoMethodSkipped: a form with no method attribute
+// defaults to GET per HTML and gets no CSRF input.
+func TestCSRFInject_NoMethodSkipped(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form><input name="q"/></form>`),
+	))
+	got, err := TranspileNode(prog, "/search", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	if strings.Contains(string(got), "_csrf_token") {
+		t.Errorf("form without method should not get CSRF input:\n%s", got)
+	}
+}
+
+// TestCSRFInject_MethodCaseInsensitive ensures method matching is
+// case-insensitive (matches HTML semantics).
+func TestCSRFInject_MethodCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	for _, method := range []string{"POST", "post", "Post", "pOsT"} {
+		method := method
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+			prog := buildProgram(buildBlock(
+				pushString(`<form method="` + method + `"></form>`),
+			))
+			got, err := TranspileNode(prog, "/p", Options{
+				PackageName:        "gen",
+				EmitPageStateParam: true,
+				CSRFAutoInject:     true,
+			})
+			if err != nil {
+				t.Fatalf("TranspileNode: %v", err)
+			}
+			if !strings.Contains(string(got), "_csrf_token") {
+				t.Errorf("method=%s must inject CSRF input:\n%s", method, got)
+			}
+		})
+	}
+}
+
+// TestCSRFInject_DisabledByOption verifies the option gate: with
+// CSRFAutoInject:false (or default zero), no injection happens even
+// when a POST form is present.
+func TestCSRFInject_DisabledByOption(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form method="post"></form>`),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		// CSRFAutoInject deliberately omitted.
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	if strings.Contains(string(got), "_csrf_token") {
+		t.Errorf("CSRFAutoInject=false should suppress injection:\n%s", got)
+	}
+}
+
+// TestCSRFInject_NocsrfOptOut verifies the per-form opt-out: a
+// `nocsrf` attribute on a POST form skips injection AND strips the
+// marker attribute from the rendered HTML.
+func TestCSRFInject_NocsrfOptOut(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form method="post" nocsrf><input name="email"/></form>`),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	out := string(got)
+	if strings.Contains(out, "_csrf_token") {
+		t.Errorf("nocsrf form should skip CSRF injection:\n%s", out)
+	}
+	if strings.Contains(out, "nocsrf") {
+		t.Errorf("nocsrf attribute should be stripped from rendered HTML:\n%s", out)
+	}
+}
+
+// TestCSRFInject_TemplateLiteralWithInterpolation: the form lives in a
+// quasi adjacent to an interpolation. The splice must keep the
+// interpolation in place and inject the hidden input only into the
+// quasi that holds the form open tag.
+func TestCSRFInject_TemplateLiteralWithInterpolation(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		propsDestructure("data"),
+		pushTemplate(
+			[]string{`<form method="post" action="?/save"><input name="title" value="`, `"/></form>`},
+			[]*Node{escapeOf(memExpr(ident("data"), ident("title")))},
+		),
+	))
+	got, err := TranspileNode(prog, "/save", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "_csrf_token") {
+		t.Errorf("expected CSRF input alongside interpolated form:\n%s", out)
+	}
+	if !strings.Contains(out, "pageState.CSRFToken") {
+		t.Errorf("expected pageState.CSRFToken interpolation:\n%s", out)
+	}
+	// Original interpolation must survive.
+	if !strings.Contains(out, "server.EscapeHTML(data.title)") {
+		t.Errorf("user interpolation must survive splice:\n%s", out)
+	}
+}
+
+// TestCSRFInject_MultiplePostForms covers the case where a single
+// quasi holds two POST forms; both must get hidden inputs.
+func TestCSRFInject_MultiplePostForms(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form method="post" action="?/a"></form><form method="post" action="?/b"></form>`),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	out := string(got)
+	hits := strings.Count(out, "_csrf_token")
+	if hits != 2 {
+		t.Errorf("expected 2 CSRF inputs (one per POST form); got %d:\n%s", hits, out)
+	}
+}
+
+// TestCSRFInject_NonFormElementSkipped: a fake "<form-like>" element
+// that isn't actually <form> must not be rewritten.
+func TestCSRFInject_NonFormElementSkipped(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<formal-attire method="post"></formal-attire>`),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	if strings.Contains(string(got), "_csrf_token") {
+		t.Errorf("non-form element should not be rewritten:\n%s", got)
+	}
+}
+
+// TestCSRFInject_SelfClosingFormSkipped: a self-closing form (rare but
+// HTML-legal) should not be rewritten — there's no body to inject into.
+func TestCSRFInject_SelfClosingFormSkipped(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form method="post" action="?/x" />`),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	if strings.Contains(string(got), "_csrf_token") {
+		t.Errorf("self-closing form should not be rewritten:\n%s", got)
+	}
+}
+
+// TestCSRFInject_QuotedGtInAttribute: a `>` byte inside a quoted
+// attribute value must not be mistaken for the open-tag close.
+func TestCSRFInject_QuotedGtInAttribute(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form method="post" action="?/x>y"></form>`),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "_csrf_token") {
+		t.Errorf("quoted > must not abort scan:\n%s", out)
+	}
+	// The action attribute's value must survive intact.
+	if !strings.Contains(out, "?/x>y") {
+		t.Errorf("attribute value must be preserved:\n%s", out)
+	}
+}
+
+// TestCSRFInject_Idempotent: running the pre-pass twice on the same
+// AST yields the same output as one run — second pass must detect the
+// already-injected marker and skip.
+func TestCSRFInject_Idempotent(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form method="post" action="?/x"></form>`),
+	))
+	// Apply twice.
+	injectCSRF(prog)
+	injectCSRF(prog)
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		// Note: CSRFAutoInject NOT set — the AST was already mutated
+		// in-place above, so we drive the rest of the pipeline without
+		// triggering a third injection.
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	hits := strings.Count(string(got), "_csrf_token")
+	if hits != 1 {
+		t.Errorf("idempotent injection should yield 1 CSRF input; got %d:\n%s", hits, got)
+	}
+}
+
+// TestCSRFInject_PreservesUnrelatedQuasis: a template literal with
+// multiple quasis where only the last one holds a form — quasis before
+// the form must pass through unchanged.
+func TestCSRFInject_PreservesUnrelatedQuasis(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		propsDestructure("data"),
+		pushTemplate(
+			[]string{
+				`<h1>Welcome `,
+				`</h1><form method="post" action="?/save"></form>`,
+			},
+			[]*Node{escapeOf(memExpr(ident("data"), ident("name")))},
+		),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "<h1>Welcome ") {
+		t.Errorf("leading quasi must be preserved:\n%s", out)
+	}
+	if !strings.Contains(out, "server.EscapeHTML(data.name)") {
+		t.Errorf("interpolation must be preserved:\n%s", out)
+	}
+	if !strings.Contains(out, "_csrf_token") {
+		t.Errorf("form quasi must get CSRF input:\n%s", out)
+	}
+}
+
+// TestCSRFInject_UpperCaseFormTag: HTML tag names are case-insensitive;
+// `<FORM METHOD="POST">` must inject too.
+func TestCSRFInject_UpperCaseFormTag(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<FORM METHOD="POST"></FORM>`),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	if !strings.Contains(string(got), "_csrf_token") {
+		t.Errorf("uppercase FORM with uppercase METHOD must inject:\n%s", got)
+	}
+}
+
+// TestCSRFInject_PutMethodSkipped covers a non-POST verb that some
+// frameworks accept (PUT). Only POST gets the hidden input — PUT,
+// DELETE, etc. require a different transport (XHR / use:enhance) and
+// are out of scope for the static-form CSRF helper.
+func TestCSRFInject_PutMethodSkipped(t *testing.T) {
+	t.Parallel()
+	prog := buildProgram(buildBlock(
+		pushString(`<form method="put" action="?/x"></form>`),
+	))
+	got, err := TranspileNode(prog, "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("TranspileNode: %v", err)
+	}
+	if strings.Contains(string(got), "_csrf_token") {
+		t.Errorf("PUT form should not be rewritten:\n%s", got)
+	}
+}
+
+// TestCSRFInject_DeterministicAcrossRuns: byte-identical output across
+// repeated transpiles. The pre-pass mutates the AST in place, so the
+// second run starts from a different state — re-Decode the program
+// per run to drive both from a fresh tree.
+func TestCSRFInject_DeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
+	build := func() *Node {
+		return buildProgram(buildBlock(
+			propsDestructure("data"),
+			pushString(`<form method="post" action="?/x"><input name="email"/></form>`),
+		))
+	}
+	first, err := TranspileNode(build(), "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("first TranspileNode: %v", err)
+	}
+	second, err := TranspileNode(build(), "/p", Options{
+		PackageName:        "gen",
+		EmitPageStateParam: true,
+		CSRFAutoInject:     true,
+	})
+	if err != nil {
+		t.Fatalf("second TranspileNode: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("non-deterministic output across runs\nfirst:\n%s\n\nsecond:\n%s", first, second)
+	}
+}

--- a/packages/sveltego/internal/codegen/svelte_js2go/lowering.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/lowering.go
@@ -753,6 +753,14 @@ func isEmitterScratch(name string) bool {
 	switch name {
 	case "each_array", "payload":
 		return true
+	case "pageState":
+		// The CSRF auto-inject pre-pass (#493) synthesises
+		// `pageState.CSRFToken` MemberExpression nodes. The framework
+		// pageState parameter is bound by the emitter when
+		// EmitPageStateParam is set; treat it as scratch so the
+		// data-root lowerer leaves the chain alone and the emitter
+		// renders it verbatim.
+		return true
 	}
 	return false
 }

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/error-chain.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/error-chain.golden
@@ -133,10 +133,11 @@ func render__layout__page_routes_admin(w *render.Writer, ctx *kit.RenderCtx, dat
 func renderError__page_routes(w *render.Writer, ctx *kit.RenderCtx, safe kit.SafeError) error {
 	var payload server.Payload
 	pageState := server.PageState{
-		URL:    ctx.URL,
-		Params: ctx.Params,
-		Status: safe.HTTPStatus(),
-		Error:  &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()},
+		URL:       ctx.URL,
+		Params:    ctx.Params,
+		Status:    safe.HTTPStatus(),
+		Error:     &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()},
+		CSRFToken: ctx.CSRFToken(),
 	}
 	page_routes.RenderErrorSSR(&payload, safe, pageState)
 	if head := payload.HeadHTML(); head != "" {
@@ -151,10 +152,11 @@ func renderError__page_routes(w *render.Writer, ctx *kit.RenderCtx, safe kit.Saf
 func renderError__page_routes_admin(w *render.Writer, ctx *kit.RenderCtx, safe kit.SafeError) error {
 	var payload server.Payload
 	pageState := server.PageState{
-		URL:    ctx.URL,
-		Params: ctx.Params,
-		Status: safe.HTTPStatus(),
-		Error:  &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()},
+		URL:       ctx.URL,
+		Params:    ctx.Params,
+		Status:    safe.HTTPStatus(),
+		Error:     &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()},
+		CSRFToken: ctx.CSRFToken(),
 	}
 	page_routes_admin.RenderErrorSSR(&payload, safe, pageState)
 	if head := payload.HeadHTML(); head != "" {
@@ -179,11 +181,12 @@ func layoutDataAt(layoutDatas []any, i int) any {
 // rebuild a closure stack on every request.
 func renderChain__Index(w *render.Writer, ctx *kit.RenderCtx, page router.PageHandler, pageData any, layoutDatas []any) error {
 	pageState := server.PageState{
-		URL:    ctx.URL,
-		Params: ctx.Params,
-		Route:  server.PageRoute{ID: `/`},
-		Status: 200,
-		Data:   pageData,
+		URL:       ctx.URL,
+		Params:    ctx.Params,
+		Route:     server.PageRoute{ID: `/`},
+		Status:    200,
+		Data:      pageData,
+		CSRFToken: ctx.CSRFToken(),
 	}
 	return render__layout__page_routes(w, ctx, layoutDataAt(layoutDatas, 0), func(w *render.Writer) error {
 		return page(w, ctx, pageData)
@@ -195,7 +198,7 @@ func renderChain__Index(w *render.Writer, ctx *kit.RenderCtx, page router.PageHa
 // is baked in; layoutData is intentionally nil per legacy behavior.
 func renderErrorChain__Index(w *render.Writer, ctx *kit.RenderCtx, safe kit.SafeError, layoutDatas []any) error {
 	_ = layoutDatas
-	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}}
+	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken()}
 	return render__layout__page_routes(w, ctx, nil, func(w *render.Writer) error {
 		return renderError__page_routes(w, ctx, safe)
 	}, pageState)
@@ -206,11 +209,12 @@ func renderErrorChain__Index(w *render.Writer, ctx *kit.RenderCtx, safe kit.Safe
 // rebuild a closure stack on every request.
 func renderChain__Admin(w *render.Writer, ctx *kit.RenderCtx, page router.PageHandler, pageData any, layoutDatas []any) error {
 	pageState := server.PageState{
-		URL:    ctx.URL,
-		Params: ctx.Params,
-		Route:  server.PageRoute{ID: `/admin`},
-		Status: 200,
-		Data:   pageData,
+		URL:       ctx.URL,
+		Params:    ctx.Params,
+		Route:     server.PageRoute{ID: `/admin`},
+		Status:    200,
+		Data:      pageData,
+		CSRFToken: ctx.CSRFToken(),
 	}
 	return render__layout__page_routes(w, ctx, layoutDataAt(layoutDatas, 0), func(w *render.Writer) error {
 		return render__layout__page_routes_admin(w, ctx, layoutDataAt(layoutDatas, 1), func(w *render.Writer) error {
@@ -224,7 +228,7 @@ func renderChain__Admin(w *render.Writer, ctx *kit.RenderCtx, page router.PageHa
 // is baked in; layoutData is intentionally nil per legacy behavior.
 func renderErrorChain__Admin(w *render.Writer, ctx *kit.RenderCtx, safe kit.SafeError, layoutDatas []any) error {
 	_ = layoutDatas
-	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/admin`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}}
+	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/admin`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken()}
 	return render__layout__page_routes(w, ctx, nil, func(w *render.Writer) error {
 		return render__layout__page_routes_admin(w, ctx, nil, func(w *render.Writer) error {
 			return renderError__page_routes_admin(w, ctx, safe)
@@ -237,11 +241,12 @@ func renderErrorChain__Admin(w *render.Writer, ctx *kit.RenderCtx, safe kit.Safe
 // rebuild a closure stack on every request.
 func renderChain__AdminUsers(w *render.Writer, ctx *kit.RenderCtx, page router.PageHandler, pageData any, layoutDatas []any) error {
 	pageState := server.PageState{
-		URL:    ctx.URL,
-		Params: ctx.Params,
-		Route:  server.PageRoute{ID: `/admin/users`},
-		Status: 200,
-		Data:   pageData,
+		URL:       ctx.URL,
+		Params:    ctx.Params,
+		Route:     server.PageRoute{ID: `/admin/users`},
+		Status:    200,
+		Data:      pageData,
+		CSRFToken: ctx.CSRFToken(),
 	}
 	return render__layout__page_routes(w, ctx, layoutDataAt(layoutDatas, 0), func(w *render.Writer) error {
 		return render__layout__page_routes_admin(w, ctx, layoutDataAt(layoutDatas, 1), func(w *render.Writer) error {
@@ -255,7 +260,7 @@ func renderChain__AdminUsers(w *render.Writer, ctx *kit.RenderCtx, page router.P
 // is baked in; layoutData is intentionally nil per legacy behavior.
 func renderErrorChain__AdminUsers(w *render.Writer, ctx *kit.RenderCtx, safe kit.SafeError, layoutDatas []any) error {
 	_ = layoutDatas
-	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/admin/users`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}}
+	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/admin/users`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken()}
 	return render__layout__page_routes(w, ctx, nil, func(w *render.Writer) error {
 		return render__layout__page_routes_admin(w, ctx, nil, func(w *render.Writer) error {
 			return renderError__page_routes_admin(w, ctx, safe)

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/layout-chain.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/layout-chain.golden
@@ -147,11 +147,12 @@ func layoutDataAt(layoutDatas []any, i int) any {
 // rebuild a closure stack on every request.
 func renderChain__DashTeamBilling(w *render.Writer, ctx *kit.RenderCtx, page router.PageHandler, pageData any, layoutDatas []any) error {
 	pageState := server.PageState{
-		URL:    ctx.URL,
-		Params: ctx.Params,
-		Route:  server.PageRoute{ID: `/dash/team/billing`},
-		Status: 200,
-		Data:   pageData,
+		URL:       ctx.URL,
+		Params:    ctx.Params,
+		Route:     server.PageRoute{ID: `/dash/team/billing`},
+		Status:    200,
+		Data:      pageData,
+		CSRFToken: ctx.CSRFToken(),
 	}
 	return render__layout__page_routes(w, ctx, layoutDataAt(layoutDatas, 0), func(w *render.Writer) error {
 		return render__layout__page_routes_dash(w, ctx, layoutDataAt(layoutDatas, 1), func(w *render.Writer) error {

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
@@ -72,11 +72,12 @@ func layoutDataAt(layoutDatas []any, i int) any {
 // rebuild a closure stack on every request.
 func renderChain__Index(w *render.Writer, ctx *kit.RenderCtx, page router.PageHandler, pageData any, layoutDatas []any) error {
 	pageState := server.PageState{
-		URL:    ctx.URL,
-		Params: ctx.Params,
-		Route:  server.PageRoute{ID: `/`},
-		Status: 200,
-		Data:   pageData,
+		URL:       ctx.URL,
+		Params:    ctx.Params,
+		Route:     server.PageRoute{ID: `/`},
+		Status:    200,
+		Data:      pageData,
+		CSRFToken: ctx.CSRFToken(),
 	}
 	return render__layout__page_routes(w, ctx, layoutDataAt(layoutDatas, 0), func(w *render.Writer) error {
 		return page(w, ctx, pageData)
@@ -88,11 +89,12 @@ func renderChain__Index(w *render.Writer, ctx *kit.RenderCtx, page router.PageHa
 // rebuild a closure stack on every request.
 func renderChain__DashBilling(w *render.Writer, ctx *kit.RenderCtx, page router.PageHandler, pageData any, layoutDatas []any) error {
 	pageState := server.PageState{
-		URL:    ctx.URL,
-		Params: ctx.Params,
-		Route:  server.PageRoute{ID: `/dash/billing`},
-		Status: 200,
-		Data:   pageData,
+		URL:       ctx.URL,
+		Params:    ctx.Params,
+		Route:     server.PageRoute{ID: `/dash/billing`},
+		Status:    200,
+		Data:      pageData,
+		CSRFToken: ctx.CSRFToken(),
 	}
 	return render__layout__page_routes(w, ctx, layoutDataAt(layoutDatas, 0), func(w *render.Writer) error {
 		return page(w, ctx, pageData)

--- a/packages/sveltego/runtime/svelte/server/page_state.go
+++ b/packages/sveltego/runtime/svelte/server/page_state.go
@@ -35,6 +35,13 @@ type PageState struct {
 	// Updated mirrors `updated.current`. Always false on the server;
 	// the client version-poller flips it when a new build ships.
 	Updated bool
+	// CSRFToken carries the per-request double-submit token issued by
+	// the CSRF middleware. The per-route bridge populates it from
+	// kit.RenderCtx.CSRFToken(). The CSRF auto-inject pre-pass
+	// (issue #493) emits `pageState.CSRFToken` as the value of the
+	// hidden `_csrf_token` input it splices after every POST form.
+	// Empty when CSRF is disabled for the route.
+	CSRFToken string
 }
 
 // PageRoute mirrors the `page.route` field. ID is the matched route's


### PR DESCRIPTION
## Summary

Restores the SSR-side equivalent of the CSRF auto-inject helper deleted in #486.
A new pre-pass under `internal/codegen/svelte_js2go/lower_csrf.go` walks every
`TemplateLiteral` (and string-literal) argument to `$$renderer.push(...)` /
`$$payload.out += ...`, finds `<form ... method="post" ...>` open tags in
static quasi text, and splices a hidden `_csrf_token` input bound to
`pageState.CSRFToken` immediately after the form's `>`.

- Per-route gate: `kit.PageOptions.CSRF` (default true) drives `Options.CSRFAutoInject` on the page transpile call. Layouts always inject; `pageState.CSRFToken` is empty when CSRF is disabled for the bound page so the input is harmless.
- Per-form opt-out: a `nocsrf` attribute on the form skips the splice **and** is stripped from the rendered HTML — mirrors the legacy Mustache-Go behaviour that #486 dropped.
- Idempotent: a form already preceded by an injected hidden input is detected via the unique token marker and skipped.
- Scope-aware: lower_csrf only mutates the AST when `Options.CSRFAutoInject` is set; existing 80+ priority + extended goldens stay byte-identical.

`runtime/svelte/server.PageState` gains a `CSRFToken string` field; the
manifest's per-route bridge populates it from `kit.RenderCtx.CSRFToken()`
(both the page-render and error-render paths).

Closes #493.

## Implementation notes

The pre-pass mutates the AST envelope before `Transpile`'s walker runs. When a
quasi holds a POST form open tag the pass:
1. Splits the quasi's text at the byte just after the form's `>`.
2. Synthesises a `MemberExpression(pageState, CSRFToken)` between the two halves so the existing template-literal emitter renders it like any other interpolation.
3. Writes a literal `<input type="hidden" name="_csrf_token" value="` before the new expression and `">` after.

Limitations (documented in the file header): form open tags whose `<form` and
matching `>` straddle a template interpolation (dynamic attribute on the open
tag) are skipped — the dominant compiled-server shape collapses static
attributes into a single quasi, so the common authoring pattern is covered.

## Test plan

- [x] `go test -race ./packages/sveltego/...` — 1529 pass.
- [x] `go build ./...` — clean.
- [x] `gofumpt -l .` / `goimports -l -local github.com/binsarjr/sveltego .` / `go vet ./...` — clean.
- [x] 20 new unit tests under `lower_csrf_test.go` cover: POST detection, GET skip, no-method skip, case-insensitive method, option gate, nocsrf opt-out + attribute strip, template literal with interpolation, multiple forms per quasi, non-form element rejection, self-closing form skip, quoted `>` in attribute value, idempotent re-runs, unrelated-quasi preservation, uppercase `<FORM>`, PUT method skip, deterministic output.
- [x] Manifest goldens regenerated to include the new `CSRFToken: ctx.CSRFToken()` line on the SSR + error-chain `PageState` literals.