### PR TITLE
fix(init): add json tag to scaffold PageData.Greeting (#524)

### DIFF
--- a/packages/init/internal/scaffold/scaffold.go
+++ b/packages/init/internal/scaffold/scaffold.go
@@ -384,7 +384,7 @@ const pageSvelteBody = `<script lang="ts">
   let { data } = $props();
 </script>
 
-<h1>{data.Greeting}</h1>
+<h1>{data.greeting}</h1>
 `
 
 const pageServerBody = `package routes
@@ -392,7 +392,7 @@ const pageServerBody = `package routes
 import "github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
 
 type PageData struct {
-	Greeting string
+	Greeting string ` + "`json:\"greeting\"`" + `
 }
 
 func Load(ctx *kit.LoadCtx) (PageData, error) {

--- a/packages/init/internal/scaffold/scaffold_test.go
+++ b/packages/init/internal/scaffold/scaffold_test.go
@@ -376,6 +376,40 @@ func TestRun_MainGoWiresViteAndStatic(t *testing.T) {
 	}
 }
 
+// TestRun_PageDataMatchesJSONTagContract pins the scaffold to the
+// Go ↔ TypeScript boundary the SSR transpiler enforces (ADR 0008): every
+// PageData field carries an explicit `json:"..."` tag, and the template
+// reads `data.<lowercase>` matching that tag. Without this, the welcome
+// page fails to build out of the box with "<Field> not in PageData JSON
+// tag map" (#524).
+func TestRun_PageDataMatchesJSONTagContract(t *testing.T) {
+	for _, flavor := range []TailwindFlavor{TailwindNone, TailwindV4, TailwindV3} {
+		t.Run(string(flavor), func(t *testing.T) {
+			dir := t.TempDir()
+			if _, err := Run(Options{Dir: dir, Module: "example.com/hello", Tailwind: flavor}); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			server, err := os.ReadFile(filepath.Join(dir, "src/routes/_page.server.go"))
+			if err != nil {
+				t.Fatalf("read _page.server.go: %v", err)
+			}
+			if !bytes.Contains(server, []byte("`json:\"greeting\"`")) {
+				t.Errorf("_page.server.go missing `json:\"greeting\"` tag on PageData.Greeting; body:\n%s", server)
+			}
+			page, err := os.ReadFile(filepath.Join(dir, "src/routes/_page.svelte"))
+			if err != nil {
+				t.Fatalf("read _page.svelte: %v", err)
+			}
+			if !bytes.Contains(page, []byte("{data.greeting}")) {
+				t.Errorf("_page.svelte must read {data.greeting} (lowercase, matching json tag); body:\n%s", page)
+			}
+			if bytes.Contains(page, []byte("{data.Greeting}")) {
+				t.Errorf("_page.svelte references {data.Greeting} (uppercase) — transpiler rejects this; body:\n%s", page)
+			}
+		})
+	}
+}
+
 func contains(xs []string, s string) bool {
 	i := sort.SearchStrings(xs, s)
 	return i < len(xs) && xs[i] == s

--- a/packages/init/internal/scaffold/tailwind.go
+++ b/packages/init/internal/scaffold/tailwind.go
@@ -133,7 +133,7 @@ func renderPageSvelte(flavor TailwindFlavor) string {
 	b.WriteString("<script lang=\"ts\">\n")
 	b.WriteString("  let { data } = $props();\n")
 	b.WriteString("</script>\n\n")
-	b.WriteString("<h1 class=\"text-3xl font-bold underline\">{data.Greeting}</h1>\n")
+	b.WriteString("<h1 class=\"text-3xl font-bold underline\">{data.greeting}</h1>\n")
 	b.WriteString("<p class=\"note\">Tailwind utilities + scoped &lt;style&gt; coexist.</p>\n\n")
 	b.WriteString("<style>\n")
 	b.WriteString("  .note { color: rgb(82 82 91); }\n")


### PR DESCRIPTION
## Summary

Fixes the out-of-the-box scaffold build failure (#524). Fresh `sveltego-init ./hello && sveltego build` errored with `cannot lower property access ... "Greeting" not present in PageData JSON tag map`, because the scaffolded `PageData.Greeting` field had no `json:` tag and the template referenced `{data.Greeting}` (uppercase) instead of `{data.greeting}` (the JSON-tag-aligned name the svelte_js2go transpiler resolves through).

ADR 0008 makes JSON tags the canonical Go ↔ TypeScript boundary. Scaffold now matches that contract:

- `_page.server.go` (plain) emits `Greeting string `\``json:"greeting"`\`` `
- `_page.svelte` (plain + Tailwind variants) reads `{data.greeting}`
- New regression test pins the contract across all three Tailwind flavors (none / v4 / v3)

## Verification

Built `sveltego` + `sveltego-init` from this branch, scaffolded a clean app, and ran `sveltego compile`:

```
$ /tmp/sveltego-scaffold-verify-redo/sveltego-init ./hello
... wrote 14 files
$ cd hello && sveltego compile
compiled: 1 route(s) -> .gen/manifest.gen.go
```

Generated SSR (`page_render.gen.go`) correctly lowers `data.greeting` → `data.Greeting` via the JSON tag map:

```go
payload.Push(server.EscapeHTML(data.Greeting))   // <-- Go field
```

## Local gate

`gofumpt` / `goimports` / `go vet` / `go test -race ./...` all clean on `packages/init` (36 tests pass, including the new `TestRun_PageDataMatchesJSONTagContract`).

## Notes

This is a redo of an earlier attempt that was lost to a worktree-collision (the original `fix/scaffold-ootb-build` branch in `phase-gap-unblock-478` got stomped by a sibling agent's WIP — see internal log for context). Identical fix replayed in a clean dedicated worktree.

Closes #524