### PR TITLE
feat(server): emit entry <script> at end of body, modulepreload in head

### DIFF
--- a/docs/render-modes.md
+++ b/docs/render-modes.md
@@ -166,6 +166,33 @@ src/routes/about/
 - **Mixing modes in a layout chain.** A layout's data flows into every child page regardless of mode. SSG children that read SSR-only layout fields fail at build time with a clear error.
 - **Authoring SPA + Static together.** Both result in the client doing the rendering work. Pick Static when the page has no server data (no `_page.server.go`); pick SPA (`SSR: false`) when the page has server data that should not be SSR'd.
 
+## App-shell template (`app.html`)
+
+Every sveltego app ships an `app.html` shell with two placeholders the runtime fills on every render:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>my app</title>
+  %sveltego.head%
+</head>
+<body>
+  %sveltego.body%
+</body>
+</html>
+```
+
+What expands where:
+
+- **`%sveltego.head%`** — head-belonging tags. Per-route stylesheet links and `<link rel="modulepreload">` hints so the browser can discover and parallel-fetch the chunks during HTML parse, plus any `<svelte:head>` content from the page and its layout chain (deduped `<title>`, meta tags, etc.).
+- **`%sveltego.body%`** — body content, expanded inline at the placeholder location, then the inline JSON hydration payload (`<script id="sveltego-data" type="application/json">…</script>`), then the per-route entry `<script type="module">`. The entry script lands at the **end of `<body>`** (just before `</body>`), matching SvelteKit's `%sveltekit.body%` convention. Putting the entry script after the SSR'd body lets the browser paint the page before any JS chunk executes (better LCP / FCP) and avoids hydration-timing races where modules try to mount markup the browser hasn't finished parsing.
+
+The `modulepreload` hints stay in `<head>` regardless — they are zero-execution, parse-time discovery only, and parallel-fetching the chunks during HTML parse is strictly faster than discovering them at end of body.
+
+For streaming (`kit.Streamed[T]` in a `Load` result) the order is the same: head + SSR body + payload first, then `<script>__sveltego__resolve(…)</script>` patches as each stream resolves, then the entry `<script type="module">` at end of body. The client glue queues incoming resolve calls until the entry module loads.
+
 ## adapter-static
 
 `packages/adapter-static` is currently a stub tracked by [#65](https://github.com/binsarjr/sveltego/issues/65). Until it lands, a static-output deploy ships the entire `Prerender: true` route set by running `sveltego build` and uploading the contents of the build's `static/` directory; the SSR Go binary is not needed if every route is `Prerender: true`. This is awkward but accurate — the prerender engine is live; the adapter wrapper is the missing piece.

--- a/packages/sveltego/server/hydration_test.go
+++ b/packages/sveltego/server/hydration_test.go
@@ -714,21 +714,34 @@ func TestStreaming_emitsViteAssetTags(t *testing.T) {
 		t.Errorf("body missing modulepreload tag for imported chunk %q; got:\n%s", preloadTag, bs)
 	}
 
-	// CSS link must precede page content (FOUC prevention) and the
-	// content must precede the resolve script (out-of-order patches
-	// arrive after first flush).
+	// CSS link must precede page content (FOUC prevention).
+	// Issue #521: the entry <script type="module"> now lands at end of
+	// body, AFTER the resolve patches. The client glue queues incoming
+	// resolve calls until the entry module loads.
 	contentIdx := strings.Index(bs, `<h1>shell</h1>`)
 	cssIdx := strings.Index(bs, cssTag)
 	jsIdx := strings.Index(bs, jsTag)
+	preloadIdx := strings.Index(bs, preloadTag)
 	resolveIdx := strings.Index(bs, `__sveltego__resolve(`)
-	if cssIdx < 0 || contentIdx < 0 || jsIdx < 0 || resolveIdx < 0 {
-		t.Fatalf("missing markers; css=%d content=%d js=%d resolve=%d", cssIdx, contentIdx, jsIdx, resolveIdx)
+	if cssIdx < 0 || contentIdx < 0 || jsIdx < 0 || resolveIdx < 0 || preloadIdx < 0 {
+		t.Fatalf("missing markers; css=%d content=%d js=%d preload=%d resolve=%d", cssIdx, contentIdx, jsIdx, preloadIdx, resolveIdx)
 	}
 	if cssIdx > contentIdx {
 		t.Errorf("CSS link must precede page content; css=%d content=%d", cssIdx, contentIdx)
 	}
-	if jsIdx > resolveIdx {
-		t.Errorf("module script must precede resolve patches; js=%d resolve=%d", jsIdx, resolveIdx)
+	// Issue #521: entry module script lives at end of body, not head.
+	headEnd := strings.Index(bs, `</head>`)
+	if headEnd < 0 {
+		t.Fatalf("missing </head> in body:\n%s", bs)
+	}
+	if jsIdx < headEnd {
+		t.Errorf("entry <script type=\"module\"> must be in body, not head; js=%d headEnd=%d", jsIdx, headEnd)
+	}
+	if preloadIdx > headEnd {
+		t.Errorf("modulepreload hint must stay in head; preload=%d headEnd=%d", preloadIdx, headEnd)
+	}
+	if jsIdx < resolveIdx {
+		t.Errorf("entry script must come AFTER resolve patches at end of body; js=%d resolve=%d", jsIdx, resolveIdx)
 	}
 }
 

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -726,7 +726,7 @@ func (s *Server) renderSvelteShell(r *http.Request, ev *kit.RequestEvent, route 
 
 	buf.WriteString(s.shellHead)
 	if route.ClientKey != "" {
-		if tags := s.viteManifest.assetTags(route.ClientKey, s.viteBase); tags != "" {
+		if tags := s.viteManifest.headAssetTags(route.ClientKey, s.viteBase); tags != "" {
 			buf.WriteString(tags)
 		}
 	}
@@ -738,6 +738,11 @@ func (s *Server) renderSvelteShell(r *http.Request, ev *kit.RequestEvent, route 
 		payload.Deps = lctx.CollectDeps()
 	}
 	s.emitPayloadScriptTag(buf, payload)
+	if route.ClientKey != "" {
+		if tag := s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase); tag != "" {
+			buf.WriteString(tag)
+		}
+	}
 	if s.serviceWorker != "" {
 		buf.WriteString(s.serviceWorker)
 	}
@@ -867,11 +872,15 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 		if lctx != nil {
 			payload.Deps = lctx.CollectDeps()
 		}
-		var assetTags string
+		var (
+			headAssetTags string
+			bodyEntryTag  string
+		)
 		if route.ClientKey != "" {
-			assetTags = s.viteManifest.assetTags(route.ClientKey, s.viteBase)
+			headAssetTags = s.viteManifest.headAssetTags(route.ClientKey, s.viteBase)
+			bodyEntryTag = s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase)
 		}
-		if err := s.renderStreaming(w, r, ev, inner, streams, status, headBytes, assetTags, payload); err != nil {
+		if err := s.renderStreaming(w, r, ev, inner, streams, status, headBytes, headAssetTags, bodyEntryTag, payload); err != nil {
 			if errors.Is(err, kit.ErrClientGone) {
 				return nil, errStreamingWrote
 			}
@@ -898,7 +907,7 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 		buf.WriteRaw(bytesAsString(headBytes))
 	}
 	if route != nil && route.ClientKey != "" {
-		if tags := s.viteManifest.assetTags(route.ClientKey, s.viteBase); tags != "" {
+		if tags := s.viteManifest.headAssetTags(route.ClientKey, s.viteBase); tags != "" {
 			buf.WriteString(tags)
 		}
 	}
@@ -912,6 +921,11 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 		payload.Deps = lctx.CollectDeps()
 	}
 	s.emitPayloadScriptTag(buf, payload)
+	if route != nil && route.ClientKey != "" {
+		if tag := s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase); tag != "" {
+			buf.WriteString(tag)
+		}
+	}
 	if s.serviceWorker != "" {
 		buf.WriteString(s.serviceWorker)
 	}
@@ -1058,11 +1072,19 @@ func isClientGone(ctx context.Context, err error) bool {
 // shellTail closes the document only after every stream resolves or
 // fails, so the response body is well-formed HTML even on timeout.
 //
+// headAssetTags carries the per-route stylesheet + modulepreload links
+// (head-belonging tags); bodyEntryTag carries the entry <script
+// type="module"> that lands at end of body just before the shell tail.
+// Splitting them matches SvelteKit's %sveltekit.head% / %sveltekit.body%
+// convention so the browser paints SSR HTML before any JS chunk
+// executes while still discovering the chunks during HTML parse via the
+// modulepreload hints.
+//
 // When a write fails because the client disconnected, renderStreaming
 // cancels any pending streams, logs once at debug level, and returns
 // kit.ErrClientGone. The caller must treat that as errStreamingWrote so
 // HandleError is not invoked — a disconnect is not a server fault.
-func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, inner func(*render.Writer) error, streams []streamedField, status int, headBytes []byte, assetTags string, payload clientPayload) error {
+func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, inner func(*render.Writer) error, streams []streamedField, status int, headBytes []byte, headAssetTags, bodyEntryTag string, payload clientPayload) error {
 	if ev.Cookies != nil {
 		ev.Cookies.Apply(w)
 	}
@@ -1078,8 +1100,8 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 	if len(headBytes) > 0 {
 		buf.WriteRaw(bytesAsString(headBytes))
 	}
-	if assetTags != "" {
-		buf.WriteString(assetTags)
+	if headAssetTags != "" {
+		buf.WriteString(headAssetTags)
 	}
 	buf.WriteString(s.shellMid)
 	if err := inner(buf); err != nil {
@@ -1124,6 +1146,9 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 		}
 	}
 
+	if bodyEntryTag != "" {
+		buf.WriteString(bodyEntryTag)
+	}
 	if s.serviceWorker != "" {
 		buf.WriteString(s.serviceWorker)
 	}

--- a/packages/sveltego/server/server.go
+++ b/packages/sveltego/server/server.go
@@ -95,9 +95,11 @@ type Config struct {
 	CronTasks []kit.CronTask
 	// ViteManifest is the JSON content of the Vite manifest produced by
 	// `vite build`. When non-empty the server parses it at startup and
-	// injects <script type="module"> and <link rel="modulepreload"> tags
-	// for the matching route chunk during SSR. Typically embedded in the
-	// binary so no runtime FS read is required.
+	// injects <link rel="modulepreload"> hints into <head> plus the
+	// per-route entry <script type="module"> at the end of <body> during
+	// SSR (#521; matches SvelteKit's %sveltekit.head% / %sveltekit.body%
+	// split). Typically embedded in the binary so no runtime FS read is
+	// required.
 	ViteManifest string
 	// ViteBase is the URL base path for Vite assets, e.g. "/static/_app".
 	// Defaults to "/static/_app" when ViteManifest is non-empty.

--- a/packages/sveltego/server/vite.go
+++ b/packages/sveltego/server/vite.go
@@ -47,20 +47,28 @@ func (m viteManifestMap) globalCSSFile() string {
 	return c.File
 }
 
-// assetTags returns the HTML fragment (script + modulepreload + stylesheet
-// tags) for routeKey. Returns an empty string when routeKey is not in the
+// headAssetTags returns the head-belonging HTML fragment for routeKey:
+// stylesheet links plus <link rel="modulepreload"> hints for every
+// transitive import. Returns an empty string when routeKey is not in the
 // manifest or when m is nil. When the manifest has a `src/app.css` entry
 // (Tailwind / PostCSS / global stylesheet path), its hashed file is
 // prepended as a <link rel="stylesheet"> so the global stylesheet loads
 // alongside route-scoped CSS.
-func (m viteManifestMap) assetTags(routeKey, base string) string {
+//
+// The entry <script type="module"> is intentionally NOT in this fragment
+// — see bodyEntryTag. End-of-body script placement matches SvelteKit's
+// %sveltekit.body% convention so the browser paints SSR HTML before any
+// JS chunk executes (better LCP, fewer hydration-timing races). The
+// modulepreload hints stay in <head> so the browser still discovers and
+// parallel-fetches the chunks during HTML parse.
+func (m viteManifestMap) headAssetTags(routeKey, base string) string {
 	if m == nil {
 		return ""
 	}
-	chunk, ok := m[routeKey]
-	if !ok {
+	if _, ok := m[routeKey]; !ok {
 		return ""
 	}
+	chunk := m[routeKey]
 	base = strings.TrimRight(base, "/")
 
 	var b strings.Builder
@@ -98,8 +106,31 @@ func (m viteManifestMap) assetTags(routeKey, base string) string {
 		b.WriteByte('\n')
 	}
 
+	return b.String()
+}
+
+// bodyEntryTag returns the per-route entry <script type="module"> tag for
+// routeKey, suitable for emission at the end of <body> just before the
+// shell tail. Returns an empty string when routeKey is not in the
+// manifest or when m is nil.
+//
+// Pairs with headAssetTags: the head fragment carries stylesheet + module
+// preload hints (parsed during the HEAD walk so the browser starts the
+// chunk fetches in parallel with HTML parsing); the body fragment carries
+// the entry script that consumes those preloaded chunks once the SSR
+// body has fully parsed.
+func (m viteManifestMap) bodyEntryTag(routeKey, base string) string {
+	if m == nil {
+		return ""
+	}
+	chunk, ok := m[routeKey]
+	if !ok {
+		return ""
+	}
+	base = strings.TrimRight(base, "/")
+
+	var b strings.Builder
 	fmt.Fprintf(&b, `<script type="module" src="%s/%s"></script>`, base, chunk.File)
 	b.WriteByte('\n')
-
 	return b.String()
 }

--- a/packages/sveltego/server/vite_test.go
+++ b/packages/sveltego/server/vite_test.go
@@ -1,8 +1,15 @@
 package server
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/render"
+	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
 )
 
 // TestAssetTags_GlobalCSSInjection pins the contract that an addon-emitted
@@ -33,22 +40,31 @@ func TestAssetTags_GlobalCSSInjection(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	tags := m.assetTags(".gen/client/routes/_page/entry.ts", "/_app")
+	headTags := m.headAssetTags(".gen/client/routes/_page/entry.ts", "/_app")
+	bodyTag := m.bodyEntryTag(".gen/client/routes/_page/entry.ts", "/_app")
 
 	for _, want := range []string{
 		`<link rel="stylesheet" href="/_app/assets/app-def.css">`,
 		`<link rel="stylesheet" href="/_app/assets/_page-xyz.css">`,
-		`<script type="module" src="/_app/assets/_page-abc.js">`,
 	} {
-		if !strings.Contains(tags, want) {
-			t.Errorf("assetTags missing %q; got:\n%s", want, tags)
+		if !strings.Contains(headTags, want) {
+			t.Errorf("headAssetTags missing %q; got:\n%s", want, headTags)
 		}
 	}
+	if !strings.Contains(bodyTag, `<script type="module" src="/_app/assets/_page-abc.js">`) {
+		t.Errorf("bodyEntryTag missing module script; got:\n%s", bodyTag)
+	}
 
-	globalIdx := strings.Index(tags, "app-def.css")
-	scopedIdx := strings.Index(tags, "_page-xyz.css")
+	// Issue #521: entry <script> must NOT live in head fragment so the
+	// browser paints body before any chunk executes.
+	if strings.Contains(headTags, `<script type="module"`) {
+		t.Errorf("headAssetTags must not include entry <script>; got:\n%s", headTags)
+	}
+
+	globalIdx := strings.Index(headTags, "app-def.css")
+	scopedIdx := strings.Index(headTags, "_page-xyz.css")
 	if globalIdx < 0 || scopedIdx < 0 || globalIdx > scopedIdx {
-		t.Errorf("global CSS must precede scoped CSS; global=%d scoped=%d\n%s", globalIdx, scopedIdx, tags)
+		t.Errorf("global CSS must precede scoped CSS; global=%d scoped=%d\n%s", globalIdx, scopedIdx, headTags)
 	}
 }
 
@@ -72,12 +88,134 @@ func TestAssetTags_NoGlobalCSSWhenAbsent(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	tags := m.assetTags(".gen/client/routes/_page/entry.ts", "/_app")
+	headTags := m.headAssetTags(".gen/client/routes/_page/entry.ts", "/_app")
+	bodyTag := m.bodyEntryTag(".gen/client/routes/_page/entry.ts", "/_app")
 
-	if strings.Contains(tags, "app-") {
-		t.Errorf("unexpected global CSS tag in no-addon build:\n%s", tags)
+	if strings.Contains(headTags, "app-") {
+		t.Errorf("unexpected global CSS tag in no-addon build:\n%s", headTags)
 	}
-	if !strings.Contains(tags, `<script type="module" src="/_app/assets/_page-abc.js">`) {
-		t.Errorf("missing module script tag:\n%s", tags)
+	if !strings.Contains(bodyTag, `<script type="module" src="/_app/assets/_page-abc.js">`) {
+		t.Errorf("missing module script tag in body fragment:\n%s", bodyTag)
+	}
+	if strings.Contains(headTags, `<script type="module"`) {
+		t.Errorf("entry script must not appear in head fragment; got:\n%s", headTags)
+	}
+}
+
+// TestRenderPage_entryScriptAtBodyEnd pins the issue #521 contract end-to-end:
+// the per-route entry <script type="module"> lands at end of <body>, not in
+// <head>. Modulepreload hints stay in <head> for parallel discovery, and the
+// inline JSON payload sits just before the entry script so the entry can
+// JSON.parse(document.getElementById('sveltego-data').textContent).
+func TestRenderPage_entryScriptAtBodyEnd(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `{
+		"src/routes/_page.svelte": {
+			"file": "_app/page-abc.js",
+			"css": ["_app/page-xyz.css"],
+			"imports": ["_shared"],
+			"isEntry": true
+		},
+		"_shared": {
+			"file": "_app/shared-def.js"
+		}
+	}`
+
+	srv, err := New(Config{
+		Routes: []router.Route{{
+			Pattern:   "/",
+			Segments:  []router.Segment{},
+			ClientKey: "src/routes/_page.svelte",
+			Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+				w.WriteString(`<main><h1>SSR'd content</h1></main>`)
+				return nil
+			},
+		}},
+		Shell:        testShell,
+		Logger:       quietLogger(),
+		ViteManifest: manifest,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, body)
+	}
+	bs := string(body)
+
+	headEnd := strings.Index(bs, `</head>`)
+	bodyOpen := strings.Index(bs, `<body>`)
+	bodyClose := strings.Index(bs, `</body>`)
+	if headEnd < 0 || bodyOpen < 0 || bodyClose < 0 {
+		t.Fatalf("missing structural markers; head=%d body=%d /body=%d in:\n%s", headEnd, bodyOpen, bodyClose, bs)
+	}
+
+	const entryScript = `<script type="module" src="/static/_app/_app/page-abc.js">`
+	const preloadHint = `<link rel="modulepreload" href="/static/_app/_app/shared-def.js">`
+	const cssHint = `<link rel="stylesheet" href="/static/_app/_app/page-xyz.css">`
+	const payloadTag = `<script id="sveltego-data" type="application/json">`
+	const renderedContent = `<main><h1>SSR'd content</h1></main>`
+
+	entryIdx := strings.Index(bs, entryScript)
+	preloadIdx := strings.Index(bs, preloadHint)
+	cssIdx := strings.Index(bs, cssHint)
+	payloadIdx := strings.Index(bs, payloadTag)
+	contentIdx := strings.Index(bs, renderedContent)
+
+	if entryIdx < 0 {
+		t.Fatalf("entry script %q not found:\n%s", entryScript, bs)
+	}
+	if preloadIdx < 0 {
+		t.Fatalf("modulepreload hint %q not found:\n%s", preloadHint, bs)
+	}
+	if cssIdx < 0 {
+		t.Fatalf("css link %q not found:\n%s", cssHint, bs)
+	}
+	if payloadIdx < 0 {
+		t.Fatalf("payload tag %q not found:\n%s", payloadTag, bs)
+	}
+	if contentIdx < 0 {
+		t.Fatalf("rendered content %q not found:\n%s", renderedContent, bs)
+	}
+
+	// Issue #521 acceptance criteria:
+	// 1. Entry <script type="module"> lands in <body>, not <head>.
+	if entryIdx < headEnd {
+		t.Errorf("entry script must be in body, not head; entry=%d </head>=%d", entryIdx, headEnd)
+	}
+	if entryIdx > bodyClose {
+		t.Errorf("entry script must precede </body>; entry=%d </body>=%d", entryIdx, bodyClose)
+	}
+
+	// 2. <link rel="modulepreload"> hints stay in <head>.
+	if preloadIdx > headEnd {
+		t.Errorf("modulepreload hint must stay in head; preload=%d </head>=%d", preloadIdx, headEnd)
+	}
+	// Stylesheet links also belong in <head>.
+	if cssIdx > headEnd {
+		t.Errorf("css link must stay in head; css=%d </head>=%d", cssIdx, headEnd)
+	}
+
+	// 3. Payload tag sits just before the entry script (so JSON.parse works).
+	if payloadIdx > entryIdx {
+		t.Errorf("payload tag must precede entry script; payload=%d entry=%d", payloadIdx, entryIdx)
+	}
+	if payloadIdx < contentIdx {
+		t.Errorf("payload tag must come AFTER SSR'd content; payload=%d content=%d", payloadIdx, contentIdx)
+	}
+	// 4. SSR'd content comes before payload + entry script.
+	if contentIdx > entryIdx {
+		t.Errorf("SSR'd content must precede entry script; content=%d entry=%d", contentIdx, entryIdx)
 	}
 }


