### PR TITLE
feat(codegen): SSR-transpile <Image> element lowering (#492)

### DIFF
--- a/packages/sveltego/internal/codegen/imagescan.go
+++ b/packages/sveltego/internal/codegen/imagescan.go
@@ -1,0 +1,104 @@
+package codegen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/images"
+)
+
+// imageSrcPattern captures the literal src= value on an `<Image>`
+// opening tag. Only the static double- or single-quoted form is
+// recognised; dynamic `src={…}` surfaces at codegen time so a typo
+// never silently disables the variant pipeline.
+//
+// Capitalised tag matches Svelte's child-component convention. The
+// scanner is the cheapest pre-pass available to gather variant work
+// before the SSR sidecar runs — no JS engine, no AST walk, just regex
+// over `_page.svelte` text.
+var imageSrcPattern = regexp.MustCompile(`<Image\b[^>]*?\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)')`)
+
+// scanProjectImages walks the project for every .svelte file and
+// returns the deduplicated set of `<Image src=…>` values. Paths are
+// normalised to forward slashes and stripped of any leading slash so
+// they match the keys produced by the asset pipeline.
+//
+// The walker covers `src/routes/`, `src/lib/`, and any other `src/`
+// subtree because <Image> may appear in a component imported from
+// anywhere.
+func scanProjectImages(projectRoot string) ([]string, error) {
+	srcRoot := filepath.Join(projectRoot, "src")
+	if _, err := os.Stat(srcRoot); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("codegen: stat %s: %w", srcRoot, err)
+	}
+	seen := make(map[string]struct{})
+	walkErr := filepath.WalkDir(srcRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".svelte") {
+			return nil
+		}
+		body, rerr := os.ReadFile(path) //nolint:gosec // path comes from WalkDir under projectRoot
+		if rerr != nil {
+			return fmt.Errorf("codegen: read %s: %w", path, rerr)
+		}
+		matches := imageSrcPattern.FindAllSubmatch(body, -1)
+		for _, m := range matches {
+			var src string
+			if len(m[1]) > 0 {
+				src = string(m[1])
+			} else if len(m[2]) > 0 {
+				src = string(m[2])
+			}
+			if src == "" {
+				continue
+			}
+			seen[strings.TrimPrefix(src, "/")] = struct{}{}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// buildImageVariants runs the image pipeline against every `<Image>`
+// source referenced in the project. An empty source list short-
+// circuits to a nil map so projects with no Image elements pay no I/O
+// cost. widths is the project's effective ImageWidths (empty falls back
+// to [images.DefaultWidths]).
+func buildImageVariants(projectRoot string, widths []int) (map[string]images.Result, error) {
+	sources, err := scanProjectImages(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	plan, err := images.Build(images.BuildOptions{
+		StaticDir: filepath.Join(projectRoot, "static"),
+		Sources:   sources,
+		Widths:    widths,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("codegen: build images: %w", err)
+	}
+	return plan.Results, nil
+}

--- a/packages/sveltego/internal/codegen/imagescan_test.go
+++ b/packages/sveltego/internal/codegen/imagescan_test.go
@@ -1,0 +1,185 @@
+package codegen
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+)
+
+// writePNG drops a 1x1 in-memory PNG at path. Used by the imagescan
+// integration tests so the variant pipeline has real bytes to decode
+// without bloating the repo with binary fixture assets.
+func writePNG(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := 0; y < 4; y++ {
+		for x := 0; x < 4; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x * 60), G: uint8(y * 60), B: 200, A: 255})
+		}
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := png.Encode(f, img); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanProjectImages_DedupAndSort(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	must := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("src/routes/_page.svelte", `<Image src="/hero.png" alt="x" /><Image src='/about.png' alt="y" />`)
+	must("src/routes/duplicate/_page.svelte", `<Image src="/hero.png" alt="dup" />`)
+	must("src/lib/Card.svelte", `<Image src="/card.png" alt="card" />`)
+	must("src/routes/notimage.svelte.txt", `<Image src="/nope.png" alt="z" />`)
+
+	got, err := scanProjectImages(root)
+	if err != nil {
+		t.Fatalf("scanProjectImages: %v", err)
+	}
+	want := []string{"about.png", "card.png", "hero.png"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestScanProjectImages_EmptyProject(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	got, err := scanProjectImages(root)
+	if err != nil {
+		t.Fatalf("scanProjectImages: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected nil/empty for project without src/, got %v", got)
+	}
+}
+
+func TestScanProjectImages_DynamicSrcSkipped(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, "src", "page.svelte"),
+		[]byte(`<Image src={data.hero} alt="dynamic" />`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	got, err := scanProjectImages(root)
+	if err != nil {
+		t.Fatalf("scanProjectImages: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("dynamic src must be skipped, got %v", got)
+	}
+}
+
+func TestBuildImageVariants_RoundTrip(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(root, "src.svelte"),
+		[]byte(`<Image src="/pixel.png" alt="x" />`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "src", "routes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, "src", "routes", "_page.svelte"),
+		[]byte(`<Image src="/pixel.png" alt="x" />`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writePNG(t, filepath.Join(root, "static", "assets", "pixel.png"))
+
+	results, err := buildImageVariants(root, []int{2})
+	if err != nil {
+		t.Fatalf("buildImageVariants: %v", err)
+	}
+	res, ok := results["pixel.png"]
+	if !ok {
+		t.Fatalf("expected pixel.png in results, got keys %v", keysOf(results))
+	}
+	if res.IntrinsicWidth != 4 || res.IntrinsicHeight != 4 {
+		t.Errorf("intrinsic dims = %dx%d, want 4x4", res.IntrinsicWidth, res.IntrinsicHeight)
+	}
+	if len(res.Variants) < 1 {
+		t.Errorf("expected at least the intrinsic variant, got %d", len(res.Variants))
+	}
+}
+
+func TestBuildImageVariants_NoSourcesShortCircuits(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	results, err := buildImageVariants(root, nil)
+	if err != nil {
+		t.Fatalf("buildImageVariants: %v", err)
+	}
+	if results != nil {
+		t.Fatalf("expected nil results for project with no Image refs, got %v", results)
+	}
+}
+
+func TestProjectImageWidths_FirstNonEmptyWins(t *testing.T) {
+	t.Parallel()
+	opts := map[string]kit.PageOptions{
+		"/blog":  {ImageWidths: []int{640, 1280}},
+		"/about": {},
+	}
+	got := projectImageWidths(opts)
+	if !reflect.DeepEqual(got, []int{640, 1280}) {
+		t.Fatalf("got %v, want [640 1280]", got)
+	}
+}
+
+func TestProjectImageWidths_AllEmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+	got := projectImageWidths(map[string]kit.PageOptions{
+		"/": {},
+	})
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/packages/sveltego/internal/codegen/ssr.go
+++ b/packages/sveltego/internal/codegen/ssr.go
@@ -119,6 +119,16 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 		return result, fmt.Errorf("codegen: ssr requires node 18+ on $PATH (or annotate routes with <!-- sveltego:ssr-fallback --> if they intentionally bypass the transpiler): %w", err)
 	}
 
+	// Image variant pipeline (issue #492): scan every .svelte source for
+	// `<Image src=…>` literals once, run the build-time resize pass, and
+	// share the resulting variant map across every Transpile call below.
+	// Empty map for projects with no <Image> elements — the lowering
+	// pre-pass is a no-op when the map is empty.
+	imageVariants, err := buildImageVariants(projectRoot, projectImageWidths(routeOptions))
+	if err != nil {
+		return result, err
+	}
+
 	jobs := make([]svelterender.SSRJob, 0, len(transpilePlan)+len(layoutPlans)+len(errorPlans))
 	for _, p := range transpilePlan {
 		rel, err := filepath.Rel(projectRoot, filepath.Join(p.route.Dir, "_page.svelte"))
@@ -200,6 +210,7 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 			TypedDataParam:     typedParam,
 			EmitPageStateParam: true,
 			CSRFAutoInject:     routeCSRFEnabled(p.route.Pattern, routeOptions),
+			ImageVariants:      imageVariants,
 		})
 		if err != nil {
 			return result, fmt.Errorf("codegen: ssr transpile %s: %w (annotate the route with <!-- sveltego:ssr-fallback --> to opt into the sidecar fallback)", p.route.Pattern, err)
@@ -281,6 +292,7 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 			// hidden input renders with an empty value (harmless because
 			// the server skips validation on opted-out routes).
 			CSRFAutoInject: true,
+			ImageVariants:  imageVariants,
 		})
 		if err != nil {
 			return result, fmt.Errorf("codegen: ssr layout transpile %s: %w", lp.pkgPath, err)
@@ -351,6 +363,7 @@ func runSSRTranspile(ctx context.Context, projectRoot, outDir, modulePath string
 			Rewriter:           lowerer,
 			TypedDataParam:     shape.RootType,
 			EmitPageStateParam: true,
+			ImageVariants:      imageVariants,
 		})
 		if err != nil {
 			return result, fmt.Errorf("codegen: ssr error transpile %s: %w", ep.pkgPath, err)
@@ -679,6 +692,24 @@ func routeEligibleForSSRChain(r routescan.ScannedRoute, routeOptions map[string]
 		return false
 	}
 	return opts.SSR || opts.Prerender || opts.PrerenderAuto
+}
+
+// projectImageWidths returns the effective ImageWidths for the
+// project's image variant pipeline (issue #492). Per
+// [kit.PageOptions.ImageWidths], the field is project-global rather
+// than per-route — variants share a single static/_app/immutable/
+// pool. Pick the first non-empty ImageWidths from any route's
+// effective options; an empty result lets the pipeline fall back to
+// [images.DefaultWidths].
+func projectImageWidths(routeOptions map[string]kit.PageOptions) []int {
+	for _, opts := range routeOptions {
+		if len(opts.ImageWidths) > 0 {
+			out := make([]int, len(opts.ImageWidths))
+			copy(out, opts.ImageWidths)
+			return out
+		}
+	}
+	return nil
 }
 
 // errorDataShape returns the synthetic typegen Shape used by the

--- a/packages/sveltego/internal/codegen/svelte_js2go/emitter.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/emitter.go
@@ -7,6 +7,8 @@ import (
 	"go/format"
 	"strconv"
 	"strings"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/images"
 )
 
 // Options configures Transpile.
@@ -93,6 +95,18 @@ type Options struct {
 	// Defaults to false so the existing 80+ priority + extended
 	// goldens stay byte-identical.
 	CSRFAutoInject bool
+
+	// ImageVariants, when non-nil, drives the build-time `<Image>`
+	// element lowering pre-pass (issue #492). Each call site of an
+	// `Image` component imported from "@sveltego/enhanced-img" is
+	// replaced with a `$$renderer.push("<img …>")` whose markup is
+	// resolved from this map. Keys are forward-slash relative paths
+	// under static/assets/ (no leading slash) — the convention shared
+	// with [internal/images.Build].
+	//
+	// Defaults to nil. Routes that import nothing from the reserved
+	// module are unaffected even when the map is supplied.
+	ImageVariants map[string]images.Result
 }
 
 // ExprRewriter is the extension point Phase 5 uses to lower JS
@@ -277,6 +291,12 @@ func TranspileNode(root *Node, route string, opts Options) ([]byte, error) {
 
 	if opts.CSRFAutoInject {
 		injectCSRF(root)
+	}
+
+	if len(opts.ImageVariants) > 0 {
+		if err := injectImage(root, opts.ImageVariants); err != nil {
+			return nil, err
+		}
 	}
 
 	e := &emitter{

--- a/packages/sveltego/internal/codegen/svelte_js2go/lower_image.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/lower_image.go
@@ -1,0 +1,539 @@
+package sveltejs2go
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/images"
+)
+
+// Image-element lowering (issue #492). The pre-pass walks the AST
+// looking for invocations of an `Image` component imported from the
+// reserved framework module `@sveltego/enhanced-img`. Each call site
+// `Image($$renderer, { src: "...", alt: "...", ... })` is replaced
+// with a `$$renderer.push("<img …>")` whose HTML is resolved at build
+// time against the [images.Result] map — the same multi-DPR `<img
+// srcset=…>` shape the previous Mustache-Go lowering emitted.
+//
+// Resolution is build-time only by design (ADR 0009): the request path
+// must stay JS-engine-free. WebP/AVIF, dynamic `src={expr}`, class /
+// style directives on `<Image>`, and runtime transform back-ends are
+// out of scope for this PR — see the PR body's deferred-items list.
+//
+// Errors land on the [imageInjector] accumulator and are returned via
+// [Options.ImageErrors] after [TranspileNode] runs so the build driver
+// can surface them with a precise route+source pointer. Returning a
+// hard error without short-circuiting the transpile keeps the dispatch
+// uniform with how `recordImport` already handles other framework
+// virtual modules.
+
+// imageImportSource is the reserved framework virtual module path the
+// user imports the `<Image>` component from. The local binding name is
+// not constrained — the pre-pass tracks whatever the user picked
+// (`import Image from "@sveltego/enhanced-img"`,
+// `import Img from "@sveltego/enhanced-img"`, etc.) so call-site
+// substitution matches the chosen alias.
+const imageImportSource = "@sveltego/enhanced-img"
+
+// rendererParamNames is the closed set of identifier names svelte/server
+// uses for the renderer parameter on a child-component invocation. The
+// pre-pass requires the call's first arg to be one of these — anything
+// else (e.g. a user-authored helper that happens to share the local
+// name) leaves the call unchanged.
+var rendererParamNames = map[string]struct{}{
+	"$$renderer": {},
+	"$$payload":  {},
+}
+
+// imageInjector mutates the AST in place, lowering Image(...) call
+// expressions to renderer.push("...") nodes whose payload is the build-
+// time-resolved <img srcset> markup. The injector accumulates errors
+// for missing variants and dynamic-src forms so callers can surface
+// every offending site in one build pass instead of failing on the
+// first one.
+type imageInjector struct {
+	variants map[string]images.Result
+	locals   map[string]struct{}
+	errs     []error
+}
+
+// injectImage runs the Image-element lowering pre-pass over root.
+// variants keys are forward-slash relative paths under static/assets/
+// (no leading slash) — the same convention the [images.Build] pipeline
+// uses. A nil or empty variants map is a no-op: routes that import
+// nothing from the reserved module surface no Image local in scope and
+// the walker exits early.
+//
+// Returned errors are joined with errors.Join so callers can format
+// each on its own line. A non-nil return does not invalidate the
+// partial AST mutation — the build driver should fail the build, not
+// re-emit.
+func injectImage(root *Node, variants map[string]images.Result) error {
+	if root == nil {
+		return nil
+	}
+	inj := &imageInjector{variants: variants, locals: map[string]struct{}{}}
+	inj.collectImports(root)
+	if len(inj.locals) == 0 {
+		return nil
+	}
+	inj.walk(root)
+	if len(inj.errs) == 0 {
+		return nil
+	}
+	return joinErrors(inj.errs)
+}
+
+// joinErrors collapses multiple lowering errors into a single error
+// whose message lists each offender on its own line. The format mirrors
+// the [Lowerer.Err] output so build drivers can surface either kind
+// uniformly.
+func joinErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	parts := make([]string, 0, len(errs))
+	for _, e := range errs {
+		parts = append(parts, e.Error())
+	}
+	return fmt.Errorf("%s", strings.Join(parts, "\n"))
+}
+
+// collectImports walks Program.body looking for ImportDeclaration nodes
+// whose source matches [imageImportSource], registering each local
+// binding as a candidate Image callee. Both default and named imports
+// are accepted — svelte/compiler treats any capitalised tag as a
+// component reference regardless of import shape.
+func (i *imageInjector) collectImports(root *Node) {
+	if root == nil || root.Type != "Program" {
+		return
+	}
+	for idx, item := range root.Body {
+		if item == nil || item.Type != "ImportDeclaration" {
+			continue
+		}
+		if item.Source == nil || item.Source.LitStr != imageImportSource {
+			continue
+		}
+		for _, sp := range item.Specifiers {
+			if sp == nil || sp.Local == nil || sp.Local.Type != "Identifier" {
+				continue
+			}
+			if sp.Local.Name == "" {
+				continue
+			}
+			i.locals[sp.Local.Name] = struct{}{}
+		}
+		// Drop the import declaration so recordImport does not hit
+		// unknownShape for the framework virtual module. Replace with
+		// a no-op statement (an EmptyStatement is rendered as nothing
+		// by emitProgram's switch). Use ExpressionStatement carrying a
+		// nil Expression — emitProgram's outer dispatch reaches only
+		// ImportDeclaration / ExportDefaultDeclaration / Function-
+		// Declaration / VariableDeclaration / ExportNamedDeclaration,
+		// so rewriting to ExportNamedDeclaration with an empty body
+		// keeps it in the silent-skip branch.
+		root.Body[idx] = &Node{Type: "ExportNamedDeclaration"}
+	}
+}
+
+// walk descends into every node looking for ExpressionStatement entries
+// whose Expression is a CallExpression matching one of the tracked
+// Image locals. Match candidates are rewritten in place; non-matches
+// are left untouched. The walker covers every ESTree branch the
+// emitter visits so an Image invocation deep inside an {#each} body or
+// {#if} branch is still rewritten.
+func (i *imageInjector) walk(n *Node) {
+	if n == nil {
+		return
+	}
+	if n.Type == "ExpressionStatement" && n.Expression != nil {
+		if rewritten, ok := i.rewriteCall(n.Expression); ok {
+			n.Expression = rewritten
+			return
+		}
+	}
+	for _, c := range n.Body {
+		i.walk(c)
+	}
+	i.walk(n.Expression)
+	i.walk(n.Callee)
+	i.walk(n.Object)
+	i.walk(n.Property)
+	i.walk(n.Argument)
+	i.walk(n.Left)
+	i.walk(n.Right)
+	i.walk(n.Test)
+	i.walk(n.Consequent)
+	i.walk(n.Alternate)
+	i.walk(n.Init)
+	i.walk(n.Update)
+	i.walk(n.FuncBody)
+	i.walk(n.ID)
+	i.walk(n.Source)
+	i.walk(n.Declaration)
+	for _, c := range n.Arguments {
+		i.walk(c)
+	}
+	for _, c := range n.Params {
+		i.walk(c)
+	}
+	for _, c := range n.Declarations {
+		i.walk(c)
+	}
+	for _, c := range n.Properties {
+		i.walk(c)
+	}
+	for _, c := range n.Specifiers {
+		i.walk(c)
+	}
+	for _, c := range n.Quasis {
+		i.walk(c)
+	}
+	for _, c := range n.Expressions {
+		i.walk(c)
+	}
+}
+
+// rewriteCall returns the substituted ExpressionStatement.Expression
+// when call is `Image($$renderer, { src: "...", ... })`. The boolean
+// signals whether a substitution occurred — false leaves the original
+// node in place so unrelated user calls survive untouched.
+//
+// Rewrites land as `$$renderer.push("<img …>")` so the existing
+// emitRendererPush path emits the resolved markup verbatim. The
+// renderer identifier is read from the call's first arg so aliasing in
+// the user's component (rare) does not break the substitution.
+func (i *imageInjector) rewriteCall(call *Node) (*Node, bool) {
+	if call.Type != "CallExpression" || call.Callee == nil {
+		return nil, false
+	}
+	if call.Callee.Type != "Identifier" {
+		return nil, false
+	}
+	if _, ok := i.locals[call.Callee.Name]; !ok {
+		return nil, false
+	}
+	if len(call.Arguments) < 2 {
+		i.errs = append(i.errs, fmt.Errorf("image lowering: %s() at byte=%d expects (renderer, props), got %d argument(s)", call.Callee.Name, call.Start, len(call.Arguments)))
+		return nil, false
+	}
+	rendererArg := call.Arguments[0]
+	if rendererArg == nil || rendererArg.Type != "Identifier" {
+		i.errs = append(i.errs, fmt.Errorf("image lowering: %s() at byte=%d expects an Identifier renderer arg, got %s", call.Callee.Name, call.Start, typeOf(rendererArg)))
+		return nil, false
+	}
+	if _, ok := rendererParamNames[rendererArg.Name]; !ok {
+		i.errs = append(i.errs, fmt.Errorf("image lowering: %s() at byte=%d expects $$renderer/$$payload, got %q", call.Callee.Name, call.Start, rendererArg.Name))
+		return nil, false
+	}
+	propsArg := call.Arguments[1]
+	if propsArg == nil || propsArg.Type != "ObjectExpression" {
+		i.errs = append(i.errs, fmt.Errorf("image lowering: %s() at byte=%d expects an inline ObjectExpression for props, got %s", call.Callee.Name, call.Start, typeOf(propsArg)))
+		return nil, false
+	}
+	attrs, err := i.collectStaticAttrs(propsArg)
+	if err != nil {
+		i.errs = append(i.errs, fmt.Errorf("image lowering: %s() at byte=%d: %w", call.Callee.Name, call.Start, err))
+		return nil, false
+	}
+	html, err := i.renderImageHTML(call, attrs)
+	if err != nil {
+		i.errs = append(i.errs, err)
+		return nil, false
+	}
+	literal := &Node{
+		Type:    "Literal",
+		LitKind: litString,
+		LitStr:  html,
+		Raw:     strconv.Quote(html),
+	}
+	return &Node{
+		Type: "CallExpression",
+		Callee: &Node{
+			Type:     "MemberExpression",
+			Object:   &Node{Type: "Identifier", Name: rendererArg.Name},
+			Property: &Node{Type: "Identifier", Name: "push"},
+		},
+		Arguments: []*Node{literal},
+	}, true
+}
+
+// imageAttrs holds the parsed static prop set on an `<Image>` call.
+// src is the only required field; everything else is optional and
+// contributes either to the open-tag attribute list or to the HTML
+// hints (loading / decoding).
+type imageAttrs struct {
+	src       string
+	alt       string
+	hasAlt    bool
+	width     int
+	height    int
+	hasW      bool
+	hasH      bool
+	priority  bool
+	classAttr string
+	hasClass  bool
+	sizes     string
+	hasSizes  bool
+}
+
+// collectStaticAttrs walks the ObjectExpression that compiled-server
+// emits for `<Image src=… alt=… />` props. Only static-string and
+// static-number prop values are accepted; dynamic forms surface as a
+// clear error so the user can either inline the value or annotate the
+// route for the sidecar fallback.
+func (i *imageInjector) collectStaticAttrs(obj *Node) (imageAttrs, error) {
+	var attrs imageAttrs
+	for _, p := range obj.Properties {
+		if p == nil {
+			continue
+		}
+		if p.Type != "Property" {
+			return attrs, fmt.Errorf("Image props: unsupported property kind %q (only static keys allowed)", p.Type)
+		}
+		if p.Computed {
+			return attrs, fmt.Errorf("Image props: computed property keys are not supported")
+		}
+		if p.Key == nil || p.Key.Type != "Identifier" {
+			return attrs, fmt.Errorf("Image props: prop key must be a bare identifier")
+		}
+		name := p.Key.Name
+		val := p.Value
+		switch name {
+		case "src":
+			s, ok := literalString(val)
+			if !ok {
+				return attrs, fmt.Errorf(`Image src=%s is dynamic; only static "src=\"…\"" is supported`, formatNodeKind(val))
+			}
+			attrs.src = strings.TrimPrefix(s, "/")
+		case "alt":
+			s, ok := literalString(val)
+			if !ok {
+				return attrs, fmt.Errorf(`Image alt=%s is dynamic; only static alt is supported`, formatNodeKind(val))
+			}
+			attrs.alt = s
+			attrs.hasAlt = true
+		case "width":
+			n, ok := literalIntish(val)
+			if !ok {
+				return attrs, fmt.Errorf("Image width must be a number literal")
+			}
+			attrs.width = n
+			attrs.hasW = true
+		case "height":
+			n, ok := literalIntish(val)
+			if !ok {
+				return attrs, fmt.Errorf("Image height must be a number literal")
+			}
+			attrs.height = n
+			attrs.hasH = true
+		case "eager", "priority":
+			b, ok := literalBool(val)
+			if !ok {
+				// Bare prop shorthand `<Image priority />` compiles to
+				// `priority: true` so the literal-bool path covers it.
+				return attrs, fmt.Errorf("Image %s must be a boolean literal", name)
+			}
+			if b {
+				attrs.priority = true
+			}
+		case "class":
+			s, ok := literalString(val)
+			if !ok {
+				return attrs, fmt.Errorf("Image class must be a static string (dynamic class= is not supported)")
+			}
+			attrs.classAttr = s
+			attrs.hasClass = true
+		case "sizes":
+			s, ok := literalString(val)
+			if !ok {
+				return attrs, fmt.Errorf("Image sizes must be a static string")
+			}
+			attrs.sizes = s
+			attrs.hasSizes = true
+		case "loading", "decoding":
+			// Honor explicit user override but require static.
+			s, ok := literalString(val)
+			if !ok {
+				return attrs, fmt.Errorf("Image %s must be a static string", name)
+			}
+			if name == "loading" && s == "eager" {
+				attrs.priority = true
+			}
+		default:
+			return attrs, fmt.Errorf("Image: unsupported attribute %q (supported: src, alt, width, height, sizes, class, eager, priority, loading, decoding)", name)
+		}
+	}
+	if attrs.src == "" {
+		return attrs, fmt.Errorf("Image is missing required src attribute")
+	}
+	return attrs, nil
+}
+
+// renderImageHTML builds the `<img>` open tag for the resolved variant
+// set. The fallback `src` always points at the largest variant so
+// non-srcset browsers see a real, full-resolution URL. width/height
+// fall back to the source's intrinsic dimensions when the user did not
+// supply them — keeping CLS-free rendering even when the template is
+// terse.
+func (i *imageInjector) renderImageHTML(call *Node, attrs imageAttrs) (string, error) {
+	res, ok := i.variants[attrs.src]
+	if !ok {
+		return "", fmt.Errorf("image lowering: <Image src=%q> at byte=%d not found in static/assets/ (build the variant set or check the path)", attrs.src, call.Start)
+	}
+	if len(res.Variants) == 0 {
+		return "", fmt.Errorf("image lowering: <Image src=%q> at byte=%d produced no variants", attrs.src, call.Start)
+	}
+	sorted := make([]images.Variant, len(res.Variants))
+	copy(sorted, res.Variants)
+	sort.Slice(sorted, func(a, b int) bool { return sorted[a].Width < sorted[b].Width })
+	fallback := sorted[len(sorted)-1]
+
+	width, height, hasW, hasH := attrs.width, attrs.height, attrs.hasW, attrs.hasH
+	if !hasW && res.IntrinsicWidth > 0 {
+		width = res.IntrinsicWidth
+		hasW = true
+	}
+	if !hasH && res.IntrinsicHeight > 0 {
+		height = res.IntrinsicHeight
+		hasH = true
+	}
+
+	loading := "lazy"
+	decoding := "async"
+	if attrs.priority {
+		loading = "eager"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(`<img src="`)
+	sb.WriteString(escapeAttrValue(fallback.URL))
+	sb.WriteString(`"`)
+	if len(sorted) > 1 {
+		sb.WriteString(` srcset="`)
+		for j, v := range sorted {
+			if j > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(escapeAttrValue(v.URL))
+			sb.WriteString(" ")
+			sb.WriteString(strconv.Itoa(v.Width))
+			sb.WriteString("w")
+		}
+		sb.WriteString(`"`)
+	}
+	if attrs.hasSizes {
+		sb.WriteString(` sizes="`)
+		sb.WriteString(escapeAttrValue(attrs.sizes))
+		sb.WriteString(`"`)
+	}
+	if hasW {
+		sb.WriteString(` width="`)
+		sb.WriteString(strconv.Itoa(width))
+		sb.WriteString(`"`)
+	}
+	if hasH {
+		sb.WriteString(` height="`)
+		sb.WriteString(strconv.Itoa(height))
+		sb.WriteString(`"`)
+	}
+	if attrs.hasAlt {
+		sb.WriteString(` alt="`)
+		sb.WriteString(escapeAttrValue(attrs.alt))
+		sb.WriteString(`"`)
+	} else {
+		// Always emit alt — empty alt is the correct a11y signal for a
+		// purely decorative image, and svelte/server defaults to that
+		// when the prop is absent. Matches the Mustache-Go behaviour.
+		sb.WriteString(` alt=""`)
+	}
+	if attrs.hasClass {
+		sb.WriteString(` class="`)
+		sb.WriteString(escapeAttrValue(attrs.classAttr))
+		sb.WriteString(`"`)
+	}
+	sb.WriteString(` loading="`)
+	sb.WriteString(loading)
+	sb.WriteString(`" decoding="`)
+	sb.WriteString(decoding)
+	sb.WriteString(`">`)
+	return sb.String(), nil
+}
+
+// literalString returns the cooked string value of a Literal node when
+// kind is litString. Returns ok=false for any other shape so callers
+// can surface a clear "dynamic value" error.
+func literalString(n *Node) (string, bool) {
+	if n == nil || n.Type != "Literal" || n.LitKind != litString {
+		return "", false
+	}
+	return n.LitStr, true
+}
+
+// literalIntish returns the integer value of a Literal node when kind
+// is litNumber and the value is a whole number. Decimal numbers are
+// rejected because HTML width/height attributes are integer-valued.
+func literalIntish(n *Node) (int, bool) {
+	if n == nil || n.Type != "Literal" || n.LitKind != litNumber {
+		return 0, false
+	}
+	if n.LitNum != float64(int(n.LitNum)) {
+		return 0, false
+	}
+	return int(n.LitNum), true
+}
+
+// literalBool returns the boolean value of a Literal node when kind is
+// litBool. The bare-prop shorthand `<Image priority />` compiles to
+// `priority: true` so litBool covers the common path.
+func literalBool(n *Node) (bool, bool) {
+	if n == nil || n.Type != "Literal" || n.LitKind != litBool {
+		return false, false
+	}
+	return n.LitBool, true
+}
+
+// formatNodeKind returns a short label describing n's structural shape.
+// Used when surfacing "src is dynamic" errors so the user sees what
+// kind of expression the template produced (Identifier, MemberExpression,
+// TemplateLiteral, …) instead of a raw "got nil" message.
+func formatNodeKind(n *Node) string {
+	if n == nil {
+		return "<nil>"
+	}
+	return n.Type
+}
+
+// escapeAttrValue HTML-escapes a value being written between double
+// quotes in an HTML attribute. Mirrors the Mustache-Go escaping rules
+// (& → &amp;, " → &quot;, < → &lt;, > → &gt;) so srcset/sizes/alt
+// produce identical bytes to the previous lowering. Single quotes are
+// safe inside double-quoted attributes.
+func escapeAttrValue(s string) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '&':
+			b.WriteString("&amp;")
+		case '"':
+			b.WriteString("&quot;")
+		case '<':
+			b.WriteString("&lt;")
+		case '>':
+			b.WriteString("&gt;")
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}

--- a/packages/sveltego/internal/codegen/svelte_js2go/lower_image.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/lower_image.go
@@ -1,6 +1,7 @@
 package sveltejs2go
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -86,22 +87,12 @@ func injectImage(root *Node, variants map[string]images.Result) error {
 	return joinErrors(inj.errs)
 }
 
-// joinErrors collapses multiple lowering errors into a single error
-// whose message lists each offender on its own line. The format mirrors
-// the [Lowerer.Err] output so build drivers can surface either kind
-// uniformly.
+// joinErrors collapses multiple lowering errors via errors.Join so each
+// offender is surfaced on its own line by the default Error() output.
+// Mirrors the [Lowerer.Err] convention so build drivers can format
+// either kind uniformly.
 func joinErrors(errs []error) error {
-	if len(errs) == 0 {
-		return nil
-	}
-	if len(errs) == 1 {
-		return errs[0]
-	}
-	parts := make([]string, 0, len(errs))
-	for _, e := range errs {
-		parts = append(parts, e.Error())
-	}
-	return fmt.Errorf("%s", strings.Join(parts, "\n"))
+	return errors.Join(errs...)
 }
 
 // collectImports walks Program.body looking for ImportDeclaration nodes
@@ -298,10 +289,10 @@ func (i *imageInjector) collectStaticAttrs(obj *Node) (imageAttrs, error) {
 			return attrs, fmt.Errorf("Image props: unsupported property kind %q (only static keys allowed)", p.Type)
 		}
 		if p.Computed {
-			return attrs, fmt.Errorf("Image props: computed property keys are not supported")
+			return attrs, errors.New("Image props: computed property keys are not supported")
 		}
 		if p.Key == nil || p.Key.Type != "Identifier" {
-			return attrs, fmt.Errorf("Image props: prop key must be a bare identifier")
+			return attrs, errors.New("Image props: prop key must be a bare identifier")
 		}
 		name := p.Key.Name
 		val := p.Value
@@ -322,14 +313,14 @@ func (i *imageInjector) collectStaticAttrs(obj *Node) (imageAttrs, error) {
 		case "width":
 			n, ok := literalIntish(val)
 			if !ok {
-				return attrs, fmt.Errorf("Image width must be a number literal")
+				return attrs, errors.New("Image width must be a number literal")
 			}
 			attrs.width = n
 			attrs.hasW = true
 		case "height":
 			n, ok := literalIntish(val)
 			if !ok {
-				return attrs, fmt.Errorf("Image height must be a number literal")
+				return attrs, errors.New("Image height must be a number literal")
 			}
 			attrs.height = n
 			attrs.hasH = true
@@ -346,14 +337,14 @@ func (i *imageInjector) collectStaticAttrs(obj *Node) (imageAttrs, error) {
 		case "class":
 			s, ok := literalString(val)
 			if !ok {
-				return attrs, fmt.Errorf("Image class must be a static string (dynamic class= is not supported)")
+				return attrs, errors.New("Image class must be a static string (dynamic class= is not supported)")
 			}
 			attrs.classAttr = s
 			attrs.hasClass = true
 		case "sizes":
 			s, ok := literalString(val)
 			if !ok {
-				return attrs, fmt.Errorf("Image sizes must be a static string")
+				return attrs, errors.New("Image sizes must be a static string")
 			}
 			attrs.sizes = s
 			attrs.hasSizes = true
@@ -371,7 +362,7 @@ func (i *imageInjector) collectStaticAttrs(obj *Node) (imageAttrs, error) {
 		}
 	}
 	if attrs.src == "" {
-		return attrs, fmt.Errorf("Image is missing required src attribute")
+		return attrs, errors.New("Image is missing required src attribute")
 	}
 	return attrs, nil
 }

--- a/packages/sveltego/internal/codegen/svelte_js2go/lower_image_test.go
+++ b/packages/sveltego/internal/codegen/svelte_js2go/lower_image_test.go
@@ -1,0 +1,454 @@
+package sveltejs2go
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/images"
+)
+
+// fakeImageVariants returns a [images.Result] map covering the fixture
+// images the tests reference. Mirrors the build-time pipeline output
+// shape so the lowering walks the same code path it would in
+// production.
+func fakeImageVariants() map[string]images.Result {
+	return map[string]images.Result{
+		"hero.png": {
+			Source:          "hero.png",
+			IntrinsicWidth:  1920,
+			IntrinsicHeight: 1080,
+			Variants: []images.Variant{
+				{Width: 320, Height: 180, URL: "/_app/immutable/assets/hero.abc12345.320.png"},
+				{Width: 640, Height: 360, URL: "/_app/immutable/assets/hero.abc12345.640.png"},
+				{Width: 1280, Height: 720, URL: "/_app/immutable/assets/hero.abc12345.1280.png"},
+				{Width: 1920, Height: 1080, URL: "/_app/immutable/assets/hero.abc12345.1920.png"},
+			},
+		},
+		"single.png": {
+			Source:          "single.png",
+			IntrinsicWidth:  200,
+			IntrinsicHeight: 100,
+			Variants: []images.Variant{
+				{Width: 200, Height: 100, URL: "/_app/immutable/assets/single.deadbeef.200.png"},
+			},
+		},
+		"needsescape.png": {
+			Source:          "needsescape.png",
+			IntrinsicWidth:  100,
+			IntrinsicHeight: 50,
+			Variants: []images.Variant{
+				{Width: 100, Height: 50, URL: "/_app/immutable/assets/needsescape&special.cafef00d.100.png"},
+			},
+		},
+	}
+}
+
+// imageImportNode builds the `import { Image } from "@sveltego/enhanced-img"`
+// declaration used by the test fixtures.
+func imageImportNode(local string) *Node {
+	return &Node{
+		Type: "ImportDeclaration",
+		Source: &Node{
+			Type:    "Literal",
+			LitKind: litString,
+			LitStr:  imageImportSource,
+		},
+		Specifiers: []*Node{
+			{
+				Type:     "ImportSpecifier",
+				Imported: ident("Image"),
+				Local:    ident(local),
+			},
+		},
+	}
+}
+
+// imageCall synthesises the Acorn shape svelte/server emits for a
+// `<Image …>` invocation: `Image($$renderer, { …props })`.
+func imageCall(local string, props ...[2]*Node) *Node {
+	pairs := make([]*Node, 0, len(props))
+	for _, p := range props {
+		pairs = append(pairs, &Node{Type: "Property", Key: p[0], Value: p[1], Kind: "init"})
+	}
+	return callStmt(
+		ident(local),
+		ident("$$renderer"),
+		&Node{Type: "ObjectExpression", Properties: pairs},
+	)
+}
+
+func TestInjectImage_BasicSrcset(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/hero.png")},
+				[2]*Node{ident("alt"), strLit("Hero")},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	got := string(out)
+
+	wants := []string{
+		`payload.Push("<img src=\"/_app/immutable/assets/hero.abc12345.1920.png\"`,
+		`srcset=\"/_app/immutable/assets/hero.abc12345.320.png 320w, /_app/immutable/assets/hero.abc12345.640.png 640w, /_app/immutable/assets/hero.abc12345.1280.png 1280w, /_app/immutable/assets/hero.abc12345.1920.png 1920w\"`,
+		`width=\"1920\"`,
+		`height=\"1080\"`,
+		`alt=\"Hero\"`,
+		`loading=\"lazy\" decoding=\"async\"`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("output missing %q\n--- got:\n%s", w, got)
+		}
+	}
+}
+
+func TestInjectImage_ExplicitWidthHeight(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/hero.png")},
+				[2]*Node{ident("alt"), strLit("Hero")},
+				[2]*Node{ident("width"), numLit(800)},
+				[2]*Node{ident("height"), numLit(450)},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `width=\"800\"`) {
+		t.Errorf("expected explicit width=800, got:\n%s", got)
+	}
+	if !strings.Contains(got, `height=\"450\"`) {
+		t.Errorf("expected explicit height=450, got:\n%s", got)
+	}
+}
+
+func TestInjectImage_SingleVariantNoSrcset(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/single.png")},
+				[2]*Node{ident("alt"), strLit("Solo")},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "srcset=") {
+		t.Errorf("single-variant image must NOT emit srcset, got:\n%s", got)
+	}
+	if !strings.Contains(got, "/single.deadbeef.200.png") {
+		t.Errorf("expected fallback src, got:\n%s", got)
+	}
+}
+
+func TestInjectImage_PriorityFlipsLoading(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/hero.png")},
+				[2]*Node{ident("alt"), strLit("Hero")},
+				[2]*Node{ident("priority"), boolLit(true)},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `loading=\"eager\"`) {
+		t.Errorf("priority must flip loading to eager, got:\n%s", got)
+	}
+}
+
+func TestInjectImage_AliasedImport(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Img",
+				[2]*Node{ident("src"), strLit("/single.png")},
+				[2]*Node{ident("alt"), strLit("Solo")},
+			),
+		),
+		imageImportNode("Img"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "/single.deadbeef.200.png") {
+		t.Errorf("aliased import must still substitute, got:\n%s", got)
+	}
+}
+
+func TestInjectImage_AttrEscaping(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/needsescape.png")},
+				[2]*Node{ident("alt"), strLit(`"quote" & <tag>`)},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `&amp;special`) {
+		t.Errorf("URL & must be HTML-escaped, got:\n%s", got)
+	}
+	if !strings.Contains(got, `&quot;quote&quot; &amp; &lt;tag&gt;`) {
+		t.Errorf("alt special chars must be HTML-escaped, got:\n%s", got)
+	}
+}
+
+func TestInjectImage_ClassAndSizes(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/hero.png")},
+				[2]*Node{ident("alt"), strLit("Hero")},
+				[2]*Node{ident("class"), strLit("rounded shadow-md")},
+				[2]*Node{ident("sizes"), strLit("(min-width: 768px) 50vw, 100vw")},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `class=\"rounded shadow-md\"`) {
+		t.Errorf("expected class attribute, got:\n%s", got)
+	}
+	if !strings.Contains(got, `sizes=\"(min-width: 768px) 50vw, 100vw\"`) {
+		t.Errorf("expected sizes attribute, got:\n%s", got)
+	}
+}
+
+func TestInjectImage_MissingVariantHardError(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/missing.png")},
+				[2]*Node{ident("alt"), strLit("oops")},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	_, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err == nil {
+		t.Fatalf("expected hard error for missing variant, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing.png") {
+		t.Errorf("error should name the missing source: %v", err)
+	}
+}
+
+func TestInjectImage_DynamicSrcHardError(t *testing.T) {
+	t.Parallel()
+	// `<Image src={data.hero}>` — src compiles to a MemberExpression,
+	// not a static literal. Reject so the user sees a clear opt-in
+	// path instead of a silent passthrough that omits the variant set.
+	root := buildProgramWithImports(
+		buildBlock(
+			propsDestructure("data"),
+			imageCall("Image",
+				[2]*Node{ident("src"), memExpr(ident("data"), ident("hero"))},
+				[2]*Node{ident("alt"), strLit("hero")},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	_, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err == nil {
+		t.Fatalf("expected hard error for dynamic src, got nil")
+	}
+	if !strings.Contains(err.Error(), "src") {
+		t.Errorf("error should name the dynamic prop: %v", err)
+	}
+}
+
+func TestInjectImage_MissingSrcHardError(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("alt"), strLit("oops")},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	_, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err == nil {
+		t.Fatalf("expected hard error for missing src, got nil")
+	}
+	if !strings.Contains(err.Error(), "src") {
+		t.Errorf("error should call out missing src: %v", err)
+	}
+}
+
+func TestInjectImage_NoVariantsMapNoOp(t *testing.T) {
+	t.Parallel()
+	// When ImageVariants is nil the pre-pass should not run and the
+	// import should still pass through to the unknownShape branch in
+	// recordImport (the existing behaviour for non-recognised imports).
+	// This test asserts the no-op shape, not the unknownShape outcome —
+	// the lowering is opt-in via Options.
+	root := buildProgramWithImports(
+		buildBlock(pushString("<p>no images here</p>")),
+	)
+	out, err := TranspileNode(root, "/test", Options{})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if !strings.Contains(string(out), `payload.Push("<p>no images here</p>")`) {
+		t.Errorf("expected baseline output preserved, got:\n%s", out)
+	}
+}
+
+func TestInjectImage_DropsImportFromAST(t *testing.T) {
+	t.Parallel()
+	// The pre-pass rewrites the @sveltego/enhanced-img import to an
+	// empty ExportNamedDeclaration so emitProgram's switch silently
+	// skips it instead of hitting unknownShape("import:..."). Without
+	// this the transpile would fail before lowering even runs.
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/single.png")},
+				[2]*Node{ident("alt"), strLit("Solo")},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if !strings.Contains(string(out), "/single.deadbeef.200.png") {
+		t.Errorf("expected lowered <img>, got:\n%s", out)
+	}
+}
+
+func TestInjectImage_InsideEachLoopAndIf(t *testing.T) {
+	t.Parallel()
+	// Image calls nested inside {#if} or {#each} bodies must still be
+	// rewritten — the walker covers every ESTree branch the emitter
+	// visits.
+	body := buildBlock(
+		ifStmt(
+			boolLit(true),
+			buildBlock(
+				imageCall("Image",
+					[2]*Node{ident("src"), strLit("/hero.png")},
+					[2]*Node{ident("alt"), strLit("Hero")},
+				),
+			),
+			nil,
+		),
+	)
+	root := buildProgramWithImports(body, imageImportNode("Image"))
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if !strings.Contains(string(out), "/_app/immutable/assets/hero.abc12345.1920.png") {
+		t.Errorf("expected nested Image to lower, got:\n%s", out)
+	}
+}
+
+func TestInjectImage_UnknownAttrHardError(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/single.png")},
+				[2]*Node{ident("alt"), strLit("Solo")},
+				[2]*Node{ident("draggable"), boolLit(false)},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	_, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err == nil {
+		t.Fatalf("expected hard error for unsupported attr, got nil")
+	}
+	if !strings.Contains(err.Error(), "draggable") {
+		t.Errorf("error should name the unsupported attr: %v", err)
+	}
+}
+
+func TestInjectImage_NoAltDefaultsEmpty(t *testing.T) {
+	t.Parallel()
+	root := buildProgramWithImports(
+		buildBlock(
+			imageCall("Image",
+				[2]*Node{ident("src"), strLit("/single.png")},
+			),
+		),
+		imageImportNode("Image"),
+	)
+	out, err := TranspileNode(root, "/test", Options{
+		ImageVariants: fakeImageVariants(),
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if !strings.Contains(string(out), `alt=\"\"`) {
+		t.Errorf("expected empty alt default, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Restores an SSR-transpile equivalent for the `<Image>` component deleted with the Mustache-Go pipeline (PR #486). Pure-Svelte authors that import `Image` from the reserved virtual module `@sveltego/enhanced-img` now see their per-route `Render()` emit a build-time-resolved multi-DPR `<img srcset=…>` shape — identical markup to what the previous Mustache-Go lowering produced.

## Architecture

Plan **B** from the scope check (post-compile JS AST pre-pass), per ADR 0009 grain:

- `injectImage` walks the Acorn output, recognises `Image($$renderer, { src, alt, … })` call expressions, looks up the build-time variant set in `internal/images.Build` results, and substitutes a `$$renderer.push(\"<img …>\")` so the existing emitter path renders the resolved bytes verbatim.
- Aliased imports (`import Img from \"@sveltego/enhanced-img\"`) and Image calls nested inside `{#if}` / `{#each}` bodies are both covered.

## Wiring

- `internal/codegen/imagescan.go` (resurrected from PR #486 git history) — scans every `.svelte` source for `<Image src=…>` literals; feeds the source list to `internal/images.Build`.
- `internal/codegen/ssr.go` — runs the scan + build once per `runSSRTranspile` invocation and threads the variant map into all three Transpile call sites (page / layout / error).
- `svelte_js2go/lower_image.go` — the AST pre-pass. Exposes `Options.ImageVariants`. Edits to `emitter.go` are 20 lines: the Options field + a guarded `injectImage` call inside `TranspileNode`. Isolated to avoid conflicts with parallel #493 CSRF work in the same package.

## Deferred (call out explicitly per scope-cut rule)

These are intentional gaps in this PR. Track as follow-up issues:

- **WebP / AVIF encoders** — out of scope per existing v1 image pipeline (`internal/images` ships JPEG/PNG only).
- **Dynamic `src={expr}`** — hard error, mirrors the old Mustache-Go behaviour. Build operators must inline the `src` literal.
- **Class / style directives on `<Image>`** — only static `class=\"…\"` and `sizes=\"…\"` pass through; dynamic forms hard-error.
- **`packages/enhanced-img/` Go API** — left as the existing pre-alpha stub. The `Image` element is framework-reserved virtual-module-only for now; no user-facing Go API is needed for this lowering.
- **Cloud transform back-ends** (Cloudflare Images, etc.) — out of scope.

## What this PR delivers

`<Image>` lowering for **static src + alt + width + height + sizes + class + priority/eager/loading**. Dynamic-src and WebP/AVIF deferred to follow-ups.

## Test fixtures

- `svelte_js2go/lower_image_test.go` — 15 cases: basic srcset, single variant (no srcset), explicit width/height, priority flips loading, aliased import, attr escaping (URL `&`, alt `<>` and `\"`), class+sizes pass-through, missing variant hard-error, dynamic src hard-error, missing src hard-error, no-variants no-op, import-drop, nested inside `{#if}`, unknown attr hard-error, default empty alt.
- `internal/codegen/imagescan_test.go` — 7 cases: dedup+sort across `src/routes/` and `src/lib/`, empty project short-circuit, dynamic-src skipped, full pipeline round-trip with a real 4×4 PNG, no-sources short-circuit, `ImageWidths` first-non-empty wins, all-empty returns nil.

## Verification commands

```
gofumpt -l .                                        # clean
goimports -l -local github.com/binsarjr/sveltego .  # clean
go vet ./packages/sveltego/... ./packages/enhanced-img/...
go test -race ./packages/sveltego/... ./packages/enhanced-img/...   # 1536 pass
go build ./...
```

Closes #492