### PR TITLE
fix(release): use packages/<name>/v* tag prefix for Go module proxy

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/sveltego": "1.0.0",
+  "packages/sveltego": "0.1.0-alpha.1",
   "packages/adapter-auto": "0.0.0",
   "packages/adapter-cloudflare": "0.0.0",
   "packages/adapter-docker": "0.0.0",
@@ -7,7 +7,7 @@
   "packages/adapter-server": "0.0.0",
   "packages/adapter-static": "0.0.0",
   "packages/enhanced-img": "0.0.0",
-  "packages/init": "0.0.0",
+  "packages/init": "0.1.0-alpha.1",
   "packages/mcp": "0.0.0",
   "packages/lsp": "0.0.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,7 +319,37 @@ changes go in the footer: `BREAKING CHANGE: <description>`.
 `release-please` (RFC #100) reads these commits to compute per-package
 version bumps and CHANGELOG entries.
 
-## 14. Local gate (run before push)
+## 14. Release tagging
+
+Tag format is load-bearing. Go's module proxy resolves tags by **module
+subdirectory prefix**, not by arbitrary release-please component name. A
+tag whose prefix doesn't match the module's path inside the repo is
+invisible to `go install ...@latest` (issue #532).
+
+Rules:
+
+1. **Tag prefix MUST be `packages/<name>/v*`** for every Go module under
+   `packages/`. Module path is `github.com/binsarjr/sveltego/packages/<name>`,
+   so the tag must mirror that subpath.
+2. **New packages** register in `release-please-config.json` with
+   `"component": "packages/<name>"` (full subpath, not bare name).
+   Combined with `"tag-separator": "/"` and `"include-component-in-tag":
+   true`, this emits the correct prefix.
+3. **Manifest version (`.release-please-manifest.json`) MUST align with a
+   tag the Go proxy can already resolve at HEAD** before any prefix
+   rename. Otherwise release-please sees the package as never-released
+   and proposes a downgrade to `v1.0.0`. Verify with:
+
+   ```bash
+   git tag -l 'packages/<name>/*'
+   ```
+
+   The highest proxy-visible tag is the floor for the manifest entry.
+4. **Old component-prefixed tags** (e.g. `sveltego/v1.0.0`) are invisible
+   to the Go proxy and stay untouched. Do not delete; do not migrate.
+   release-please ignores them once the manifest is seeded correctly.
+
+## 15. Local gate (run before push)
 
 The pre-commit hook (RFC #99, `.githooks/pre-commit`) and CI (RFC #101) run
 the same gate. Run it locally first:
@@ -342,7 +372,7 @@ When opening a PR, GitHub auto-loads
 each item as it lands. Reviewers reject PRs with unticked boxes that
 lack an explanation.
 
-## 15. AI agents
+## 16. AI agents
 
 AI agents working in this repo follow [`AGENTS.md`](./AGENTS.md) (master
 ruleset, RFC #103) plus per-package `CLAUDE.md` files for scope-specific
@@ -352,7 +382,7 @@ auto-synced from `AGENTS.md`; do not edit them directly.
 If a per-package `CLAUDE.md` disagrees with this file, the package file
 wins for that package only. Cross-cutting rules live here.
 
-## 16. Merging to main
+## 17. Merging to main
 
 PRs land via the **GitHub merge queue**. The queue batches entries, runs CI
 on the merged candidate, and lands the commit only when all required checks
@@ -397,7 +427,7 @@ this account. Enable it manually:
 >
 > This is required to activate `gh pr merge --auto` queue behavior.
 
-## 17. References
+## 18. References
 
 Foundation RFCs on `github.com/binsarjr/sveltego`:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,16 +18,16 @@
     { "type": "rfc", "section": "RFCs" }
   ],
   "packages": {
-    "packages/sveltego":           { "component": "sveltego",           "package-name": "sveltego" },
-    "packages/adapter-auto":       { "component": "adapter-auto",       "package-name": "adapter-auto" },
-    "packages/adapter-cloudflare": { "component": "adapter-cloudflare", "package-name": "adapter-cloudflare" },
-    "packages/adapter-docker":     { "component": "adapter-docker",     "package-name": "adapter-docker" },
-    "packages/adapter-lambda":     { "component": "adapter-lambda",     "package-name": "adapter-lambda" },
-    "packages/adapter-server":     { "component": "adapter-server",     "package-name": "adapter-server" },
-    "packages/adapter-static":     { "component": "adapter-static",     "package-name": "adapter-static" },
-    "packages/enhanced-img":       { "component": "enhanced-img",       "package-name": "enhanced-img" },
-    "packages/init":               { "component": "init",               "package-name": "init" },
-    "packages/mcp":                { "component": "mcp",                "package-name": "mcp" },
-    "packages/lsp":                { "component": "lsp",                "package-name": "lsp" }
+    "packages/sveltego":           { "component": "packages/sveltego",           "package-name": "sveltego" },
+    "packages/adapter-auto":       { "component": "packages/adapter-auto",       "package-name": "adapter-auto" },
+    "packages/adapter-cloudflare": { "component": "packages/adapter-cloudflare", "package-name": "adapter-cloudflare" },
+    "packages/adapter-docker":     { "component": "packages/adapter-docker",     "package-name": "adapter-docker" },
+    "packages/adapter-lambda":     { "component": "packages/adapter-lambda",     "package-name": "adapter-lambda" },
+    "packages/adapter-server":     { "component": "packages/adapter-server",     "package-name": "adapter-server" },
+    "packages/adapter-static":     { "component": "packages/adapter-static",     "package-name": "adapter-static" },
+    "packages/enhanced-img":       { "component": "packages/enhanced-img",       "package-name": "enhanced-img" },
+    "packages/init":               { "component": "packages/init",               "package-name": "init" },
+    "packages/mcp":                { "component": "packages/mcp",                "package-name": "mcp" },
+    "packages/lsp":                { "component": "packages/lsp",                "package-name": "lsp" }
   }
 }


### PR DESCRIPTION
## Summary

- Switch every package in `release-please-config.json` to `"component": "packages/<name>"` so emitted tags become `packages/<name>/v*` — the prefix the Go module proxy resolves.
- Seed `.release-please-manifest.json` to the proxy-visible floor at HEAD so the prefix rename does not trigger downgrade proposals: `packages/sveltego` `1.0.0` → `0.1.0-alpha.1`, `packages/init` `0.0.0` → `0.1.0-alpha.1`. Other 9 packages remain `0.0.0` (no proxy-visible tags yet).
- Document the tag-format contract in a new `CONTRIBUTING.md §14 Release tagging` section so future package additions don't regress the bug.

## Why

`release-please-config.json` previously used bare component names (`sveltego`, `adapter-static`, …), producing tags like `sveltego/v1.0.0`. Go's module proxy resolves tags by **module subdirectory prefix**, not by arbitrary component name, so those tags are invisible to `go install github.com/binsarjr/sveltego/packages/<name>/...@latest`. Surfaced via #526; manual workaround in #530 (lightweight `packages/sveltego/v0.1.0-alpha.0` + alpha.1 tags). This fix prevents every future release-please cut from reproducing the bug.

Issue #532 lays out the full design (Option A: explicit full-path components).

## Out of scope

- Cutting public GitHub Releases (release embargo per `feedback_no_release.md` — tags only).
- Migrating the existing `sveltego/v1.0.0` tag (Go proxy ignores it; deleting churns release-please state).
- Touching the `packages/sveltego/v0.1.0-alpha.{0,1}` / `packages/init/v0.1.0-alpha.1` tags pushed by #530 / earlier work.
- GoReleaser config changes (#368 — tracked separately).

## Verification

- [x] `jq . release-please-config.json` — valid JSON
- [x] `jq . .release-please-manifest.json` — valid JSON
- [x] All 11 package entries have `component` matching their key path (verified via `jq -e`)
- [x] Manifest floors aligned with proxy-visible tags at HEAD
- [x] Commit subject ≤72 chars (validate-commits.sh format)
- [ ] CI green
- [ ] Self-merge via `gh pr merge --auto --squash --delete-branch`

## Note on schema comment

Issue acceptance criterion #3 asks for a top-level comment in `release-please-config.json` describing the constraint. JSON has no comments, and the published release-please config schema sets `additionalProperties: false`, so adding a sibling `_comment` key risks silent schema-validator failure. The constraint is documented in `CONTRIBUTING.md §14` instead — explicit fallback per the task brief.

Closes #532