### PR TITLE
fix(server): emit csrfToken on hydration payload (#523)

### DIFF
--- a/packages/sveltego/server/csrf_inject_integration_test.go
+++ b/packages/sveltego/server/csrf_inject_integration_test.go
@@ -114,6 +114,61 @@ func TestCSRFInject_FallbackPathInjectsHiddenInput(t *testing.T) {
 	}
 }
 
+// TestCSRFInject_HydrationPayloadIncludesCSRFToken covers issue #523: the
+// JSON hydration payload shipped to the client must carry the per-request
+// `csrfToken` so the post-mount splicer in entry.ts can re-add the hidden
+// input whenever Svelte 5 hydration strips it (typical on ssr-fallback
+// routes whose source `.svelte` lacks the input in its vDOM). Without
+// this field, `__sveltego_csrf__()` early-returns and the form submits
+// without `_csrf_token`, triggering 403 forbidden.
+func TestCSRFInject_HydrationPayloadIncludesCSRFToken(t *testing.T) {
+	t.Parallel()
+	actions := kit.ActionMap{
+		"login": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionDataResult(200, "ok")
+		},
+	}
+	opts := kit.DefaultPageOptions()
+	opts.Templates = ""
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     fallbackInjectedPage(),
+		Actions:  func() any { return actions },
+		Options:  opts,
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/login")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	var cookieToken string
+	for _, c := range resp.Cookies() {
+		if c.Name == "_csrf" {
+			cookieToken = c.Value
+			break
+		}
+	}
+	if cookieToken == "" {
+		t.Fatalf("expected _csrf cookie on GET; got cookies=%v", resp.Cookies())
+	}
+
+	// The hydration payload script tag must carry "csrfToken":"<value>"
+	// so client entry.ts has something to splice back in after Svelte
+	// hydration strips the SSR-injected hidden input. The value must
+	// match the `_csrf` cookie so a POST sent with that hidden field
+	// passes the double-submit check.
+	want := `"csrfToken":"` + cookieToken + `"`
+	if !strings.Contains(string(body), want) {
+		t.Fatalf("hydration payload missing %q; body=\n%s", want, body)
+	}
+}
+
 // TestCSRFInject_FallbackPathSkipsGetForm asserts the same renderFallback
 // shape leaves GET forms alone — the runtime rewriter gates on method
 // just like the build-time pass.

--- a/packages/sveltego/server/payload_writer.go
+++ b/packages/sveltego/server/payload_writer.go
@@ -185,6 +185,19 @@ func (s *Server) writePayloadJSON(dst *bytes.Buffer, p clientPayload) error {
 		}
 	}
 