### PR DESCRIPTION
## Summary

Splits per-route Vite asset injection into two fragments matching SvelteKit's `%sveltekit.head%` / `%sveltekit.body%` convention:

- `headAssetTags` — `<link rel="modulepreload">` hints + stylesheet links so the browser still discovers and parallel-fetches chunks during HTML parse.
- `bodyEntryTag` — the entry `<script type="module">`, lands at end of `<body>` (just before the shell tail) so the browser paints SSR'd content before any JS chunk executes.

The inline `<script id="sveltego-data" type="application/json">` payload sits just before the entry script so the entry can `JSON.parse(document.getElementById('sveltego-data').textContent)`.

All three render paths updated:
- `renderPage` (legacy SSR, non-streaming)
- `renderSvelteShell` (Templates=svelte / SPA-mode)
- `renderStreaming` (emits entry script after the resolve patches at end of body)

Closes #521.

## Reproduction

```bash
cd /path/to/sveltego-dummy
SVELTEGO_REPO=<this-repo> bash setup.sh && bash run-all.sh
curl -s http://localhost:8085/ | python3 -c "
import sys, re
h = sys.stdin.read()
body = re.search(r'<body[^>]*>(.*?)</body>', h, re.S).group(1)
head = re.search(r'<head[^>]*>(.*?)</head>', h, re.S).group(1)
assert '<script type=\"module\"' in body, 'entry script not found in body'
assert '<script type=\"module\"' not in head, 'entry script still in head'
assert 'modulepreload' in head, 'modulepreload not in head'
print('OK: script at body-end, modulepreload in head')
"
```

