### PR TITLE
fix(server,client): emit csrfToken on __data.json + re-fire splicer (#541)

### DIFF
--- a/packages/sveltego/internal/vite/cliententry.go
+++ b/packages/sveltego/internal/vite/cliententry.go
@@ -75,7 +75,7 @@ func GenerateClientEntry(opts ClientEntryOptions) string {
 	default:
 		fmt.Fprintf(&b, "import Root from %q;\n", opts.RelSveltePath)
 	}
-	fmt.Fprintf(&b, "import { startRouter } from %q;\n", opts.RelRouterPath)
+	fmt.Fprintf(&b, "import { startRouter, afterNavigate } from %q;\n", opts.RelRouterPath)
 	// `.svelte.ts` (matched via the `.svelte` half here) routes the
 	// state module through vite-plugin-svelte so its `$state` runes
 	// compile rather than shipping raw to the browser (#471).
@@ -130,12 +130,15 @@ func GenerateClientEntry(opts ClientEntryOptions) string {
 	// CSRF auto-inject for client-rendered POST forms (#510). The
 	// build-time AST splice handles SSR; the runtime sidecar splice
 	// handles fallback routes; this third path covers SPA / Static
-	// routes whose forms are constructed in the browser. The walk
-	// runs once after mount (no MutationObserver — keeps the runtime
-	// dead simple; users adding forms dynamically can re-run via
-	// window.__sveltego_csrf__()).
+	// routes whose forms are constructed in the browser. Reads from
+	// window.__sveltego__.csrfToken so the value stays current after
+	// SPA nav (router rewrites the global on every nav). Registered
+	// via afterNavigate so the splicer re-fires on each navigation
+	// (#541) — without it the second-and-later page rendered via
+	// the client router has no hidden input and the user's first
+	// POST returns 403.
 	b.WriteString("const __sveltegoInjectCSRF = () => {\n")
-	b.WriteString("  const t = (payload as any).csrfToken;\n")
+	b.WriteString("  const t = (window as any).__sveltego__?.csrfToken;\n")
 	b.WriteString("  if (!t) return;\n")
 	b.WriteString("  const forms = target.querySelectorAll('form');\n")
 	b.WriteString("  forms.forEach((f) => {\n")
@@ -150,6 +153,7 @@ func GenerateClientEntry(opts ClientEntryOptions) string {
 	b.WriteString("  });\n")
 	b.WriteString("};\n")
 	b.WriteString("queueMicrotask(__sveltegoInjectCSRF);\n")
+	b.WriteString("afterNavigate(__sveltegoInjectCSRF);\n")
 	b.WriteString("(window as any).__sveltego_csrf__ = __sveltegoInjectCSRF;\n\n")
 	b.WriteString("(window as any).__sveltego_hydrated = true;\n\n")
 	// Forward the layout chain identifier so the SPA router can swap

--- a/packages/sveltego/internal/vite/cliententry_test.go
+++ b/packages/sveltego/internal/vite/cliententry_test.go
@@ -63,12 +63,15 @@ func TestGenerateEnhanceRuntime_Deterministic(t *testing.T) {
 	}
 }
 
-// TestGenerateClientEntry_CSRFAutoInject covers issue #510 on the SPA
-// path: the per-route entry must walk every <form method="post"> the
-// client mounts and splice a hidden _csrf_token input populated from
-// payload.csrfToken. Without this, SPA / Static routes that render
-// forms entirely in the browser would POST without the field and
-// trigger the framework's 403 CSRF rejection.
+// TestGenerateClientEntry_CSRFAutoInject covers #510 (SPA path) and
+// #541 (SPA-nav re-fire). The per-route entry must walk every
+// <form method="post"> the client mounts and splice a hidden
+// _csrf_token input populated from window.__sveltego__.csrfToken (the
+// router rewrites the global on every nav, so reading from the global
+// keeps the value fresh after navigation). The splicer is registered
+// via afterNavigate so it re-runs on each SPA navigation; without it
+// the second-and-later page rendered via the client router has no
+// hidden input and the user's first POST returns 403.
 func TestGenerateClientEntry_CSRFAutoInject(t *testing.T) {
 	t.Parallel()
 	out := GenerateClientEntry(ClientEntryOptions{
@@ -76,12 +79,13 @@ func TestGenerateClientEntry_CSRFAutoInject(t *testing.T) {
 		RelRouterPath: "../../__router/router",
 	})
 	for _, want := range []string{
-		"(payload as any).csrfToken",
+		"(window as any).__sveltego__?.csrfToken",
 		"target.querySelectorAll('form')",
 		"_csrf_token",
 		"input.type = 'hidden';",
 		"f.insertBefore(input, f.firstChild);",
 		"window as any).__sveltego_csrf__",
+		"afterNavigate(__sveltegoInjectCSRF)",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("client entry missing %q for CSRF auto-inject:\n%s", want, out)

--- a/packages/sveltego/internal/vite/router_test.go
+++ b/packages/sveltego/internal/vite/router_test.go
@@ -275,7 +275,7 @@ func TestGenerateClientEntry_importsRouter(t *testing.T) {
 	})
 	for _, want := range []string{
 		`import Root from "../../routes/_page.svelte"`,
-		`import { startRouter } from "../__router/router"`,
+		`import { startRouter, afterNavigate } from "../__router/router"`,
 		"import { hydrate, mount } from 'svelte'",
 		"const appShell = document.getElementById('app');",
 		"const target = appShell ?? document.body;",

--- a/packages/sveltego/server/csrf_inject_integration_test.go
+++ b/packages/sveltego/server/csrf_inject_integration_test.go
@@ -169,6 +169,56 @@ func TestCSRFInject_HydrationPayloadIncludesCSRFToken(t *testing.T) {
 	}
 }
 
+// TestCSRFInject_DataJSONPayloadIncludesCSRFToken covers issue #541:
+// the __data.json response served to the SPA router on every client
+// navigation must carry the per-request csrfToken. Without this, the
+// second-and-later page rendered after SPA nav has no token in
+// window.__sveltego__, the splicer reads undefined, and the user's
+// first POST returns 403. The fix runs applyCSRF before
+// renderDataJSON so the token lands in ev.Locals.
+func TestCSRFInject_DataJSONPayloadIncludesCSRFToken(t *testing.T) {
+	t.Parallel()
+	actions := kit.ActionMap{
+		"login": func(_ *kit.RequestEvent) kit.ActionResult {
+			return kit.ActionDataResult(200, "ok")
+		},
+	}
+	opts := kit.DefaultPageOptions()
+	opts.Templates = ""
+	srv := newTestServer(t, []router.Route{{
+		Pattern:  "/login",
+		Segments: []router.Segment{{Kind: router.SegmentStatic, Value: "login"}},
+		Page:     fallbackInjectedPage(),
+		Actions:  func() any { return actions },
+		Options:  opts,
+	}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/login/__data.json")
+	if err != nil {
+		t.Fatalf("GET __data.json: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	var cookieToken string
+	for _, c := range resp.Cookies() {
+		if c.Name == "_csrf" {
+			cookieToken = c.Value
+			break
+		}
+	}
+	if cookieToken == "" {
+		t.Fatalf("expected _csrf cookie on __data.json GET; got cookies=%v", resp.Cookies())
+	}
+
+	want := `"csrfToken":"` + cookieToken + `"`
+	if !strings.Contains(string(body), want) {
+		t.Fatalf("__data.json payload missing %q; body=\n%s", want, body)
+	}
+}
+
 // TestCSRFInject_FallbackPathSkipsGetForm asserts the same renderFallback
 // shape leaves GET forms alone — the runtime rewriter gates on method
 // just like the build-time pass.

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -253,6 +253,12 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 		if route.Options.SSROnly {
 			return nil, kit.SafeError{Code: http.StatusNotFound, Message: http.StatusText(http.StatusNotFound)}
 		}
+		// Run applyCSRF for the GET-only __data.json path so the
+		// payload carries `csrfToken` after SPA nav. Without this,
+		// the second-and-later page rendered via the client router
+		// has no token in its hydration payload, the splicer reads
+		// undefined, and the user's first POST returns 403 (#541).
+		s.applyCSRF(r, ev, route)
 		return s.renderDataJSON(r, ev, route, nil)
 	}
 	if rejected := s.applyCSRF(r, ev, route); rejected != nil {


### PR DESCRIPTION
## Summary

SPA-nav into a POST-form route returned 403 even after #529. Two combined gaps:

1. **`__data.json` omitted `csrfToken`.** `renderDataJSON` short-circuited before `applyCSRF` (`pipeline.go:252-256`), so the navigated payload had no token. The SPA router writes `window.__sveltego__` on every nav, so the second-and-later page saw `csrfToken: undefined`.
2. **Client splicer fired once.** `cliententry.go:152` scheduled `__sveltegoInjectCSRF` exactly once at mount, and read from a closure over the initial payload — never re-ran on nav.

## Fix

- Lift `applyCSRF` above the `__data.json` branch (GET-only path, no method-conditional cost).
- Splicer now reads `window.__sveltego__?.csrfToken` (always current) and registers via `afterNavigate(__sveltegoInjectCSRF)` so it re-fires on every SPA nav.

## Test plan

- [x] `go test -race ./packages/sveltego/server/ ./packages/sveltego/internal/vite/` — 319 passed.
- [x] New `TestCSRFInject_DataJSONPayloadIncludesCSRFToken` asserts `__data.json` carries the token matching the cookie.
- [x] `TestGenerateClientEntry_CSRFAutoInject` updated for the new global lookup + `afterNavigate` registration.
- [x] `TestGenerateClientEntry_importsRouter` updated for the `afterNavigate` import.
- [ ] CI green.

Closes #541