### PR TITLE
docs: bump install pin to v0.1.0-alpha.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ The `playgrounds/basic` app runs SSR by default; switch any route by editing the
 Pre-alpha — expect rough edges. One Go command from any terminal, no clone, no global install:
 
 ```sh
-go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest ./hello
+go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@v0.1.0-alpha.1 ./hello
 cd hello
-go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0   # build CLI (until #368 ships release binaries)
+go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.1   # build CLI (until #368 ships release binaries)
 sveltego build && ./build/app                                  # listens on :3000
 ```
 

--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -26,7 +26,7 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0 \
+RUN go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.1 \
     && sveltego build \
     && go build -trimpath -ldflags="-s -w" -o /out/app ./cmd/app
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -13,7 +13,7 @@ sveltego is pre-alpha. Expect rough edges and breaking changes. The shape below 
 One Go command from any terminal — no clone, no `go install` ceremony:
 
 ```sh
-go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@latest ./hello
+go run github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@v0.1.0-alpha.1 ./hello
 cd hello
 ```
 
@@ -31,7 +31,7 @@ cd hello
 Until [#368](https://github.com/binsarjr/sveltego/issues/368) ships release binaries, install the build CLI from source:
 
 ```sh
-go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0
+go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.1
 sveltego version
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,7 +9,7 @@ summary: sveltego command reference — build, compile, dev, check, routes, vers
 `sveltego` is the project's primary command-line entry point. Project scaffolding lives in a separate binary, `sveltego-init`, that is normally invoked through `go run @latest` rather than installed globally. Install the framework CLI with:
 
 ```sh
-go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.0
+go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.1
 ```
 
 ## Global flags


### PR DESCRIPTION
## Summary

`v0.1.0-alpha.0` (33277ef) predates #525 sidecar auto-install + #527 build-tag drop, so a fresh `go install ...@v0.1.0-alpha.0 && sveltego build` blows up with `codegen: ssr ast: svelterender: sidecar deps not installed`.

Cut new lightweight tags `packages/sveltego/v0.1.0-alpha.1` and `packages/init/v0.1.0-alpha.1` at `0d8d30e` (current HEAD). Bump README + quickstart + deploy + cli docs. Also pin `sveltego-init` (was `@latest`, resolving to a pre-#527 pseudo-version on fresh module cache).

## Smoke verification

```
go clean -modcache
GOBIN=/tmp/x/bin go install github.com/binsarjr/sveltego/packages/sveltego/cmd/sveltego@v0.1.0-alpha.1
GOBIN=/tmp/x/bin go install github.com/binsarjr/sveltego/packages/init/cmd/sveltego-init@v0.1.0-alpha.1
sveltego-init --non-interactive --module hello hello
cd hello && npm install && sveltego build --out ./build/app
./build/app   # listens :3000
curl -s http://localhost:3000/   # 200, hydration payload + csrfToken present
```

End-to-end OOTB now works.

## Test plan

- [x] `go install ...@v0.1.0-alpha.1` resolves both packages
- [x] scaffold has `json:"greeting"` tag (#524) and no `//go:build sveltego` (#527)
- [x] sidecar deps auto-installed on first build (#525)
- [x] csrfToken present in hydration payload (#523)
- [x] cross-route layout state preserved (#518) — relevant for non-trivial scaffolds; trivial `hello` doesn't exercise

## Notes

Tags are lightweight, no GitHub Release per `feedback_no_release.md`. Existing `packages/sveltego/v0.1.0-alpha.0` tag retained for any external pin already in use (older reference, but functional with `@main` install path documented as fallback if needed). Future release-please cuts are tracked in #532.