Verified against all 5 sub-apps (ssr/ssg/spa/static/kitchen-sink) plus 6 kitchen-sink sub-routes covering SSR, SPA-mode, prerendered SSG, form actions, catch-all params, and snapshot routes.

## Acceptance criteria

- [x] Generated HTML places per-route entry `<script type="module">` at end of `<body>`, not in `<head>`.
- [x] `<link rel="modulepreload">` hints remain in `<head>` for parallel discovery.
- [x] Inline JSON payload sits just before the entry script in body.
- [x] All 5 sub-apps build and serve all routes correctly.
- [x] No new hydration mismatches (visual smoke + payload tag still emitted before any resolve patches in streaming).
- [x] App-shell template `app.html` placeholder semantics unchanged from the user's perspective — `%sveltego.head%` still expands to head-belonging tags; `%sveltego.body%` continues to expand to inline body content + payload + entry script. No new placeholder introduced; existing user `app.html` files keep working.
- [x] Documentation updated in `docs/render-modes.md` (new "App-shell template" section).

## Test plan

- [x] `go test -race ./packages/sveltego/...` (1620 tests pass)
- [x] `gofumpt -l .` / `goimports -l` / `go vet ./...` clean
- [x] New unit test `TestRenderPage_entryScriptAtBodyEnd` pins shape end-to-end
- [x] `TestStreaming_emitsViteAssetTags` updated: entry script must come AFTER resolve patches and live in body, modulepreload stays in head
- [x] `TestAssetTags_*` split into head/body fragment assertions
- [x] kitchen-sink E2E repro passes across all 5 sub-apps and all routes