+	// CSRFToken sits between AppVersion and VersionPoll to mirror the
+	// clientPayload struct's declaration order so writePayloadJSON stays
+	// byte-identical to encoding/json's output (asserted by
+	// TestWritePayloadByteIdenticalToJSONMarshal). Empty token is
+	// omitted to match the json:"csrfToken,omitempty" tag — routes that
+	// opt out of CSRF (or routes without Actions) leave the field blank.
+	if p.CSRFToken != "" {
+		dst.WriteString(`,"csrfToken":`)
+		if err := encodeJSONString(dst, p.CSRFToken); err != nil {
+			return fmt.Errorf("marshal csrfToken: %w", err)
+		}
+	}
+
 	if p.VersionPoll != nil {
 		if len(s.encodedVersionPoll) > 0 {
 			dst.Write(s.encodedVersionPoll)

--- a/packages/sveltego/server/payload_writer_test.go
+++ b/packages/sveltego/server/payload_writer_test.go
@@ -124,6 +124,42 @@ func TestWritePayloadByteIdenticalToJSONMarshal(t *testing.T) {
 				Status:  200,
 			},
 		},
+		{
+			// CSRFToken populated covers the per-request token field the
+			// CSRF auto-inject contract (#510 / #523) ships to the client
+			// so the post-mount splicer can re-add the hidden input that
+			// Svelte 5 hydration would otherwise strip on ssr-fallback
+			// routes whose source `.svelte` lacks the input in its vDOM.
+			name: "csrf-token-set",
+			payload: clientPayload{
+				RouteID:   "/login",
+				Data:      map[string]any{},
+				URL:       "https://example.test/login",
+				Params:    map[string]string{},
+				Status:    200,
+				CSRFToken: "abc123-token-with-dashes_and-underscores",
+			},
+		},
+		{
+			// CSRFToken alongside AppVersion + VersionPoll pins the
+			// relative emit order so the splice writer keeps matching
+			// encoding/json's struct-declaration ordering (CSRFToken
+			// sits between AppVersion and VersionPoll in clientPayload).
+			name: "csrf-token-with-app-version-and-poll",
+			payload: clientPayload{
+				RouteID:    "/post/[id]",
+				Data:       loadShape{Title: "hi", Count: 7},
+				URL:        "https://example.test/post/42",
+				Params:     map[string]string{"id": "42"},
+				Status:     200,
+				Manifest:   srv.clientManifest,
+				AppVersion: "abc123",
+				CSRFToken:  "tok-xyz",
+				VersionPoll: &clientVersionPoll{
+					IntervalMS: 30000,
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Closes #523. Refs #510 / PR #513 / PR #517.

## Approach

The cleanest fix turned out to be much smaller than the issue's spike order suggested. Diagnosis with the kitchen-sink `/login` repro showed the SSR HTML *did* carry the hidden `_csrf_token` input (sidecar + `csrfinject.Rewrite`), Svelte 5 hydration stripped it (vDOM mismatch — wrapper imports the user's source `.svelte` which has no input), and the post-mount splicer `__sveltego_csrf__()` from #513 was *supposed* to re-add it from `payload.csrfToken`. Instrumenting `buildClientPayload` showed `p.CSRFToken` was set correctly. But `writePayloadJSON` (the byte-stable splice writer in `payload_writer.go`) never wrote the field — it pre-dated the `CSRFToken` addition on `clientPayload` and was simply missing the case. Result: `payload.csrfToken` was `undefined` client-side, the splicer hit `if (!t) return;` and bailed.

Fix is one if-block in `writePayloadJSON`, positioned between AppVersion and VersionPoll to match the `clientPayload` struct's declaration order so the byte-identity test against `encoding/json` keeps passing. No source-level Svelte AST splice and no new wrapper-level effect were needed; the existing client splicer just needed the data it was already wired to consume.

## Files touched

- `packages/sveltego/server/payload_writer.go` — write `csrfToken` in `writePayloadJSON`.
- `packages/sveltego/server/payload_writer_test.go` — two new cases: csrfToken alone, csrfToken alongside AppVersion+VersionPoll (pins emit ordering).
- `packages/sveltego/server/csrf_inject_integration_test.go` — new `TestCSRFInject_HydrationPayloadIncludesCSRFToken` regression test that hits the full server pipeline and asserts `"csrfToken":"<cookie value>"` lands in the rendered HTML.

## Acceptance criteria

- [x] On `/login` (ssr-fallback route), the form's hidden `_csrf_token` input is present in the DOM after hydration completes (verified via DevTools console on `localhost:8085/login` — `inputs: ["_csrf_token","username","password"]`).
- [x] Browser POST without manually adding the field returns 200, not 403 (verified end-to-end: typed credentials, clicked the actual `<button class="primary">`, page navigated to `?/login` and rendered "Welcome, admin").
- [x] Token value matches the `_csrf` cookie value (verified by `tokenMatchesInput: true` and by the new integration test's exact-string match against `cookieToken`).
- [x] No regression on routes whose SSR is the build-time transpile path. The build-time AST splice in `lower_csrf.go` already bakes the token into the SSR template HTML; the client vDOM matches, no strip happens. Independent of this change. `playgrounds/dashboard/src/routes/login/_page.svelte` (transpile path) builds and tests still pass.
- [x] No regression on `SSR=false` SPA-only POST forms (path 3). Same `__sveltego_csrf__()` runs on every per-route entry; previously it bailed for *all* paths because the payload field was missing — this fix universally enables it.
- [x] Existing `runtime/svelte/csrfinject` integration tests stay green (3 tests in the file, all pass).

## Test plan

- [x] `go test -race ./packages/sveltego/...` — 1630 passed (was 1629; +1 new integration test).
- [x] `go test -race ./packages/auth/... ./packages/cookiesession/... ./packages/lsp/... ./packages/mcp/... ./packages/init/... ./packages/enhanced-img/...` — 207 passed.
- [x] `go test -race ./bench/... ./benchmarks/... ./packages/adapter-*/...` — 91 passed.
- [x] `gofumpt -l .` clean.
- [x] `goimports -l -local github.com/binsarjr/sveltego .` clean.
- [x] `go vet ./packages/sveltego/...` clean.
- [x] `go build ./bench/... ./benchmarks/... ./packages/... ./playgrounds/... ./templates/...` clean.
- [x] E2E browser repro on kitchen-sink `/login` — hidden input present after hydration, button click submit returns 200, "Welcome, admin" renders.
- [ ] CI green.