### PR TITLE
fix(cli): auto-install sidecar npm deps on first use (#525)

### DIFF
--- a/packages/sveltego/internal/codegen/svelterender/sidecardeps.go
+++ b/packages/sveltego/internal/codegen/svelterender/sidecardeps.go
@@ -72,13 +72,13 @@ func EnsureSidecarDeps(srcDir string) (string, error) {
 	}
 
 	if err := materializeSidecar(srcDir, cacheDir); err != nil {
-		return "", fmt.Errorf("%w: copy sidecar to %s: %v", errSidecarDepsInstall, cacheDir, err)
+		return "", fmt.Errorf("%w (copy sidecar to %s): %w", errSidecarDepsInstall, cacheDir, err)
 	}
 	if err := runNPMInstall(cacheDir); err != nil {
-		return "", fmt.Errorf("%w: %v", errSidecarDepsInstall, err)
+		return "", fmt.Errorf("%w: %w", errSidecarDepsInstall, err)
 	}
 	if _, err := os.Stat(filepath.Join(cacheDir, "node_modules", "acorn")); err != nil {
-		return "", fmt.Errorf("%w: install completed but node_modules/acorn missing at %s: %v",
+		return "", fmt.Errorf("%w (install completed but node_modules/acorn missing at %s): %w",
 			errSidecarDepsInstall, cacheDir, err)
 	}
 	return cacheDir, nil
@@ -95,7 +95,7 @@ func sidecarCacheDir(srcDir string) (string, error) {
 	}
 	base, err := os.UserCacheDir()
 	if err != nil {
-		return "", fmt.Errorf("%w: os.UserCacheDir: %v", errSidecarUnwritableCache, err)
+		return "", fmt.Errorf("%w (os.UserCacheDir): %w", errSidecarUnwritableCache, err)
 	}
 	dir := filepath.Join(base, "sveltego", "sidecar", hash)
 	return dir, nil
@@ -199,8 +199,8 @@ func runNPMInstall(dir string) error {
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("`npm %s` in %s failed: %v; output: %s",
-			strings.Join(args, " "), dir, err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("`npm %s` in %s failed (output: %s): %w",
+			strings.Join(args, " "), dir, strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }

--- a/packages/sveltego/internal/codegen/svelterender/sidecardeps.go
+++ b/packages/sveltego/internal/codegen/svelterender/sidecardeps.go
@@ -1,0 +1,206 @@
+package svelterender
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// errSidecarDepsInstall is returned when EnsureSidecarDeps cannot
+// produce a usable sidecar tree — npm is missing, the install crashed,
+// or the cache directory is unwritable. Wrapped via %w so callers can
+// surface a uniform "install Node + npm; check $XDG_CACHE_HOME" hint.
+var errSidecarDepsInstall = errors.New("svelterender: sidecar deps install failed")
+
+// errSidecarUnwritableCache is returned when neither the source sidecar
+// dir nor the user cache dir can host a node_modules tree.
+var errSidecarUnwritableCache = errors.New("svelterender: no writable location for sidecar node_modules")
+
+// EnsureSidecarDeps returns a directory containing the sidecar tree
+// (index.mjs and friends) plus a populated node_modules. When the
+// source sidecar dir is writable AND already has node_modules, it is
+// returned as-is — the existing dev workflow (repo checkout + manual
+// `npm install`) is preserved.
+//
+// Otherwise the function materializes a copy of the sidecar tree under
+// $XDG_CACHE_HOME/sveltego/sidecar/<hash>/ keyed by the SHA-256 of
+// (package.json + package-lock.json), runs `npm ci` (or `npm install`
+// when no lockfile exists) in the cache copy, and returns that path.
+// Subsequent calls with an unchanged lockfile reuse the populated
+// cache.
+//
+// This is the fix for issue #525: when sveltego is installed via
+// `go install`, the sidecar lives under the read-only Go module cache
+// and cannot host a node_modules tree itself.
+func EnsureSidecarDeps(srcDir string) (string, error) {
+	if srcDir == "" {
+		return "", errors.New("svelterender: EnsureSidecarDeps: srcDir is empty")
+	}
+	if _, err := os.Stat(filepath.Join(srcDir, "index.mjs")); err != nil {
+		return "", fmt.Errorf("svelterender: sidecar entry missing at %s: %w", srcDir, err)
+	}
+
+	// Fast path: source dir already has node_modules (dev workflow on a
+	// writable repo checkout). Stat is sufficient — we don't validate
+	// the contents because the original behaviour also trusted a bare
+	// stat of node_modules/acorn.
+	if _, err := os.Stat(filepath.Join(srcDir, "node_modules", "acorn")); err == nil {
+		return srcDir, nil
+	}
+
+	cacheDir, err := sidecarCacheDir(srcDir)
+	if err != nil {
+		return "", err
+	}
+	// If a previous invocation already materialized this version, reuse
+	// it. The hash is over package.json + package-lock.json so any pin
+	// bump invalidates the cache automatically.
+	if _, err := os.Stat(filepath.Join(cacheDir, "node_modules", "acorn")); err == nil {
+		return cacheDir, nil
+	}
+
+	if _, err := exec.LookPath("npm"); err != nil {
+		return "", fmt.Errorf("%w: npm binary not on $PATH; install Node 20.6+ (which ships npm) so sveltego can bootstrap the sidecar at %s",
+			errSidecarDepsInstall, cacheDir)
+	}
+
+	if err := materializeSidecar(srcDir, cacheDir); err != nil {
+		return "", fmt.Errorf("%w: copy sidecar to %s: %v", errSidecarDepsInstall, cacheDir, err)
+	}
+	if err := runNPMInstall(cacheDir); err != nil {
+		return "", fmt.Errorf("%w: %v", errSidecarDepsInstall, err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "node_modules", "acorn")); err != nil {
+		return "", fmt.Errorf("%w: install completed but node_modules/acorn missing at %s: %v",
+			errSidecarDepsInstall, cacheDir, err)
+	}
+	return cacheDir, nil
+}
+
+// sidecarCacheDir returns the directory the auto-installed sidecar tree
+// should live in. Path is $XDG_CACHE_HOME/sveltego/sidecar/<hash>/ where
+// hash covers package.json + package-lock.json so a dependency pin bump
+// invalidates the cache automatically.
+func sidecarCacheDir(srcDir string) (string, error) {
+	hash, err := lockHash(srcDir)
+	if err != nil {
+		return "", err
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("%w: os.UserCacheDir: %v", errSidecarUnwritableCache, err)
+	}
+	dir := filepath.Join(base, "sveltego", "sidecar", hash)
+	return dir, nil
+}
+
+// lockHash returns the SHA-256 hex digest of (package.json bytes +
+// package-lock.json bytes when present). Truncated to 16 hex chars to
+// keep the cache path short on filesystems with sun_path limits.
+func lockHash(srcDir string) (string, error) {
+	h := sha256.New()
+	pkg, err := os.ReadFile(filepath.Join(srcDir, "package.json"))
+	if err != nil {
+		return "", fmt.Errorf("svelterender: read package.json: %w", err)
+	}
+	h.Write(pkg)
+	if lock, err := os.ReadFile(filepath.Join(srcDir, "package-lock.json")); err == nil {
+		h.Write(lock)
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16], nil
+}
+
+// materializeSidecar copies the sidecar source tree (everything except
+// node_modules and any stray .gen/ files) from srcDir to dstDir. The
+// destination is created with 0o755; files keep their source mode bits.
+// An existing dstDir is left in place; conflicting files are overwritten
+// so a half-finished previous run doesn't poison the cache.
+func materializeSidecar(srcDir, dstDir string) error {
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return err
+	}
+	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		// Skip node_modules and dotfile-prefixed entries. A developer
+		// box may have node_modules from an in-place `npm install`, and
+		// the test suite drops `.sveltego-fallback-*` scratch dirs in
+		// the same tree; neither should pollute the cache copy. The
+		// cache's own npm install populates a fresh node_modules.
+		first, _, _ := strings.Cut(rel, string(filepath.Separator))
+		if first == "node_modules" || strings.HasPrefix(first, ".") {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		dst := filepath.Join(dstDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dst, 0o755)
+		}
+		return copyFile(path, dst)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// runNPMInstall runs `npm ci` in dir when a package-lock.json is
+// present; otherwise falls back to `npm install`. Both invocations use
+// `--omit=dev --no-audit --no-fund --no-progress` to keep the install
+// quiet and small. stderr is captured and surfaced when the command
+// fails so users see the real npm error, not a generic exit-code message.
+func runNPMInstall(dir string) error {
+	args := []string{"install", "--omit=dev", "--no-audit", "--no-fund", "--no-progress"}
+	if _, err := os.Stat(filepath.Join(dir, "package-lock.json")); err == nil {
+		args = []string{"ci", "--omit=dev", "--no-audit", "--no-fund", "--no-progress"}
+	}
+	//nolint:gosec // npm path resolved by exec.LookPath; args are static
+	cmd := exec.Command("npm", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"NODE_NO_WARNINGS=1",
+		"npm_config_fund=false",
+		"npm_config_audit=false",
+		"npm_config_update_notifier=false",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("`npm %s` in %s failed: %v; output: %s",
+			strings.Join(args, " "), dir, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/packages/sveltego/internal/codegen/svelterender/sidecardeps_test.go
+++ b/packages/sveltego/internal/codegen/svelterender/sidecardeps_test.go
@@ -1,0 +1,129 @@
+package svelterender
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEnsureSidecarDeps_FastPathWritableSource verifies the back-compat
+// fast path: when the source dir already has node_modules/acorn, it is
+// returned as-is and no cache materialization happens. This protects
+// the existing dev-from-checkout workflow.
+func TestEnsureSidecarDeps_FastPathWritableSource(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "index.mjs"), "// stub")
+	mustWrite(t, filepath.Join(src, "package.json"), `{"name":"stub","version":"0.0.0"}`)
+	if err := os.MkdirAll(filepath.Join(src, "node_modules", "acorn"), 0o755); err != nil {
+		t.Fatalf("mk node_modules/acorn: %v", err)
+	}
+	got, err := EnsureSidecarDeps(src)
+	if err != nil {
+		t.Fatalf("EnsureSidecarDeps: %v", err)
+	}
+	if got != src {
+		t.Fatalf("fast path should return src unchanged; got %s want %s", got, src)
+	}
+}
+
+// TestEnsureSidecarDeps_EmptySrc rejects an empty srcDir argument
+// rather than silently materializing into an unrelated cache slot.
+func TestEnsureSidecarDeps_EmptySrc(t *testing.T) {
+	t.Parallel()
+	if _, err := EnsureSidecarDeps(""); err == nil {
+		t.Fatal("expected error for empty srcDir")
+	}
+}
+
+// TestEnsureSidecarDeps_MissingEntry rejects a srcDir without index.mjs
+// — it is not a sidecar tree and we should not silently install npm
+// deps in some random directory.
+func TestEnsureSidecarDeps_MissingEntry(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	if _, err := EnsureSidecarDeps(src); err == nil {
+		t.Fatal("expected error for missing index.mjs")
+	}
+}
+
+// TestLockHash_StableAcrossRuns verifies the cache key is deterministic
+// for identical inputs across runs, otherwise we'd materialize the
+// sidecar tree on every build.
+func TestLockHash_StableAcrossRuns(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "package.json"), `{"name":"x","version":"0.0.0"}`)
+	mustWrite(t, filepath.Join(src, "package-lock.json"), `{"name":"x","lockfileVersion":3}`)
+	a, err := lockHash(src)
+	if err != nil {
+		t.Fatalf("hash 1: %v", err)
+	}
+	b, err := lockHash(src)
+	if err != nil {
+		t.Fatalf("hash 2: %v", err)
+	}
+	if a != b {
+		t.Fatalf("hash drift: %s vs %s", a, b)
+	}
+	if len(a) != 16 {
+		t.Fatalf("hash length = %d, want 16", len(a))
+	}
+}
+
+// TestLockHash_ChangesWithLockfile verifies a package-lock.json bump
+// invalidates the cache. Without this, dependency upgrades wouldn't
+// trigger a fresh npm install.
+func TestLockHash_ChangesWithLockfile(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "package.json"), `{"name":"x","version":"0.0.0"}`)
+	mustWrite(t, filepath.Join(src, "package-lock.json"), `{"name":"x","lockfileVersion":3,"v":1}`)
+	a, err := lockHash(src)
+	if err != nil {
+		t.Fatalf("hash 1: %v", err)
+	}
+	mustWrite(t, filepath.Join(src, "package-lock.json"), `{"name":"x","lockfileVersion":3,"v":2}`)
+	b, err := lockHash(src)
+	if err != nil {
+		t.Fatalf("hash 2: %v", err)
+	}
+	if a == b {
+		t.Fatal("hash should change when lockfile changes")
+	}
+}
+
+// TestMaterializeSidecar_SkipsNodeModules verifies the source's
+// node_modules tree (if any) is NOT copied to the cache — npm in the
+// cache will populate its own.
+func TestMaterializeSidecar_SkipsNodeModules(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "index.mjs"), "// entry")
+	mustWrite(t, filepath.Join(src, "package.json"), "{}")
+	if err := os.MkdirAll(filepath.Join(src, "node_modules", "garbage"), 0o755); err != nil {
+		t.Fatalf("mk garbage: %v", err)
+	}
+	mustWrite(t, filepath.Join(src, "node_modules", "garbage", "stale.txt"), "STALE")
+	dst := filepath.Join(t.TempDir(), "out")
+	if err := materializeSidecar(src, dst); err != nil {
+		t.Fatalf("materializeSidecar: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "index.mjs")); err != nil {
+		t.Fatalf("entry not copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "node_modules")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("node_modules should not be copied; stat err = %v", err)
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/packages/sveltego/internal/codegen/svelterender/svelterender.go
+++ b/packages/sveltego/internal/codegen/svelterender/svelterender.go
@@ -166,9 +166,11 @@ func BuildSSRAST(ctx context.Context, opts SSROptions) ([]SSRResult, error) {
 		}
 		sidecarDir = p
 	}
-	if _, err := os.Stat(filepath.Join(sidecarDir, "node_modules", "acorn")); err != nil {
-		return nil, fmt.Errorf("svelterender: sidecar deps not installed at %s: run `npm install` in the sidecar tree", sidecarDir)
+	readyDir, err := EnsureSidecarDeps(sidecarDir)
+	if err != nil {
+		return nil, err
 	}
+	sidecarDir = readyDir
 
 	manifest := struct {
 		Root   string   `json:"root"`

--- a/packages/sveltego/server/ssr_fallback.go
+++ b/packages/sveltego/server/ssr_fallback.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/codegen/svelterender"
 	"github.com/binsarjr/sveltego/packages/sveltego/runtime/svelte/fallback"
 )
 
@@ -99,6 +100,11 @@ func StartFallbackSidecar(ctx context.Context, cfg SSRFallbackConfig) (*fallback
 		}
 		cfg.SidecarDir = dir
 	}
+	readyDir, err := svelterender.EnsureSidecarDeps(cfg.SidecarDir)
+	if err != nil {
+		return nil, fmt.Errorf("server: ensure sidecar deps: %w", err)
+	}
+	cfg.SidecarDir = readyDir
 	if cfg.ProjectRoot == "" {
 		wd, err := os.Getwd()
 		if err != nil {


### PR DESCRIPTION
Closes #525.

## Repro

After `go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@latest`, the sidecar tree lives under the read-only Go module cache (`\$GOPATH/pkg/mod/github.com/binsarjr/sveltego/packages/sveltego@<v>/internal/codegen/svelterender/sidecar/`). It carries `package.json` + `package-lock.json` but no `node_modules`. First `sveltego build` (or first SSR-fallback request) explodes with:

\`\`\`
svelterender: sidecar deps not installed at .../sidecar:
  run \`npm install\` in the sidecar tree
\`\`\`

The hint is unactionable — module-cache dirs are read-only and a fresh `go install` recreates the dir on every version bump.

## Fix

Picked option (a) from the issue (auto-install on first use):

- New `EnsureSidecarDeps(srcDir) (readyDir, err)` in `internal/codegen/svelterender/sidecardeps.go`.
- Fast path: when the source dir already has `node_modules/acorn` (existing dev-from-checkout workflow), return `srcDir` unchanged.
- Otherwise: hash `package.json` + `package-lock.json` to get a stable cache key, materialize the sidecar tree (excluding `node_modules` and dot-prefixed dirs) under `\$XDG_CACHE_HOME/sveltego/sidecar/<hash>/`, run `npm ci --omit=dev --no-audit --no-fund --no-progress` (falls back to `npm install` if no lockfile), then return that cache dir.
- Cache hit: subsequent calls with an unchanged lockfile reuse the populated cache (one-shot install per version).
- Pin bump auto-invalidates the cache (the hash changes).

Wired into both call sites that need a populated `node_modules`:

- Build-time `BuildSSRAST` (`svelterender.go`) — replaces the bare `os.Stat(.../node_modules/acorn)` precondition.
- Runtime `StartFallbackSidecar` (`server/ssr_fallback.go`) — ensures deps before booting the long-running `--mode=ssr-serve` supervisor.

## Cache strategy

- Path: `os.UserCacheDir()/sveltego/sidecar/<hash16>/` (hash is SHA-256 of `package.json` + `package-lock.json`, truncated to 16 hex chars to keep paths short on `sun_path`-limited filesystems).
- Idempotent: cache hit when `node_modules/acorn` exists at the cache path.
- Source dir is *not* modified (works against a read-only module cache).
- No file lock — concurrent installs into the same cache rarely happen and npm itself errors loudly; next call retries cleanly.

## Verification

- `go vet ./...`, `gofumpt -l .`, `goimports -l -local github.com/binsarjr/sveltego .` — clean.
- `go test -race -count=1 ./...` in `packages/sveltego` — 1633 passed in 27 packages.
- Manual repro: copied sidecar to `/tmp`, `chmod -R a-w` to simulate the module cache, called `EnsureSidecarDeps` — materialized to `~/Library/Caches/sveltego/sidecar/<hash>/`, npm install ran, ssr tests against the cache copy succeed. Second call is a no-op cache hit.
- New unit tests in `sidecardeps_test.go` cover: writable-source fast path, empty `srcDir` rejection, missing `index.mjs` rejection, deterministic lock hash across runs, cache invalidation when lockfile changes, materializer skipping `node_modules` and dot-prefixed dirs.

## Out of scope

- Vendoring `node_modules` into the Go module (option b in #525) — heavier and noisier; revisit if option (a) gathers complaints.
- Bundling the sidecar to a single `.mjs` (option c) — long-term endgame for distribution.