### PR TITLE
feat(server,codegen): auto-inject CSP nonce on emitted scripts (#539)

### DIFF
--- a/docs/guide/csp.md
+++ b/docs/guide/csp.md
@@ -39,9 +39,35 @@ form-action 'self'
 
 Your `Directives` map merges over this baseline. Setting a directive to an empty slice removes it.
 
+## Auto-injected scripts
+
+Codegen-emitted tags inherit the per-request nonce automatically when `kit.CSPConfig.Mode` is `CSPStrict` or `CSPReportOnly`. No template change is required for:
+
+- `<script type="module">` — the per-route entry chunk emitted before `</body>`.
+- `<link rel="modulepreload">` — the head-belonging hints for transitive imports.
+- `<script id="sveltego-data" type="application/json">` — the JSON hydration payload.
+- The streaming `<script>__sveltego__resolve(...)</script>` chunks emitted for `kit.Streamed[T]` fields.
+- The service-worker registration `<script>` (when `Config.ServiceWorker = true`).
+
+A live `CSPStrict` response carries one nonce on the header and on every emitted tag:
+
+```
+Content-Security-Policy: script-src 'nonce-AbC123…' 'strict-dynamic'; …
+```
+
+```html
+<link rel="modulepreload" nonce="AbC123…" href="/_app/shared-def.js">
+<script type="module" nonce="AbC123…" src="/_app/page-abc.js"></script>
+<script id="sveltego-data" nonce="AbC123…" type="application/json">{…}</script>
+```
+
+`<link rel="stylesheet">` tags are intentionally not nonce-attributed — the default `style-src` directive does not gate on nonce. CSS hashes from Vite are already content-addressed.
+
+> **SSG note.** Prerendered routes (`Prerender: true`) cannot use a nonce: the HTML is built once at `sveltego build` time, before any per-request value exists. SSG users keep `'unsafe-inline'`, switch to per-asset hashes, or rely on `'strict-dynamic'`. SSR (the default), SPA, and Static routes all carry nonces at request time.
+
 ## Inline scripts
 
-Use the per-request nonce on every inline `<script>`. The nonce arrives via the standard `data` prop (populate it from your layout's `Load`):
+Use the per-request nonce on every developer-authored inline `<script>`. The nonce arrives via the standard `data` prop (populate it from your layout's `Load`):
 
 ```svelte
 <script lang="ts">
@@ -57,11 +83,12 @@ In `_layout.server.go`:
 
 ```go
 func Load(ctx *kit.LoadCtx) (LayoutData, error) {
-  return LayoutData{Nonce: kit.Nonce(ctx)}, nil
+  nonce, _ := ctx.Locals["cspNonce"].(string)
+  return LayoutData{Nonce: nonce}, nil
 }
 ```
 
-`kit.Nonce(ctx)` returns the per-request nonce when CSP is on, or the empty string when off — so the same template compiles uniformly across opt-in and opt-out builds.
+The `cspNonce` key is populated by the CSP middleware on every request before any `Load` runs; it returns the empty string when CSP is off, so the same template compiles uniformly across opt-in and opt-out builds. Templates that read `page.nonce` (Svelte 5 `$app/state`) receive the same value via the per-route `RenderCtx.Nonce()` accessor — no separate Load channel is needed.
 
 ## Modes
 

--- a/packages/sveltego/exports/kit/ctx.go
+++ b/packages/sveltego/exports/kit/ctx.go
@@ -77,6 +77,21 @@ func (c *RenderCtx) CSRFToken() string {
 	return ""
 }
 
+// Nonce returns the per-request CSP nonce the pipeline stored on Locals
+// before Render runs, or the empty string when CSP is disabled. Codegen
+// emits ctx.Nonce() into the per-route PageState so templates that read
+// `page.nonce` see the same value the response's
+// Content-Security-Policy header advertises.
+func (c *RenderCtx) Nonce() string {
+	if c == nil || c.Locals == nil {
+		return ""
+	}
+	if v, ok := c.Locals[cspNonceKey].(string); ok {
+		return v
+	}
+	return ""
+}
+
 // LoadCtx is the request-scoped context handed to user-written Load
 // functions in _page.server.go and _layout.server.go.
 //

--- a/packages/sveltego/internal/codegen/manifest.go
+++ b/packages/sveltego/internal/codegen/manifest.go
@@ -605,6 +605,7 @@ func emitPageStateBuild(b *Builder, pattern, dataIdent string) {
 	b.Line("Status: 200,")
 	b.Linef("Data:   %s,", dataIdent)
 	b.Line("CSRFToken: ctx.CSRFToken(),")
+	b.Line("Nonce: ctx.Nonce(),")
 	b.Dedent()
 	b.Line("}")
 }
@@ -819,6 +820,7 @@ func emitSSRErrorAdapter(b *Builder, ei errorImport) {
 	b.Line("Status: safe.HTTPStatus(),")
 	b.Line("Error:  &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()},")
 	b.Line("CSRFToken: ctx.CSRFToken(),")
+	b.Line("Nonce: ctx.Nonce(),")
 	b.Dedent()
 	b.Line("}")
 	b.Linef("%s.RenderErrorSSR(&payload, safe, pageState)", ei.alias)
@@ -944,7 +946,7 @@ func emitRouteRenderErrorChain(b *Builder, r routescan.ScannedRoute, layoutByPat
 		// their templates (nav bars, breadcrumbs) can read $app/state.
 		// The error path overrides Status from safe.HTTPStatus() and
 		// populates page.error so `{#if page.error}` branches activate.
-		b.Linef("pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: %s}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken()}", quoteGo(r.Pattern))
+		b.Linef("pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: %s}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken(), Nonce: ctx.Nonce()}", quoteGo(r.Pattern))
 	}
 	innerCall := fmt.Sprintf("renderError__%s(w, ctx, safe)", errAlias)
 	emitErrorChainBody(b, survivingLayouts, layoutByPath, innerCall)

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/error-chain.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/error-chain.golden
@@ -138,6 +138,7 @@ func renderError__page_routes(w *render.Writer, ctx *kit.RenderCtx, safe kit.Saf
 		Status:    safe.HTTPStatus(),
 		Error:     &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()},
 		CSRFToken: ctx.CSRFToken(),
+		Nonce:     ctx.Nonce(),
 	}
 	page_routes.RenderErrorSSR(&payload, safe, pageState)
 	if head := payload.HeadHTML(); head != "" {
@@ -157,6 +158,7 @@ func renderError__page_routes_admin(w *render.Writer, ctx *kit.RenderCtx, safe k
 		Status:    safe.HTTPStatus(),
 		Error:     &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()},
 		CSRFToken: ctx.CSRFToken(),
+		Nonce:     ctx.Nonce(),
 	}
 	page_routes_admin.RenderErrorSSR(&payload, safe, pageState)
 	if head := payload.HeadHTML(); head != "" {
@@ -187,6 +189,7 @@ func renderChain__Index(w *render.Writer, ctx *kit.RenderCtx, page router.PageHa
 		Status:    200,
 		Data:      pageData,
 		CSRFToken: ctx.CSRFToken(),
+		Nonce:     ctx.Nonce(),
 	}
 	w.WriteString(server.BlockOpen)
 	if err := func(w *render.Writer) error {
@@ -210,7 +213,7 @@ func renderChain__Index(w *render.Writer, ctx *kit.RenderCtx, page router.PageHa
 // is baked in; layoutData is intentionally nil per legacy behavior.
 func renderErrorChain__Index(w *render.Writer, ctx *kit.RenderCtx, safe kit.SafeError, layoutDatas []any) error {
 	_ = layoutDatas
-	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken()}
+	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken(), Nonce: ctx.Nonce()}
 	return render__layout__page_routes(w, ctx, nil, func(w *render.Writer) error {
 		return renderError__page_routes(w, ctx, safe)
 	}, pageState)
@@ -227,6 +230,7 @@ func renderChain__Admin(w *render.Writer, ctx *kit.RenderCtx, page router.PageHa
 		Status:    200,
 		Data:      pageData,
 		CSRFToken: ctx.CSRFToken(),
+		Nonce:     ctx.Nonce(),
 	}
 	w.WriteString(server.BlockOpen)
 	if err := func(w *render.Writer) error {
@@ -252,7 +256,7 @@ func renderChain__Admin(w *render.Writer, ctx *kit.RenderCtx, page router.PageHa
 // is baked in; layoutData is intentionally nil per legacy behavior.
 func renderErrorChain__Admin(w *render.Writer, ctx *kit.RenderCtx, safe kit.SafeError, layoutDatas []any) error {
 	_ = layoutDatas
-	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/admin`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken()}
+	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/admin`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken(), Nonce: ctx.Nonce()}
 	return render__layout__page_routes(w, ctx, nil, func(w *render.Writer) error {
 		return render__layout__page_routes_admin(w, ctx, nil, func(w *render.Writer) error {
 			return renderError__page_routes_admin(w, ctx, safe)
@@ -271,6 +275,7 @@ func renderChain__AdminUsers(w *render.Writer, ctx *kit.RenderCtx, page router.P
 		Status:    200,
 		Data:      pageData,
 		CSRFToken: ctx.CSRFToken(),
+		Nonce:     ctx.Nonce(),
 	}
 	w.WriteString(server.BlockOpen)
 	if err := func(w *render.Writer) error {
@@ -296,7 +301,7 @@ func renderChain__AdminUsers(w *render.Writer, ctx *kit.RenderCtx, page router.P
 // is baked in; layoutData is intentionally nil per legacy behavior.
 func renderErrorChain__AdminUsers(w *render.Writer, ctx *kit.RenderCtx, safe kit.SafeError, layoutDatas []any) error {
 	_ = layoutDatas
-	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/admin/users`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken()}
+	pageState := server.PageState{URL: ctx.URL, Params: ctx.Params, Route: server.PageRoute{ID: `/admin/users`}, Status: safe.HTTPStatus(), Error: &server.PageError{Message: safe.Error(), Status: safe.HTTPStatus()}, CSRFToken: ctx.CSRFToken(), Nonce: ctx.Nonce()}
 	return render__layout__page_routes(w, ctx, nil, func(w *render.Writer) error {
 		return render__layout__page_routes_admin(w, ctx, nil, func(w *render.Writer) error {
 			return renderError__page_routes_admin(w, ctx, safe)

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/layout-chain.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/layout-chain.golden
@@ -153,6 +153,7 @@ func renderChain__DashTeamBilling(w *render.Writer, ctx *kit.RenderCtx, page rou
 		Status:    200,
 		Data:      pageData,
 		CSRFToken: ctx.CSRFToken(),
+		Nonce:     ctx.Nonce(),
 	}
 	w.WriteString(server.BlockOpen)
 	if err := func(w *render.Writer) error {

--- a/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
+++ b/packages/sveltego/internal/codegen/testdata/golden/manifest/page-options.golden
@@ -78,6 +78,7 @@ func renderChain__Index(w *render.Writer, ctx *kit.RenderCtx, page router.PageHa
 		Status:    200,
 		Data:      pageData,
 		CSRFToken: ctx.CSRFToken(),
+		Nonce:     ctx.Nonce(),
 	}
 	w.WriteString(server.BlockOpen)
 	if err := func(w *render.Writer) error {
@@ -107,6 +108,7 @@ func renderChain__DashBilling(w *render.Writer, ctx *kit.RenderCtx, page router.
 		Status:    200,
 		Data:      pageData,
 		CSRFToken: ctx.CSRFToken(),
+		Nonce:     ctx.Nonce(),
 	}
 	w.WriteString(server.BlockOpen)
 	if err := func(w *render.Writer) error {

--- a/packages/sveltego/internal/vite/manifest.go
+++ b/packages/sveltego/internal/vite/manifest.go
@@ -37,9 +37,14 @@ func Parse(data []byte) (Manifest, error) {
 //   - one <link rel="stylesheet"> per CSS file
 //   - one <script type="module"> for the entry chunk itself
 //
+// nonce is the per-request CSP nonce; when non-empty, the emitted
+// <script type="module"> and <link rel="modulepreload"> tags carry
+// nonce="…" so a strict `script-src 'nonce-…'` directive permits the
+// preloaded chunks. Empty nonce (CSP off) emits the unattributed form.
+//
 // Returns an empty string when routeKey is not found in the manifest (e.g.
 // when the client build was skipped with --no-client).
-func (m Manifest) Tags(routeKey, base string) string {
+func (m Manifest) Tags(routeKey, base, nonce string) string {
 	if m == nil {
 		return ""
 	}
@@ -48,6 +53,10 @@ func (m Manifest) Tags(routeKey, base string) string {
 		return ""
 	}
 	base = strings.TrimRight(base, "/")
+	na := ""
+	if nonce != "" {
+		na = ` nonce="` + nonce + `"`
+	}
 
 	var b strings.Builder
 
@@ -67,7 +76,7 @@ func (m Manifest) Tags(routeKey, base string) string {
 			if !ok {
 				continue
 			}
-			fmt.Fprintf(&b, `<link rel="modulepreload" href="%s/%s">`, base, ic.File)
+			fmt.Fprintf(&b, `<link rel="modulepreload"%s href="%s/%s">`, na, base, ic.File)
 			b.WriteByte('\n')
 			collectImports(imp)
 		}
@@ -79,7 +88,7 @@ func (m Manifest) Tags(routeKey, base string) string {
 		b.WriteByte('\n')
 	}
 
-	fmt.Fprintf(&b, `<script type="module" src="%s/%s"></script>`, base, chunk.File)
+	fmt.Fprintf(&b, `<script type="module"%s src="%s/%s"></script>`, na, base, chunk.File)
 	b.WriteByte('\n')
 
 	return b.String()

--- a/packages/sveltego/runtime/svelte/server/page_state.go
+++ b/packages/sveltego/runtime/svelte/server/page_state.go
@@ -42,6 +42,14 @@ type PageState struct {
 	// hidden `_csrf_token` input it splices after every POST form.
 	// Empty when CSRF is disabled for the route.
 	CSRFToken string
+	// Nonce carries the per-request CSP nonce issued by the applyCSP
+	// middleware. The per-route bridge populates it from
+	// kit.RenderCtx.Nonce(). Templates that read `page.nonce` receive
+	// the same value the response's Content-Security-Policy header
+	// advertises so developer-authored inline `<script nonce={...}>`
+	// tags can opt into the strict CSP without a separate Load
+	// channel. Empty when CSP is off for the request.
+	Nonce string
 }
 
 // PageRoute mirrors the `page.route` field. ID is the matched route's

--- a/packages/sveltego/runtime/svelte/server/payload.go
+++ b/packages/sveltego/runtime/svelte/server/payload.go
@@ -6,8 +6,10 @@ import "strings"
 // render functions. Out collects the body, Head collects <svelte:head>
 // contributions; Title is the latest <title> seen during render.
 //
-// Phase 6 will extend Payload with CSP nonce, route metadata, and any
-// other request-scoped fields the pipeline needs to inject.
+// Request-scoped fields the SSR templates can read (CSP nonce, CSRF
+// token, route metadata) live on the sibling PageState struct — that is
+// what the per-route bridge constructs from kit.RenderCtx and forwards
+// into the transpiled Render function. See page_state.go.
 type Payload struct {
 	Out   strings.Builder
 	Head  strings.Builder

--- a/packages/sveltego/server/csp_integration_test.go
+++ b/packages/sveltego/server/csp_integration_test.go
@@ -2,12 +2,15 @@ package server
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/render"
 	"github.com/binsarjr/sveltego/packages/sveltego/runtime/router"
 )
 
@@ -219,5 +222,150 @@ func TestCSP_NonceAttrInUserScript(t *testing.T) {
 	got := resp.Header.Get("X-Nonce-Attr")
 	if !strings.HasPrefix(got, `nonce="`) || !strings.HasSuffix(got, `"`) {
 		t.Errorf("NonceAttr shape = %q", got)
+	}
+}
+
+// TestCSP_NonceOnAutoInjectedScripts pins issue #539: every codegen-emitted
+// <script> and <link rel="modulepreload"> tag carries the same per-request
+// nonce that the Content-Security-Policy header advertises. Asserts the
+// JSON hydration payload, the entry module script, the modulepreload hint,
+// and the response header all share one value.
+func TestCSP_NonceOnAutoInjectedScripts(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `{
+		"src/routes/_page.svelte": {
+			"file": "_app/page-abc.js",
+			"imports": ["_shared"],
+			"isEntry": true
+		},
+		"_shared": {
+			"file": "_app/shared-def.js"
+		}
+	}`
+
+	srv, err := New(Config{
+		Routes: []router.Route{{
+			Pattern:   "/",
+			Segments:  []router.Segment{},
+			ClientKey: "src/routes/_page.svelte",
+			Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+				w.WriteString(`<main>hello</main>`)
+				return nil
+			},
+		}},
+		Shell:         testShell,
+		Logger:        quietLogger(),
+		ViteManifest:  manifest,
+		CSP:           kit.CSPConfig{Mode: kit.CSPStrict},
+		ServiceWorker: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	bs := string(body)
+
+	header := resp.Header.Get("Content-Security-Policy")
+	if header == "" {
+		t.Fatal("Content-Security-Policy header missing")
+	}
+
+	headerNonceRe := regexp.MustCompile(`'nonce-([^']+)'`)
+	hm := headerNonceRe.FindStringSubmatch(header)
+	if len(hm) != 2 {
+		t.Fatalf("could not extract nonce from header: %q", header)
+	}
+	headerNonce := hm[1]
+
+	wantStrings := []string{
+		// Entry module script under /static/_app/_app/page-abc.js.
+		`<script type="module" nonce="` + headerNonce + `" src="/static/_app/_app/page-abc.js"></script>`,
+		// Modulepreload hint for the shared chunk.
+		`<link rel="modulepreload" nonce="` + headerNonce + `" href="/static/_app/_app/shared-def.js">`,
+		// JSON hydration payload script.
+		`<script id="sveltego-data" nonce="` + headerNonce + `" type="application/json">`,
+		// Service worker registration.
+		`<script nonce="` + headerNonce + `">if('serviceWorker' in navigator)`,
+	}
+	for _, want := range wantStrings {
+		if !strings.Contains(bs, want) {
+			t.Errorf("body missing %q\nbody:\n%s", want, bs)
+		}
+	}
+
+	// Negative assertions: no auto-injected <script> or <link rel="modulepreload">
+	// without a nonce attribute (would defeat the strict CSP).
+	scriptRe := regexp.MustCompile(`<script (?:[^>]*?)>`)
+	for _, m := range scriptRe.FindAllString(bs, -1) {
+		// Skip resolve scripts the streaming chain emits — none on this route.
+		if !strings.Contains(m, `nonce="`+headerNonce+`"`) {
+			t.Errorf("found <script> without matching nonce: %q", m)
+		}
+	}
+	preloadRe := regexp.MustCompile(`<link rel="modulepreload"[^>]*>`)
+	for _, m := range preloadRe.FindAllString(bs, -1) {
+		if !strings.Contains(m, `nonce="`+headerNonce+`"`) {
+			t.Errorf("found <link rel=\"modulepreload\"> without matching nonce: %q", m)
+		}
+	}
+}
+
+// TestCSP_OffEmitsNoNonceAttribute pins the off-CSP byte stability:
+// when CSP is disabled, no auto-injected tag carries a nonce attribute.
+// Guards against accidental coupling that would alter SSG / cache hashes.
+func TestCSP_OffEmitsNoNonceAttribute(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `{
+		"src/routes/_page.svelte": {
+			"file": "_app/page-abc.js",
+			"imports": ["_shared"],
+			"isEntry": true
+		},
+		"_shared": {
+			"file": "_app/shared-def.js"
+		}
+	}`
+
+	srv, err := New(Config{
+		Routes: []router.Route{{
+			Pattern:   "/",
+			Segments:  []router.Segment{},
+			ClientKey: "src/routes/_page.svelte",
+			Page: func(w *render.Writer, _ *kit.RenderCtx, _ any) error {
+				w.WriteString(`<main>hello</main>`)
+				return nil
+			},
+		}},
+		Shell:         testShell,
+		Logger:        quietLogger(),
+		ViteManifest:  manifest,
+		ServiceWorker: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	bs := string(body)
+
+	if strings.Contains(bs, ` nonce="`) {
+		t.Errorf("nonce attribute leaked when CSP off:\n%s", bs)
 	}
 }

--- a/packages/sveltego/server/pipeline.go
+++ b/packages/sveltego/server/pipeline.go
@@ -291,7 +291,7 @@ func (s *Server) resolve(w http.ResponseWriter, r *http.Request, ev *kit.Request
 		if isSvelteMode {
 			return s.renderSvelteShell(r, ev, route, form)
 		}
-		return s.renderEmptyShell(), nil
+		return s.renderEmptyShell(ev), nil
 	}
 	// ADR 0009 phase 6 (#428): Svelte-mode routes with a generated
 	// Render emit have route.Page wired to the bridge adapter that
@@ -338,9 +338,10 @@ func optionsAllowSSR(opts kit.PageOptions) bool {
 // an empty mount point. Used when route.Options.SSR is false: the
 // browser receives a valid HTML document and hydrates from the client
 // bundle once delivered (#34). Cookies queued during Reroute / Handle
-// still flow through writeResponse.
-func (s *Server) renderEmptyShell() *kit.Response {
-	body := s.shellHead + s.shellMid + `<div id="app"></div>` + s.serviceWorker + s.shellTail
+// still flow through writeResponse. The service-worker registration
+// tag (when enabled) inherits the per-request CSP nonce from ev.
+func (s *Server) renderEmptyShell(ev *kit.RequestEvent) *kit.Response {
+	body := s.shellHead + s.shellMid + `<div id="app"></div>` + s.serviceWorkerTag(kit.Nonce(ev)) + s.shellTail
 	headers := http.Header{}
 	headers.Set("Content-Type", "text/html; charset=utf-8")
 	headers.Set("Content-Length", strconv.Itoa(len(body)))
@@ -549,17 +550,27 @@ func (s *Server) applyInitialPayloadFields(p *clientPayload) {
 // pre-encoded stable fields owned by s; the assembled bytes are then
 // passed through escapeScriptSpecial so any "</" or "<!--" inside
 // per-request data can't break out of the script tag.
-func (s *Server) emitPayloadScriptTag(buf *render.Writer, p clientPayload) {
+//
+// nonce is the per-request CSP nonce (kit.Nonce(ev)); when non-empty
+// the emitted tag carries nonce="…" so a strict
+// `script-src 'nonce-…'` directive permits the JSON payload script
+// alongside the entry chunk and modulepreload hints (#539).
+func (s *Server) emitPayloadScriptTag(buf *render.Writer, p clientPayload, nonce string) {
 	scratch := acquirePayloadBuf()
 	defer releasePayloadBuf(scratch)
+	openTag := `<script id="sveltego-data" type="application/json">`
+	if nonce != "" {
+		openTag = `<script id="sveltego-data" nonce="` + nonce + `" type="application/json">`
+	}
 	if err := s.writePayloadJSON(scratch, p); err != nil {
 		// Emit an empty payload rather than omitting the tag; the client
 		// will mount with nil data rather than crashing on a missing element.
-		buf.WriteString(`<script id="sveltego-data" type="application/json">{}</script>`)
+		buf.WriteString(openTag)
+		buf.WriteString(`{}</script>`)
 		return
 	}
 	encoded := escapeScriptSpecial(scratch.Bytes())
-	buf.WriteString(`<script id="sveltego-data" type="application/json">`)
+	buf.WriteString(openTag)
 	buf.WriteRaw(bytesAsString(encoded))
 	buf.WriteString(`</script>`)
 }
@@ -730,9 +741,10 @@ func (s *Server) renderSvelteShell(r *http.Request, ev *kit.RequestEvent, route 
 	buf := render.Acquire()
 	defer render.Release(buf)
 
+	nonce := kit.Nonce(ev)
 	buf.WriteString(s.shellHead)
 	if route.ClientKey != "" {
-		if tags := s.viteManifest.headAssetTags(route.ClientKey, s.viteBase); tags != "" {
+		if tags := s.viteManifest.headAssetTags(route.ClientKey, s.viteBase, nonce); tags != "" {
 			buf.WriteString(tags)
 		}
 	}
@@ -743,14 +755,14 @@ func (s *Server) renderSvelteShell(r *http.Request, ev *kit.RequestEvent, route 
 	if lctx != nil {
 		payload.Deps = lctx.CollectDeps()
 	}
-	s.emitPayloadScriptTag(buf, payload)
+	s.emitPayloadScriptTag(buf, payload, nonce)
 	if route.ClientKey != "" {
-		if tag := s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase); tag != "" {
+		if tag := s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase, nonce); tag != "" {
 			buf.WriteString(tag)
 		}
 	}
-	if s.serviceWorker != "" {
-		buf.WriteString(s.serviceWorker)
+	if sw := s.serviceWorkerTag(nonce); sw != "" {
+		buf.WriteString(sw)
 	}
 	buf.WriteString(s.shellTail)
 
@@ -858,6 +870,7 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 		}
 	}
 
+	nonce := kit.Nonce(ev)
 	streams := collectStreams(data, layoutDatas)
 	if len(streams) > 0 {
 		status := http.StatusOK
@@ -883,10 +896,10 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 			bodyEntryTag  string
 		)
 		if route.ClientKey != "" {
-			headAssetTags = s.viteManifest.headAssetTags(route.ClientKey, s.viteBase)
-			bodyEntryTag = s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase)
+			headAssetTags = s.viteManifest.headAssetTags(route.ClientKey, s.viteBase, nonce)
+			bodyEntryTag = s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase, nonce)
 		}
-		if err := s.renderStreaming(w, r, ev, inner, streams, status, headBytes, headAssetTags, bodyEntryTag, payload); err != nil {
+		if err := s.renderStreaming(w, r, ev, inner, streams, status, headBytes, headAssetTags, bodyEntryTag, payload, nonce); err != nil {
 			if errors.Is(err, kit.ErrClientGone) {
 				return nil, errStreamingWrote
 			}
@@ -913,7 +926,7 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 		buf.WriteRaw(bytesAsString(headBytes))
 	}
 	if route != nil && route.ClientKey != "" {
-		if tags := s.viteManifest.headAssetTags(route.ClientKey, s.viteBase); tags != "" {
+		if tags := s.viteManifest.headAssetTags(route.ClientKey, s.viteBase, nonce); tags != "" {
 			buf.WriteString(tags)
 		}
 	}
@@ -926,14 +939,14 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, ev *kit.Requ
 	if lctx != nil {
 		payload.Deps = lctx.CollectDeps()
 	}
-	s.emitPayloadScriptTag(buf, payload)
+	s.emitPayloadScriptTag(buf, payload, nonce)
 	if route != nil && route.ClientKey != "" {
-		if tag := s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase); tag != "" {
+		if tag := s.viteManifest.bodyEntryTag(route.ClientKey, s.viteBase, nonce); tag != "" {
 			buf.WriteString(tag)
 		}
 	}
-	if s.serviceWorker != "" {
-		buf.WriteString(s.serviceWorker)
+	if sw := s.serviceWorkerTag(nonce); sw != "" {
+		buf.WriteString(sw)
 	}
 	buf.WriteString(s.shellTail)
 
@@ -1090,7 +1103,7 @@ func isClientGone(ctx context.Context, err error) bool {
 // cancels any pending streams, logs once at debug level, and returns
 // kit.ErrClientGone. The caller must treat that as errStreamingWrote so
 // HandleError is not invoked — a disconnect is not a server fault.
-func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, inner func(*render.Writer) error, streams []streamedField, status int, headBytes []byte, headAssetTags, bodyEntryTag string, payload clientPayload) error {
+func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit.RequestEvent, inner func(*render.Writer) error, streams []streamedField, status int, headBytes []byte, headAssetTags, bodyEntryTag string, payload clientPayload, nonce string) error {
 	if ev.Cookies != nil {
 		ev.Cookies.Apply(w)
 	}
@@ -1113,7 +1126,7 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 	if err := inner(buf); err != nil {
 		return err
 	}
-	s.emitPayloadScriptTag(buf, payload)
+	s.emitPayloadScriptTag(buf, payload, nonce)
 
 	ctx := r.Context()
 
@@ -1127,7 +1140,7 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 	}
 
 	for i, f := range streams {
-		emitResolveScript(ctx, buf, f.id, f.stream, s.streamTimeout)
+		emitResolveScript(ctx, buf, f.id, f.stream, s.streamTimeout, nonce)
 		// ctx.Err() is set when the client disconnected and WaitAny
 		// returned early. The resolve script carries an error payload
 		// that we don't need to flush — log once and bail.
@@ -1155,8 +1168,8 @@ func (s *Server) renderStreaming(w http.ResponseWriter, r *http.Request, ev *kit
 	if bodyEntryTag != "" {
 		buf.WriteString(bodyEntryTag)
 	}
-	if s.serviceWorker != "" {
-		buf.WriteString(s.serviceWorker)
+	if sw := s.serviceWorkerTag(nonce); sw != "" {
+		buf.WriteString(sw)
 	}
 	buf.WriteString(s.shellTail)
 	if err := buf.FlushTo(w); err != nil {
@@ -1195,9 +1208,19 @@ func cancelStreams(fs []streamedField) {
 // on timeout, cancellation, or producer error the call carries an error
 // object the client can branch on. Errors are intentionally string-only
 // to avoid leaking goroutine internals.
-func emitResolveScript(ctx context.Context, buf *render.Writer, id uint64, stream kit.StreamedAny, timeout time.Duration) {
+//
+// nonce is the per-request CSP nonce; when non-empty the emitted
+// <script> tag carries nonce="…" so streaming chunks land under the
+// same `script-src 'nonce-…'` directive as the initial payload (#539).
+func emitResolveScript(ctx context.Context, buf *render.Writer, id uint64, stream kit.StreamedAny, timeout time.Duration, nonce string) {
 	v, err := stream.WaitAny(ctx, timeout)
-	buf.WriteString(`<script>__sveltego__resolve(`)
+	if nonce != "" {
+		buf.WriteString(`<script nonce="`)
+		buf.WriteString(nonce)
+		buf.WriteString(`">__sveltego__resolve(`)
+	} else {
+		buf.WriteString(`<script>__sveltego__resolve(`)
+	}
 	buf.WriteString(strconv.FormatUint(id, 10))
 	buf.WriteString(`,`)
 	if err != nil {

--- a/packages/sveltego/server/server.go
+++ b/packages/sveltego/server/server.go
@@ -162,10 +162,11 @@ type Server struct {
 	viteManifest viteManifestMap
 	viteBase     string
 
-	// serviceWorker is the precomputed registration <script> tag emitted
-	// before </body> when Config.ServiceWorker is true. Empty disables the
-	// runtime injection entirely (#89).
-	serviceWorker string
+	// serviceWorker indicates whether the registration <script> tag
+	// should be emitted before </body>. The actual tag is built per
+	// request via serviceWorkerTag so it can carry the per-request CSP
+	// nonce (#539). False disables the runtime injection entirely (#89).
+	serviceWorker bool
 
 	// clientManifest is the SPA route table embedded in the initial SSR
 	// payload so the client SPA router can match link URLs and look up
@@ -291,10 +292,7 @@ func New(cfg Config) (*Server, error) {
 		viteBase = "/static/_app"
 	}
 
-	swTag := ""
-	if cfg.ServiceWorker {
-		swTag = serviceWorkerRegisterScript
-	}
+	swEnabled := cfg.ServiceWorker
 	done := make(chan struct{})
 	clientManifest := buildClientManifest(tree.Routes())
 	appVersion := computeAppVersion(cfg.ViteManifest)
@@ -312,7 +310,7 @@ func New(cfg Config) (*Server, error) {
 		shellTail:          tail,
 		viteManifest:       vm,
 		viteBase:           viteBase,
-		serviceWorker:      swTag,
+		serviceWorker:      swEnabled,
 		clientManifest:     clientManifest,
 		encodedManifest:    encodePayloadField("manifest", clientManifest),
 		encodedAppVersion:  encodeAppVersionField(appVersion),

--- a/packages/sveltego/server/serviceworker.go
+++ b/packages/sveltego/server/serviceworker.go
@@ -1,16 +1,29 @@
 package server
 
-// serviceWorkerRegisterScript is the inline <script> emitted before
-// </body> when Config.ServiceWorker is true. It feature-gates registration
-// on `'serviceWorker' in navigator` so non-supporting browsers no-op,
-// scope is rooted at "/" so SPA navigation under any sub-path is covered,
-// and registration runs on `load` to avoid contending with the page's
-// initial render. Errors are logged at warn level rather than thrown so
-// a SW fault does not block hydration (#89).
-const serviceWorkerRegisterScript = `<script>` +
-	`if('serviceWorker' in navigator){` +
+// serviceWorkerScriptBody is the inline JS payload registering the
+// service worker (#89). It feature-gates registration on
+// `'serviceWorker' in navigator` so non-supporting browsers no-op,
+// scope is rooted at "/" so SPA navigation under any sub-path is
+// covered, and registration runs on `load` to avoid contending with
+// the page's initial render. Errors are logged at warn level rather
+// than thrown so a SW fault does not block hydration.
+const serviceWorkerScriptBody = `if('serviceWorker' in navigator){` +
 	`addEventListener('load',function(){` +
 	`navigator.serviceWorker.register('/service-worker.js',{scope:'/'})` +
 	`.catch(function(e){console.warn('sveltego: service worker registration failed',e)});` +
 	`});` +
-	`}</script>`
+	`}`
+
+// serviceWorkerTag returns the inline registration <script> tag with
+// an optional CSP nonce attribute. Returns the empty string when the
+// service worker is disabled for this server. The nonce is the
+// per-request CSP nonce (kit.Nonce(ev)); empty for off-CSP requests.
+func (s *Server) serviceWorkerTag(nonce string) string {
+	if !s.serviceWorker {
+		return ""
+	}
+	if nonce == "" {
+		return `<script>` + serviceWorkerScriptBody + `</script>`
+	}
+	return `<script nonce="` + nonce + `">` + serviceWorkerScriptBody + `</script>`
+}

--- a/packages/sveltego/server/vite.go
+++ b/packages/sveltego/server/vite.go
@@ -47,6 +47,17 @@ func (m viteManifestMap) globalCSSFile() string {
 	return c.File
 }
 
+// nonceAttr returns ` nonce="<nonce>"` (with a leading space) when nonce
+// is non-empty, otherwise the empty string. Stylesheet links do not
+// require a nonce under the default style-src directive, so callers
+// pass nonce only into the script + modulepreload emit sites.
+func nonceAttr(nonce string) string {
+	if nonce == "" {
+		return ""
+	}
+	return ` nonce="` + nonce + `"`
+}
+
 // headAssetTags returns the head-belonging HTML fragment for routeKey:
 // stylesheet links plus <link rel="modulepreload"> hints for every
 // transitive import. Returns an empty string when routeKey is not in the
@@ -55,13 +66,19 @@ func (m viteManifestMap) globalCSSFile() string {
 // prepended as a <link rel="stylesheet"> so the global stylesheet loads
 // alongside route-scoped CSS.
 //
+// nonce is the per-request CSP nonce (kit.Nonce(ev)); when non-empty
+// each <link rel="modulepreload"> tag carries nonce="…" so a strict
+// `script-src 'nonce-…'` directive permits the preloaded chunks
+// without falling back to 'unsafe-inline' or per-asset hashes. Empty
+// nonce (CSP off) emits the legacy unattributed form.
+//
 // The entry <script type="module"> is intentionally NOT in this fragment
 // — see bodyEntryTag. End-of-body script placement matches SvelteKit's
 // %sveltekit.body% convention so the browser paints SSR HTML before any
 // JS chunk executes (better LCP, fewer hydration-timing races). The
 // modulepreload hints stay in <head> so the browser still discovers and
 // parallel-fetches the chunks during HTML parse.
-func (m viteManifestMap) headAssetTags(routeKey, base string) string {
+func (m viteManifestMap) headAssetTags(routeKey, base, nonce string) string {
 	if m == nil {
 		return ""
 	}
@@ -70,6 +87,7 @@ func (m viteManifestMap) headAssetTags(routeKey, base string) string {
 	}
 	chunk := m[routeKey]
 	base = strings.TrimRight(base, "/")
+	na := nonceAttr(nonce)
 
 	var b strings.Builder
 
@@ -94,7 +112,7 @@ func (m viteManifestMap) headAssetTags(routeKey, base string) string {
 			if !ok {
 				continue
 			}
-			fmt.Fprintf(&b, `<link rel="modulepreload" href="%s/%s">`, base, ic.File)
+			fmt.Fprintf(&b, `<link rel="modulepreload"%s href="%s/%s">`, na, base, ic.File)
 			b.WriteByte('\n')
 			collectImports(imp)
 		}
@@ -114,12 +132,17 @@ func (m viteManifestMap) headAssetTags(routeKey, base string) string {
 // shell tail. Returns an empty string when routeKey is not in the
 // manifest or when m is nil.
 //
+// nonce is the per-request CSP nonce (kit.Nonce(ev)); when non-empty
+// the emitted tag carries nonce="…" so a strict
+// `script-src 'nonce-…'` directive permits the entry chunk without
+// falling back to 'unsafe-inline' or per-asset hashes.
+//
 // Pairs with headAssetTags: the head fragment carries stylesheet + module
 // preload hints (parsed during the HEAD walk so the browser starts the
 // chunk fetches in parallel with HTML parsing); the body fragment carries
 // the entry script that consumes those preloaded chunks once the SSR
 // body has fully parsed.
-func (m viteManifestMap) bodyEntryTag(routeKey, base string) string {
+func (m viteManifestMap) bodyEntryTag(routeKey, base, nonce string) string {
 	if m == nil {
 		return ""
 	}
@@ -130,7 +153,7 @@ func (m viteManifestMap) bodyEntryTag(routeKey, base string) string {
 	base = strings.TrimRight(base, "/")
 
 	var b strings.Builder
-	fmt.Fprintf(&b, `<script type="module" src="%s/%s"></script>`, base, chunk.File)
+	fmt.Fprintf(&b, `<script type="module"%s src="%s/%s"></script>`, nonceAttr(nonce), base, chunk.File)
 	b.WriteByte('\n')
 	return b.String()
 }

--- a/packages/sveltego/server/vite_test.go
+++ b/packages/sveltego/server/vite_test.go
@@ -40,8 +40,8 @@ func TestAssetTags_GlobalCSSInjection(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	headTags := m.headAssetTags(".gen/client/routes/_page/entry.ts", "/_app")
-	bodyTag := m.bodyEntryTag(".gen/client/routes/_page/entry.ts", "/_app")
+	headTags := m.headAssetTags(".gen/client/routes/_page/entry.ts", "/_app", "")
+	bodyTag := m.bodyEntryTag(".gen/client/routes/_page/entry.ts", "/_app", "")
 
 	for _, want := range []string{
 		`<link rel="stylesheet" href="/_app/assets/app-def.css">`,
@@ -88,8 +88,8 @@ func TestAssetTags_NoGlobalCSSWhenAbsent(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 
-	headTags := m.headAssetTags(".gen/client/routes/_page/entry.ts", "/_app")
-	bodyTag := m.bodyEntryTag(".gen/client/routes/_page/entry.ts", "/_app")
+	headTags := m.headAssetTags(".gen/client/routes/_page/entry.ts", "/_app", "")
+	bodyTag := m.bodyEntryTag(".gen/client/routes/_page/entry.ts", "/_app", "")
 
 	if strings.Contains(headTags, "app-") {
 		t.Errorf("unexpected global CSS tag in no-addon build:\n%s", headTags)
@@ -99,6 +99,92 @@ func TestAssetTags_NoGlobalCSSWhenAbsent(t *testing.T) {
 	}
 	if strings.Contains(headTags, `<script type="module"`) {
 		t.Errorf("entry script must not appear in head fragment; got:\n%s", headTags)
+	}
+}
+
+// TestAssetTags_NonceAttachedWhenSet pins issue #539: when a per-request
+// CSP nonce is supplied, every auto-emitted <script type="module"> and
+// <link rel="modulepreload"> carries the same nonce. <link rel="stylesheet">
+// is intentionally skipped — the default CSP style-src does not gate on
+// nonce, and Vite's hashed CSS already lives under /_app.
+func TestAssetTags_NonceAttachedWhenSet(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `{
+		".gen/client/routes/_page/entry.ts": {
+			"file": "assets/_page-abc.js",
+			"name": "routes/_page",
+			"src": ".gen/client/routes/_page/entry.ts",
+			"isEntry": true,
+			"imports": ["_shared"],
+			"css": ["assets/_page-xyz.css"]
+		},
+		"_shared": {
+			"file": "assets/shared-def.js"
+		}
+	}`
+
+	m, err := parseViteManifest(manifest)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	const nonce = "abc123XYZ"
+	headTags := m.headAssetTags(".gen/client/routes/_page/entry.ts", "/_app", nonce)
+	bodyTag := m.bodyEntryTag(".gen/client/routes/_page/entry.ts", "/_app", nonce)
+
+	wantBody := `<script type="module" nonce="abc123XYZ" src="/_app/assets/_page-abc.js"></script>`
+	if !strings.Contains(bodyTag, wantBody) {
+		t.Errorf("bodyEntryTag missing nonce attribute; want %q, got:\n%s", wantBody, bodyTag)
+	}
+	wantPreload := `<link rel="modulepreload" nonce="abc123XYZ" href="/_app/assets/shared-def.js">`
+	if !strings.Contains(headTags, wantPreload) {
+		t.Errorf("headAssetTags missing nonce on modulepreload; want %q, got:\n%s", wantPreload, headTags)
+	}
+	// Stylesheet links must NOT carry nonce (style-src not gated on nonce).
+	if strings.Contains(headTags, `<link rel="stylesheet" nonce=`) {
+		t.Errorf("stylesheet links should not carry nonce; got:\n%s", headTags)
+	}
+}
+
+// TestAssetTags_NoNonceWhenEmpty pins the byte-identical CSP-off output:
+// passing an empty nonce string emits the legacy unattributed form so
+// existing builds (CSP=Off) produce zero diff.
+func TestAssetTags_NoNonceWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `{
+		".gen/client/routes/_page/entry.ts": {
+			"file": "assets/_page-abc.js",
+			"name": "routes/_page",
+			"src": ".gen/client/routes/_page/entry.ts",
+			"isEntry": true,
+			"imports": ["_shared"]
+		},
+		"_shared": {
+			"file": "assets/shared-def.js"
+		}
+	}`
+
+	m, err := parseViteManifest(manifest)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	headTags := m.headAssetTags(".gen/client/routes/_page/entry.ts", "/_app", "")
+	bodyTag := m.bodyEntryTag(".gen/client/routes/_page/entry.ts", "/_app", "")
+
+	if strings.Contains(headTags, `nonce=`) {
+		t.Errorf("headAssetTags must not contain nonce when CSP off; got:\n%s", headTags)
+	}
+	if strings.Contains(bodyTag, `nonce=`) {
+		t.Errorf("bodyEntryTag must not contain nonce when CSP off; got:\n%s", bodyTag)
+	}
+	if !strings.Contains(bodyTag, `<script type="module" src="/_app/assets/_page-abc.js"></script>`) {
+		t.Errorf("bodyEntryTag legacy unattributed form changed:\n%s", bodyTag)
+	}
+	if !strings.Contains(headTags, `<link rel="modulepreload" href="/_app/assets/shared-def.js">`) {
+		t.Errorf("headAssetTags legacy unattributed form changed:\n%s", headTags)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #539. Per-request CSP nonce now propagates onto every script and module-preload tag the server emits at request time, so a `kit.CSPConfig{Mode: kit.CSPStrict}` deploy no longer needs `'unsafe-inline'` (or per-asset hashes) for hydration to work.

- `viteManifestMap.headAssetTags` / `bodyEntryTag` (and the parallel `internal/vite.Manifest.Tags`) take a `nonce string` and attach `nonce="…"` to the `<script type="module">` entry and every `<link rel="modulepreload">` hint when non-empty.
- `emitPayloadScriptTag` carries the nonce on the JSON hydration `<script id="sveltego-data">`. `emitResolveScript` carries it on streaming `<script>__sveltego__resolve(...)</script>` chunks. `Server.serviceWorkerTag(nonce)` replaces the static swTag so the SW registration script also inherits the nonce.
- `kit.RenderCtx.Nonce()` mirrors `RenderCtx.CSRFToken()`. `runtime/svelte/server.PageState` gets a `Nonce` field that codegen populates (3 emit sites in `internal/codegen/manifest.go`).
- Empty nonce keeps the legacy unattributed form so off-CSP builds and SSG output stay byte-stable.

## Before / After (CSPStrict)

Before — emitted tags carried no nonce so a strict `script-src 'nonce-…'` directive blocked them:

```
Content-Security-Policy: ... script-src 'nonce-AbC123' 'strict-dynamic' ...

<link rel="modulepreload" href="/static/_app/_app/shared-def.js">
<script id="sveltego-data" type="application/json">{...}</script>
<script type="module" src="/static/_app/_app/page-abc.js"></script>
<script>if('serviceWorker' in navigator){...}</script>
```

After — every emitted tag carries the same nonce as the header:

```
Content-Security-Policy: base-uri 'self'; ...; script-src 'nonce-NfB1_Tbm_83-jQw7C27UWg' 'strict-dynamic'; style-src 'self' 'unsafe-inline'

<link rel="modulepreload" nonce="NfB1_Tbm_83-jQw7C27UWg" href="/static/_app/_app/shared-def.js">
<script id="sveltego-data" nonce="NfB1_Tbm_83-jQw7C27UWg" type="application/json">{...}</script>
<script type="module" nonce="NfB1_Tbm_83-jQw7C27UWg" src="/static/_app/_app/page-abc.js"></script>
<script nonce="NfB1_Tbm_83-jQw7C27UWg">if('serviceWorker' in navigator){...}</script>
```

CSP off — byte-stable, no nonce attribute leaks:

```
<link rel="modulepreload" href="/static/_app/_app/shared-def.js">
<script id="sveltego-data" type="application/json">{...}</script>
<script type="module" src="/static/_app/_app/page-abc.js"></script>
<script>if('serviceWorker' in navigator){...}</script>
```

## Test plan

- [x] `go build ./...` across the workspace
- [x] `go vet ./packages/sveltego/...`
- [x] `go test -race ./packages/sveltego/...` (1633 passed)
- [x] `gofumpt -l .` clean; `goimports -l -local github.com/binsarjr/sveltego .` clean
- [x] `internal/codegen` goldens regenerated for the 3 PageState emit sites
- [x] `server/vite_test.go` — nonce-on and nonce-off matrices
- [x] `server/csp_integration_test.go` — end-to-end assertion that header nonce matches every emitted tag (entry script, modulepreload link, hydration payload, service worker), plus off-CSP byte stability
- [x] `docs/guide/csp.md` — new "Auto-injected scripts" section documents the inheritance contract; SSG carve-out called out (no per-request value at build time, use hashes / `'strict-dynamic'`)

## Out of scope

- SRI hashes (separate concern)
- SSG nonce (impossible — documented)
- Changing `kit.DefaultCSPDirectives()` defaults