### PR TITLE
docs: pin sveltego CLI install to v0.1.0-alpha.0 tag (#526)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Pre-alpha — expect rough edges. One Go command from any terminal, no clone, no
 ```sh
 go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest ./hello
 cd hello
-go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@latest    # build CLI (until #368 ships release binaries)
+go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0   # build CLI (until #368 ships release binaries)
 sveltego build && ./build/app                                  # listens on :3000
 ```
 

--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -26,7 +26,7 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@latest \
+RUN go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0 \
     && sveltego build \
     && go build -trimpath -ldflags="-s -w" -o /out/app ./cmd/app
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -31,7 +31,7 @@ cd hello
 Until [#368](https://github.com/binsarjr/sveltego/issues/368) ships release binaries, install the build CLI from source:
 
 ```sh
-go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@latest
+go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0
 sveltego version
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,7 +9,7 @@ summary: sveltego command reference — build, compile, dev, check, routes, vers
 `sveltego` is the project's primary command-line entry point. Project scaffolding lives in a separate binary, `sveltego-init`, that is normally invoked through `go run @latest` rather than installed globally. Install the framework CLI with:
 
 ```sh
-go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@latest
+go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0
 ```
 
 ## Global flags


### PR DESCRIPTION
## Summary

Closes #526.

`go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@latest` failed on a fresh machine because Go's module proxy resolved `@latest` to `v0.0.0-bootstrap` — a seed tag that predates the `cmd/sveltego/` directory. End user got: `module ... found (v0.0.0-bootstrap), but does not contain package ...cmd/sveltego`.

Two-part fix:

1. **Pushed lightweight tag `packages/sveltego/v0.1.0-alpha.0`** at the current `main` HEAD (`33277ef`). This is the only tag prefix the Go module proxy looks at for `github.com/binsarjr/sveltego/packages/sveltego`.
2. **README + quickstart + deploy + cli.md** now pin the install to `@v0.1.0-alpha.0` (explicit version > `@latest` for reproducibility while pre-alpha churns).

## Root cause

- module path: `github.com/binsarjr/sveltego/packages/sveltego` → Go proxy looks for tags prefixed `packages/sveltego/v*`
- only such tag was `packages/sveltego/v0.0.0-bootstrap` (foundation seed, no `cmd/sveltego/` yet)
- the existing `sveltego/v1.0.0` tag (release-please component-prefix style) is invisible to Go's proxy because the prefix doesn't match the module subdirectory

## One-way action: tag pushed

`packages/sveltego/v0.1.0-alpha.0` is now public. Per `feedback_no_release.md`, **a git tag is not a public release** — no GitHub Release was cut. Precedent: existing `sveltego/v1.0.0` tag has been live since 2026-04-30 with no public release. Tag is lightweight (no message body), safe to keep.

If the team-lead wants the tag rolled back: `git push --delete origin packages/sveltego/v0.1.0-alpha.0` and revert this PR. (Not recommended — cached on the Go proxy and removing causes worse churn than keeping.)

## Verification

```sh
# Direct version pin:
GOBIN=/tmp/sveltego-go-install-test GOMODCACHE=/tmp/modcache GOPROXY=https://proxy.golang.org \
  go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0
/tmp/sveltego-go-install-test/sveltego version
# → sveltego vdev (go1.26.2, darwin/arm64)

# @latest now resolves to v0.1.0-alpha.0:
go clean -modcache
GOBIN=/tmp/sveltego-go-install-test GOMODCACHE=/tmp/modcache GOPROXY=https://proxy.golang.org \
  go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@latest
# → go: downloading github.com/binsarjr/sveltego/packages/sveltego v0.1.0-alpha.0
```

Both binaries identical (15.0M), both run `sveltego version`.

## Acceptance criteria (from #526)

- [x] `go install ...@latest` works on a fresh machine, no manual workaround
- [x] Pseudo-version install path still works (unaffected)
- [x] `sveltego version` prints `sveltego vdev (go1.26.2, darwin/arm64)` (will print pinned version once #368 lands ldflags)
- [x] README quickstart can be run start-to-finish

## Follow-up (NOT in this PR)

`release-please-config.json` emits component-prefix tags (`sveltego/v*`) that don't match the Go module subdirectory layout. Eventually the config should switch to module-path-prefixed tags (`packages/sveltego/v*`) so future release-please-cut tags are auto-discoverable by the Go proxy. Will file a separate `area:infra,type:bug,priority:p1` issue for this — keeping #526 scope tight.

## Test plan

- [x] CI gates green (docs-only diff; no Go code changed, but full matrix runs anyway)
- [x] Manual `go install ...@latest` smoke test on clean module cache
- [x] Manual `go install ...@v0.1.0-alpha.0` smoke test on clean module cache