### PR TITLE
fix(codegen): lower CSRF input into client source for fallback (#540)

### DIFF
--- a/packages/sveltego/internal/codegen/build.go
+++ b/packages/sveltego/internal/codegen/build.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/binsarjr/sveltego/packages/sveltego/exports/kit"
+	"github.com/binsarjr/sveltego/packages/sveltego/internal/codegen/csrffallback"
 	"github.com/binsarjr/sveltego/packages/sveltego/internal/codegen/svelterender"
 	"github.com/binsarjr/sveltego/packages/sveltego/internal/routescan"
 	"github.com/binsarjr/sveltego/packages/sveltego/internal/vite"
@@ -218,7 +219,8 @@ func Build(ctx context.Context, opts BuildOptions) (*BuildResult, error) {
 			// drop ClientKey from every route, leaving the frozen HTML
 			// without its <script type="module"> client bundle tag and
 			// breaking hydration on SSG pages.
-			ck, relPageFromRouter, chainKey, cerr := emitClientEntry(opts.ProjectRoot, outDir, routesDir, route, pageName, hasSnapshot, !opts.NoClient)
+			csrfLowering := route.SSRFallback && routeCSRFEnabled(route.Pattern, routeOptions)
+			ck, relPageFromRouter, chainKey, cerr := emitClientEntry(opts.ProjectRoot, outDir, routesDir, route, pageName, hasSnapshot, csrfLowering, !opts.NoClient)
 			if cerr != nil {
 				return nil, cerr
 			}
@@ -442,7 +444,15 @@ func serviceWorkerEntry(projectRoot string) string {
 // and the layout-chain key. Routes without a chain mount the page
 // directly; chained routes mount the shared wrapper and seed
 // wrapperState.Page from the page module's default export.
-func emitClientEntry(projectRoot, outDir, routesDir string, route routescan.ScannedRoute, pageName string, hasSnapshot bool, writeFiles bool) (string, string, string, error) {
+//
+// When csrfLowering is true the route is ssr-fallback annotated AND
+// has CSRF enabled (#540): emit a Svelte-source rewrite under
+// `.gen/csrf-fallback/<routeKey>/_page.svelte` that splices the hidden
+// `_csrf_token` input into every POST form so Svelte 5 hydrate sees
+// the input in the vDOM and does not strip the SSR-rendered DOM node.
+// The sidecar continues reading the user's original `_page.svelte`;
+// the post-hoc `csrfinject.Rewrite` keeps the SSR HTML correct.
+func emitClientEntry(projectRoot, outDir, routesDir string, route routescan.ScannedRoute, pageName string, hasSnapshot, csrfLowering, writeFiles bool) (string, string, string, error) {
 	routesParent := filepath.Dir(routesDir)
 	relDir, err := filepath.Rel(routesParent, route.Dir)
 	if err != nil {
@@ -457,6 +467,16 @@ func emitClientEntry(projectRoot, outDir, routesDir string, route routescan.Scan
 		return "", "", "", fmt.Errorf("codegen: client entry svelte rel path: %w", err)
 	}
 	svelteSrc := filepath.ToSlash(routeDirFromRoot) + "/" + pageName
+
+	if csrfLowering && writeFiles {
+		lowered, lerr := emitCSRFFallbackLowering(projectRoot, outDir, routeKey, route.Dir, pageName)
+		if lerr != nil {
+			return "", "", "", lerr
+		}
+		if lowered != "" {
+			svelteSrc = lowered
+		}
+	}
 
 	// Path to the .svelte source from the SPA router directory
 	// (.gen/client/__router/) — depth from routes parent to project root
@@ -510,6 +530,46 @@ func emitClientEntry(projectRoot, outDir, routesDir string, route routescan.Scan
 	}
 
 	return routeKey, relSvelteFromRouter, chainKey, nil
+}
+
+// emitCSRFFallbackLowering writes a CSRF-spliced copy of the user's
+// `_page.svelte` to `.gen/csrf-fallback/<routeKey>/_page.svelte` for an
+// ssr-fallback route that opted into CSRF (#540). Returns the
+// project-relative path of the lowered file (suitable for the client
+// entry's `import Page from`) when the splicer mutated the source, or
+// the empty string when the source contains no POST forms (in which
+// case the caller keeps the original path). The sidecar continues
+// reading the user's original `_page.svelte`; only the client compile
+// is redirected so Svelte 5 hydrate sees the hidden input in vDOM.
+func emitCSRFFallbackLowering(projectRoot, outDir, routeKey, routeDir, pageName string) (string, error) {
+	srcAbs := filepath.Join(routeDir, pageName)
+	contents, err := os.ReadFile(srcAbs) //nolint:gosec // path comes from the trusted route scan
+	if err != nil {
+		return "", fmt.Errorf("codegen: read csrf-fallback source %s: %w", srcAbs, err)
+	}
+	result, err := csrffallback.Lower(csrffallback.LowerOptions{
+		Source:        srcAbs,
+		SourceContent: contents,
+	})
+	if err != nil {
+		return "", fmt.Errorf("codegen: lower csrf-fallback %s: %w", srcAbs, err)
+	}
+	if !result.Mutated {
+		return "", nil
+	}
+	loweredDir := filepath.Join(projectRoot, outDir, "csrf-fallback", filepath.FromSlash(routeKey))
+	if err := os.MkdirAll(loweredDir, 0o755); err != nil {
+		return "", fmt.Errorf("codegen: mkdir csrf-fallback %s: %w", loweredDir, err)
+	}
+	loweredAbs := filepath.Join(loweredDir, pageName)
+	if err := os.WriteFile(loweredAbs, result.Content, genFileMode); err != nil {
+		return "", fmt.Errorf("codegen: write csrf-fallback %s: %w", loweredAbs, err)
+	}
+	rel, err := filepath.Rel(projectRoot, loweredAbs)
+	if err != nil {
+		return "", fmt.Errorf("codegen: csrf-fallback rel path: %w", err)
+	}
+	return filepath.ToSlash(rel), nil
 }
 
 // emitChainWrapper writes a single chainKey-shared wrapper.svelte

--- a/packages/sveltego/internal/codegen/build_test.go
+++ b/packages/sveltego/internal/codegen/build_test.go
@@ -762,3 +762,93 @@ func Load(ctx *kit.LoadCtx) (LayoutData, error) {
 	assertParsesAsGo(t, mirror)
 	assertParsesAsGo(t, wire)
 }
+
+// TestBuild_CSRFFallbackLowersClientSource pins the #540 fix: an
+// ssr-fallback annotated route with CSRF enabled must emit a Svelte
+// source rewrite under .gen/csrf-fallback/<routeKey>/_page.svelte that
+// splices the hidden _csrf_token input into POST forms, and the
+// per-route entry.ts must import the lowered file rather than the
+// user's source. The sidecar continues reading the original source —
+// the post-hoc csrfinject.Rewrite handles the SSR HTML splice — but
+// the client vDOM now contains the input element so Svelte 5 hydrate
+// matches the SSR DOM and stops stripping the field.
+func TestBuild_CSRFFallbackLowersClientSource(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/csrffb\n\ngo 1.23\n")
+	// SSR=false keeps the route off the build-time SSR transpiler so the
+	// test does not require the Node sidecar.
+	writeFile(t, filepath.Join(root, "src", "routes", "login", "_page.server.go"),
+		"//go:build sveltego\n\npackage login\n\nconst SSR = false\nconst CSRF = true\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "login", "_page.svelte"),
+		`<!-- sveltego:ssr-fallback -->
+<script lang="ts">
+  let { data, form } = $props();
+</script>
+
+<form method="post" action="?/login">
+  <input name="username" />
+  <input name="password" type="password" />
+  <button>Sign in</button>
+</form>
+`)
+
+	if _, err := Build(context.Background(), BuildOptions{ProjectRoot: root}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	loweredPath := filepath.Join(root, ".gen", "csrf-fallback", "routes", "login", "_page", "_page.svelte")
+	loweredBytes, err := os.ReadFile(loweredPath)
+	if err != nil {
+		t.Fatalf("lowered _page.svelte not emitted at %s: %v", loweredPath, err)
+	}
+	loweredSrc := string(loweredBytes)
+	if !strings.Contains(loweredSrc, `<input type="hidden" name="_csrf_token" value={`) {
+		t.Errorf("lowered _page.svelte missing hidden CSRF input:\n%s", loweredSrc)
+	}
+	if !strings.Contains(loweredSrc, `globalThis.__sveltego__?.csrfToken`) {
+		t.Errorf("lowered _page.svelte missing client-evaluated value expression:\n%s", loweredSrc)
+	}
+	// Original form open tag is preserved.
+	if !strings.Contains(loweredSrc, `<form method="post" action="?/login">`) {
+		t.Errorf("lowered _page.svelte stripped original form tag:\n%s", loweredSrc)
+	}
+
+	entryPath := filepath.Join(root, ".gen", "client", "routes", "login", "_page", "entry.ts")
+	entryBytes, err := os.ReadFile(entryPath)
+	if err != nil {
+		t.Fatalf("login entry.ts not emitted: %v", err)
+	}
+	entrySrc := string(entryBytes)
+	// Entry must import from the lowered .gen/csrf-fallback path, NOT
+	// the user's src/routes path.
+	if !strings.Contains(entrySrc, "/csrf-fallback/") {
+		t.Errorf("login entry.ts must import from .gen/csrf-fallback/, got:\n%s", entrySrc)
+	}
+	if strings.Contains(entrySrc, `from "../../../../src/routes/login/_page.svelte"`) {
+		t.Errorf("login entry.ts must NOT import the user's source directly when CSRF lowering applies:\n%s", entrySrc)
+	}
+}
+
+// TestBuild_CSRFFallbackSkipsLoweringWithoutPostForm pins the no-op
+// case: an ssr-fallback annotated route whose source has no POST form
+// must NOT emit a lowered file (no work to do) and the entry.ts must
+// still point at the user's source.
+func TestBuild_CSRFFallbackSkipsLoweringWithoutPostForm(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/csrffb\n\ngo 1.23\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "about", "_page.server.go"),
+		"//go:build sveltego\n\npackage about\n\nconst SSR = false\nconst CSRF = true\n")
+	writeFile(t, filepath.Join(root, "src", "routes", "about", "_page.svelte"),
+		"<!-- sveltego:ssr-fallback -->\n<h1>about</h1>\n")
+
+	if _, err := Build(context.Background(), BuildOptions{ProjectRoot: root}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	loweredPath := filepath.Join(root, ".gen", "csrf-fallback", "routes", "about", "_page", "_page.svelte")
+	if _, err := os.Stat(loweredPath); err == nil {
+		t.Errorf("lowered file emitted for source without POST forms: %s", loweredPath)
+	}
+}

--- a/packages/sveltego/internal/codegen/csrffallback/lower.go
+++ b/packages/sveltego/internal/codegen/csrffallback/lower.go
@@ -1,0 +1,566 @@
+// Package csrffallback rewrites the Svelte source of an ssr-fallback
+// route's `_page.svelte` so the hidden `_csrf_token` input lives in the
+// component's own vDOM. Closes #540: the runtime sidecar's post-hoc
+// `csrfinject.Rewrite` produces correct SSR HTML, but Svelte 5
+// `hydrate()` walks DOM-vs-vDOM and strips the unmatched DOM input
+// because the user's source has no input element. Lowering at the
+// source level puts the input in vDOM so hydration matches.
+//
+// The lowered file is paired with the unmodified user source: the
+// sidecar continues reading the user's `_page.svelte` (post-hoc rewrite
+// adds the real token to the SSR HTML), but the per-route client
+// `entry.ts` imports the lowered file. The client's vDOM therefore
+// contains the input element with a value mustache that resolves
+// against `globalThis.__sveltego__?.csrfToken` — the same token the
+// hydration payload carries — so Svelte 5 reconciles the live DOM
+// input value with the SSR-rendered token without stripping the node.
+//
+// The scanner mirrors the rules already documented on
+// `runtime/svelte/csrfinject` and
+// `internal/codegen/svelte_js2go/lower_csrf.go`:
+//
+//   - method="post" / 'post' / POST etc. — case-insensitive.
+//   - The `nocsrf` attribute opts a single form out and is stripped.
+//   - A form that already carries a hidden `_csrf_token` input
+//     immediately after its open tag is left alone (idempotent).
+//   - Self-closing forms and forms with a dynamic method are skipped.
+//   - `<script>` and `<style>` blocks are skipped wholesale so a `<form`
+//     string literal in JS or CSS is not mistaken for HTML.
+package csrffallback
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// CSRFValueExpr is the Svelte mustache expression spliced into the
+// hidden input's `value=` attribute. It resolves at hydration time
+// against the `window.__sveltego__` object that `cliententry.ts`
+// seeds from the JSON payload before calling `hydrate()`. SSR
+// rendering through the sidecar evaluates the expression to the
+// empty string (the Node sandbox has no `__sveltego__` global), but
+// the post-hoc `csrfinject.Rewrite` on the sidecar HTML still emits
+// a complete input with the real token in the response bytes — the
+// vDOM input only has to exist for hydration to match the DOM.
+const CSRFValueExpr = `globalThis.__sveltego__?.csrfToken ?? ''`
+
+// LowerOptions controls a single Lower invocation.
+//
+// Source is the absolute path of the user's `_page.svelte` on disk.
+// SourceContent holds its bytes. Returning the path lets the rewriter
+// emit absolute import specifiers when it has to relocate a relative
+// import out of the user's directory.
+type LowerOptions struct {
+	Source        string
+	SourceContent []byte
+}
+
+// LowerResult bundles the rewritten Svelte source and a mutated flag.
+//
+// Mutated is false when the input contained no POST forms (and no
+// nocsrf opt-outs); callers can fall back to the original source in
+// that case to avoid emitting an unnecessary lowered file.
+type LowerResult struct {
+	Content []byte
+	Mutated bool
+}
+
+// Lower rewrites src so every `<form method="post">` open tag is
+// followed by a hidden `_csrf_token` input whose value mustache
+// resolves to `CSRFValueExpr`. Forms carrying a `nocsrf` attribute are
+// left alone (and the attribute is stripped). Forms already followed
+// by a hidden `_csrf_token` input are left alone. Relative imports in
+// the source's `<script>` block are rewritten to absolute file paths
+// anchored at the source's directory so the lowered file can live
+// outside the user's route directory without breaking module
+// resolution. Returns the original bytes (Mutated=false) when no form
+// or import required a rewrite.
+func Lower(opts LowerOptions) (LowerResult, error) {
+	if len(opts.SourceContent) == 0 {
+		return LowerResult{Content: opts.SourceContent}, nil
+	}
+	src := string(opts.SourceContent)
+
+	formsRewrote, body, err := spliceForms(src)
+	if err != nil {
+		return LowerResult{}, err
+	}
+
+	importsRewrote := false
+	if opts.Source != "" {
+		body, importsRewrote = rewriteRelativeImports(body, filepath.Dir(opts.Source))
+	}
+
+	if !formsRewrote && !importsRewrote {
+		return LowerResult{Content: opts.SourceContent}, nil
+	}
+	return LowerResult{Content: []byte(body), Mutated: formsRewrote}, nil
+}
+
+// spliceForms walks the Svelte source skipping `<script>` and `<style>`
+// blocks and rewrites POST form open tags. Returns whether any form was
+// rewritten and the resulting source.
+func spliceForms(src string) (bool, string, error) {
+	var out strings.Builder
+	out.Grow(len(src) + 128)
+
+	mutated := false
+	pos := 0
+	for pos < len(src) {
+		nextSkip, skipEnd, err := nextSkipBlock(src, pos)
+		if err != nil {
+			return false, "", err
+		}
+		end := nextSkip
+		if end < 0 {
+			end = len(src)
+		}
+		// Process the [pos, end) HTML range looking for form opens.
+		mutatedHere, processed := processFormRange(src[pos:end])
+		if mutatedHere {
+			mutated = true
+		}
+		out.WriteString(processed)
+		if nextSkip < 0 {
+			break
+		}
+		out.WriteString(src[nextSkip:skipEnd])
+		pos = skipEnd
+	}
+	return mutated, out.String(), nil
+}
+
+// nextSkipBlock locates the next `<script>` or `<style>` block start at
+// or after pos. Returns its start index, the index one past the
+// closing `</script>` / `</style>` tag, and an error when the open tag
+// has no matching close. Returns (-1, -1, nil) when no skip block
+// remains in src[pos:].
+func nextSkipBlock(src string, pos int) (int, int, error) {
+	for i := pos; i < len(src); {
+		if src[i] != '<' {
+			i++
+			continue
+		}
+		rest := src[i:]
+		switch {
+		case caseInsensitivePrefix(rest, "<script"):
+			closeOpen := strings.IndexByte(src[i:], '>')
+			if closeOpen < 0 {
+				return -1, -1, fmt.Errorf("csrffallback: unterminated <script open at offset %d", i)
+			}
+			endOpen := i + closeOpen + 1
+			closeIdx := indexCloseTag(src, endOpen, "script")
+			if closeIdx < 0 {
+				return -1, -1, fmt.Errorf("csrffallback: missing </script> after offset %d", i)
+			}
+			return i, closeIdx, nil
+		case caseInsensitivePrefix(rest, "<style"):
+			closeOpen := strings.IndexByte(src[i:], '>')
+			if closeOpen < 0 {
+				return -1, -1, fmt.Errorf("csrffallback: unterminated <style open at offset %d", i)
+			}
+			endOpen := i + closeOpen + 1
+			closeIdx := indexCloseTag(src, endOpen, "style")
+			if closeIdx < 0 {
+				return -1, -1, fmt.Errorf("csrffallback: missing </style> after offset %d", i)
+			}
+			return i, closeIdx, nil
+		default:
+			i++
+		}
+	}
+	return -1, -1, nil
+}
+
+// caseInsensitivePrefix reports whether s starts with prefix
+// (case-insensitive) AND the byte at len(prefix) is either absent or a
+// non-name continuation (whitespace, `>`, or `/`). The continuation
+// guard prevents `<scripted>` from matching `<script`.
+func caseInsensitivePrefix(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		if asciiToLower(s[i]) != asciiToLower(prefix[i]) {
+			return false
+		}
+	}
+	if len(s) == len(prefix) {
+		return true
+	}
+	c := s[len(prefix)]
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '>' || c == '/'
+}
+
+// indexCloseTag returns the byte index one past `</name>` (case
+// insensitive) at or after start, or -1 when no close tag exists.
+func indexCloseTag(s string, start int, name string) int {
+	needle := "</"
+	for i := start; i < len(s); {
+		j := strings.Index(s[i:], needle)
+		if j < 0 {
+			return -1
+		}
+		k := i + j + len(needle)
+		if k+len(name) > len(s) {
+			return -1
+		}
+		match := true
+		for n := 0; n < len(name); n++ {
+			if asciiToLower(s[k+n]) != name[n] {
+				match = false
+				break
+			}
+		}
+		if !match {
+			i = k
+			continue
+		}
+		// Allow whitespace then `>`; reject if next char continues the name
+		// (so `</scripted>` does not match `</script`).
+		m := k + len(name)
+		for m < len(s) && (s[m] == ' ' || s[m] == '\t' || s[m] == '\n' || s[m] == '\r') {
+			m++
+		}
+		if m >= len(s) || s[m] != '>' {
+			i = k
+			continue
+		}
+		return m + 1
+	}
+	return -1
+}
+
+// processFormRange runs the POST-form splicer over a contiguous HTML
+// range that contains no `<script>` or `<style>` blocks. Returns
+// whether any form was rewritten.
+func processFormRange(html string) (bool, string) {
+	if !containsFormStart(html) {
+		return false, html
+	}
+	var out strings.Builder
+	out.Grow(len(html) + 64)
+
+	mutated := false
+	pos := 0
+	for {
+		idx := indexFormStart(html, pos)
+		if idx < 0 {
+			break
+		}
+		end, rest, attrs, ok := scanFormOpenTag(html, idx)
+		if !ok {
+			out.WriteString(html[pos : idx+1])
+			pos = idx + 1
+			continue
+		}
+		out.WriteString(html[pos:idx])
+		switch {
+		case !attrs.isPost:
+			out.WriteString(html[idx:end])
+		case attrs.nocsrf:
+			out.WriteString(rest)
+			mutated = true
+		case attrs.alreadyInjected:
+			out.WriteString(html[idx:end])
+		default:
+			out.WriteString(rest)
+			out.WriteString(`<input type="hidden" name="_csrf_token" value={`)
+			out.WriteString(CSRFValueExpr)
+			out.WriteString(`}>`)
+			mutated = true
+		}
+		pos = end
+	}
+	out.WriteString(html[pos:])
+	return mutated, out.String()
+}
+
+type formAttrs struct {
+	isPost          bool
+	nocsrf          bool
+	alreadyInjected bool
+}
+
+// containsFormStart cheaply rejects strings without a `<form` token.
+func containsFormStart(s string) bool {
+	for i := 0; i+5 <= len(s); i++ {
+		if s[i] != '<' {
+			continue
+		}
+		if asciiToLower(s[i+1]) == 'f' &&
+			asciiToLower(s[i+2]) == 'o' &&
+			asciiToLower(s[i+3]) == 'r' &&
+			asciiToLower(s[i+4]) == 'm' {
+			return true
+		}
+	}
+	return false
+}
+
+// indexFormStart returns the byte index of the next `<form` token at or
+// after start; -1 when none. Match is case-insensitive on the tag name
+// and requires the byte after `<form` to be `>`, `/`, or whitespace so
+// `<form>` does not collide with `<formal>`.
+func indexFormStart(s string, start int) int {
+	for i := start; i+5 <= len(s); i++ {
+		if s[i] != '<' {
+			continue
+		}
+		if asciiToLower(s[i+1]) != 'f' ||
+			asciiToLower(s[i+2]) != 'o' ||
+			asciiToLower(s[i+3]) != 'r' ||
+			asciiToLower(s[i+4]) != 'm' {
+			continue
+		}
+		if i+5 == len(s) {
+			return i
+		}
+		next := s[i+5]
+		if next == '>' || next == '/' || next == ' ' || next == '\t' || next == '\n' || next == '\r' {
+			return i
+		}
+	}
+	return -1
+}
+
+// scanFormOpenTag walks a `<form ...>` open tag starting at idx and
+// returns the position one past the closing `>`, the open-tag bytes
+// with any `nocsrf` attribute stripped, the parsed flags, and ok=false
+// when the tag is malformed or self-closing. Tracks single- and
+// double-quoted attribute values so a quoted `>` is not mistaken for
+// the tag close, and tolerates Svelte mustache attribute values such
+// as `action={`?/login`}` by tracking matching `{` / `}` pairs.
+func scanFormOpenTag(s string, idx int) (int, string, formAttrs, bool) {
+	pos := idx + len("<form")
+	if pos > len(s) {
+		return 0, "", formAttrs{}, false
+	}
+	type attrSpan struct {
+		nameStart, nameEnd int
+		valStart, valEnd   int
+		hasValue           bool
+		quote              byte
+	}
+	var (
+		spans      []attrSpan
+		closeAt    = -1
+		selfClose  bool
+		stripStart = -1
+		stripEnd   = -1
+	)
+	i := pos
+	for i < len(s) {
+		c := s[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i++
+			continue
+		}
+		if c == '/' {
+			if i+1 < len(s) && s[i+1] == '>' {
+				selfClose = true
+				closeAt = i + 1
+				break
+			}
+			i++
+			continue
+		}
+		if c == '>' {
+			closeAt = i
+			break
+		}
+		nameStart := i
+		for i < len(s) {
+			b := s[i]
+			if b == '=' || b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '>' || b == '/' {
+				break
+			}
+			i++
+		}
+		nameEnd := i
+		span := attrSpan{nameStart: nameStart, nameEnd: nameEnd}
+		j := i
+		for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\n' || s[j] == '\r') {
+			j++
+		}
+		if j < len(s) && s[j] == '=' {
+			span.hasValue = true
+			j++
+			for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\n' || s[j] == '\r') {
+				j++
+			}
+			if j >= len(s) {
+				break
+			}
+			switch s[j] {
+			case '"', '\'':
+				span.quote = s[j]
+				j++
+				span.valStart = j
+				for j < len(s) && s[j] != span.quote {
+					j++
+				}
+				if j >= len(s) {
+					return 0, "", formAttrs{}, false
+				}
+				span.valEnd = j
+				j++
+			case '{':
+				depth := 1
+				j++
+				span.valStart = j
+				for j < len(s) && depth > 0 {
+					switch s[j] {
+					case '{':
+						depth++
+					case '}':
+						depth--
+					}
+					if depth == 0 {
+						break
+					}
+					j++
+				}
+				if depth != 0 {
+					return 0, "", formAttrs{}, false
+				}
+				span.valEnd = j
+				j++
+			default:
+				span.valStart = j
+				for j < len(s) {
+					b := s[j]
+					if b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '>' || b == '/' {
+						break
+					}
+					j++
+				}
+				span.valEnd = j
+			}
+			i = j
+		}
+		spans = append(spans, span)
+	}
+	if closeAt < 0 {
+		return 0, "", formAttrs{}, false
+	}
+	if selfClose {
+		return closeAt + 1, s[idx : closeAt+1], formAttrs{}, true
+	}
+	end := closeAt + 1
+
+	var attrs formAttrs
+	for _, sp := range spans {
+		name := strings.ToLower(s[sp.nameStart:sp.nameEnd])
+		switch name {
+		case "method":
+			if sp.hasValue && sp.quote != 0 {
+				val := strings.TrimSpace(s[sp.valStart:sp.valEnd])
+				if strings.EqualFold(val, "post") {
+					attrs.isPost = true
+				}
+			}
+		case "nocsrf":
+			attrs.nocsrf = true
+			delStart := sp.nameStart
+			for delStart > pos && (s[delStart-1] == ' ' || s[delStart-1] == '\t' || s[delStart-1] == '\n' || s[delStart-1] == '\r') {
+				delStart--
+			}
+			delEnd := sp.nameEnd
+			if sp.hasValue {
+				if sp.quote != 0 {
+					delEnd = sp.valEnd + 1
+				} else {
+					delEnd = sp.valEnd
+				}
+			}
+			if stripStart == -1 {
+				stripStart, stripEnd = delStart, delEnd
+			} else {
+				if delStart < stripStart {
+					stripStart = delStart
+				}
+				if delEnd > stripEnd {
+					stripEnd = delEnd
+				}
+			}
+		}
+	}
+
+	rest := s[idx:end]
+	if stripStart >= 0 {
+		rest = s[idx:stripStart] + s[stripEnd:end]
+	}
+	if hasInjectedHiddenCSRF(s[end:]) {
+		attrs.alreadyInjected = true
+	}
+	return end, rest, attrs, true
+}
+
+// hasInjectedHiddenCSRF reports whether tail begins (after any
+// whitespace) with a hidden input named `_csrf_token`. Tolerates
+// attribute order and quoting so the splice is idempotent.
+func hasInjectedHiddenCSRF(tail string) bool {
+	i := 0
+	for i < len(tail) && (tail[i] == ' ' || tail[i] == '\t' || tail[i] == '\n' || tail[i] == '\r') {
+		i++
+	}
+	if i+6 > len(tail) || tail[i] != '<' {
+		return false
+	}
+	if asciiToLower(tail[i+1]) != 'i' ||
+		asciiToLower(tail[i+2]) != 'n' ||
+		asciiToLower(tail[i+3]) != 'p' ||
+		asciiToLower(tail[i+4]) != 'u' ||
+		asciiToLower(tail[i+5]) != 't' {
+		return false
+	}
+	limit := i + 6 + 256
+	if limit > len(tail) {
+		limit = len(tail)
+	}
+	end := strings.IndexByte(tail[i+6:limit], '>')
+	if end < 0 {
+		return false
+	}
+	openTag := strings.ToLower(tail[i : i+6+end])
+	return strings.Contains(openTag, `name="_csrf_token"`) ||
+		strings.Contains(openTag, `name='_csrf_token'`) ||
+		strings.Contains(openTag, `name=_csrf_token`)
+}
+
+func asciiToLower(b byte) byte {
+	if b >= 'A' && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}
+
+// relativeImportRe matches `from "./..."` or `from "../..."` (and the
+// dynamic `import("./...")` form). Captures the quote and specifier.
+var relativeImportRe = regexp.MustCompile(`(\bfrom\s*|\bimport\s*\(\s*)(['"])(\.{1,2}\/[^'"]*)(['"])`)
+
+// rewriteRelativeImports walks src once and substitutes every relative
+// import specifier with an absolute path anchored at sourceDir. Vite
+// resolves absolute fs paths natively so the lowered file can live
+// outside the user's route directory without the relative imports
+// breaking. Bare specifiers (`svelte`, `$lib/foo`) are left alone.
+// Returns the rewritten source and whether any specifier was changed.
+func rewriteRelativeImports(src, sourceDir string) (string, bool) {
+	if sourceDir == "" {
+		return src, false
+	}
+	mutated := false
+	out := relativeImportRe.ReplaceAllStringFunc(src, func(match string) string {
+		groups := relativeImportRe.FindStringSubmatch(match)
+		if len(groups) != 5 {
+			return match
+		}
+		absolute := filepath.ToSlash(filepath.Join(sourceDir, groups[3]))
+		mutated = true
+		return groups[1] + groups[2] + absolute + groups[4]
+	})
+	return out, mutated
+}

--- a/packages/sveltego/internal/codegen/csrffallback/lower_test.go
+++ b/packages/sveltego/internal/codegen/csrffallback/lower_test.go
@@ -1,0 +1,223 @@
+package csrffallback
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLower_PostFormGetsHiddenInput(t *testing.T) {
+	src := []byte(`<script lang="ts">
+  let { data, form } = $props();
+</script>
+
+<form method="post" action="?/login">
+  <input name="username">
+  <button>Submit</button>
+</form>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if !got.Mutated {
+		t.Fatalf("expected Mutated=true; output=%q", got.Content)
+	}
+	want := `<input type="hidden" name="_csrf_token" value={` + CSRFValueExpr + `}>`
+	if !strings.Contains(string(got.Content), want) {
+		t.Fatalf("hidden input not spliced; got=%q", got.Content)
+	}
+	// Form open tag itself preserved.
+	if !strings.Contains(string(got.Content), `<form method="post" action="?/login">`) {
+		t.Fatalf("original form open tag missing; got=%q", got.Content)
+	}
+}
+
+func TestLower_GetFormUntouched(t *testing.T) {
+	src := []byte(`<form method="get" action="/search">
+  <input name="q">
+</form>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if got.Mutated {
+		t.Fatalf("expected Mutated=false on GET form; got=%q", got.Content)
+	}
+	if string(got.Content) != string(src) {
+		t.Fatalf("input mutated; got=%q want=%q", got.Content, src)
+	}
+}
+
+func TestLower_NoCSRFOptOutStripsAttrAndSkipsSplice(t *testing.T) {
+	src := []byte(`<form method="post" nocsrf action="/upload">
+  <input type="file" name="file">
+</form>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if !got.Mutated {
+		t.Fatalf("nocsrf opt-out should mutate (strip attribute); got=%q", got.Content)
+	}
+	if strings.Contains(string(got.Content), "nocsrf") {
+		t.Fatalf("nocsrf attribute not stripped; got=%q", got.Content)
+	}
+	if strings.Contains(string(got.Content), `name="_csrf_token"`) {
+		t.Fatalf("hidden input spliced into nocsrf form; got=%q", got.Content)
+	}
+}
+
+func TestLower_FormStringsInScriptIgnored(t *testing.T) {
+	src := []byte(`<script>
+  // String literal that looks like a form open tag must NOT be rewritten.
+  const html = '<form method="post">';
+  const tag = "<form method=\"post\">";
+</script>
+
+<p>nothing here</p>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if got.Mutated {
+		t.Fatalf("script content rewrote; got=%q", got.Content)
+	}
+}
+
+func TestLower_FormStringsInStyleIgnored(t *testing.T) {
+	src := []byte(`<style>
+  /* form[method="post"] selector should not trigger splice */
+  form[method="post"] { display: block; }
+</style>
+
+<p>nothing here</p>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if got.Mutated {
+		t.Fatalf("style content rewrote; got=%q", got.Content)
+	}
+}
+
+func TestLower_MultiplePostFormsAllSpliced(t *testing.T) {
+	src := []byte(`<form method="post" action="?/a"><input name="x"></form>
+<form method="post" action="?/b"><input name="y"></form>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	count := strings.Count(string(got.Content), `name="_csrf_token"`)
+	if count != 2 {
+		t.Fatalf("want 2 csrf inputs spliced; got %d in %q", count, got.Content)
+	}
+}
+
+func TestLower_IdempotentWhenInputAlreadyPresent(t *testing.T) {
+	src := []byte(`<form method="post" action="?/x">
+  <input type="hidden" name="_csrf_token" value="static">
+  <input name="username">
+</form>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if got.Mutated {
+		t.Fatalf("idempotent splice should leave Mutated=false; got=%q", got.Content)
+	}
+	if c := strings.Count(string(got.Content), `name="_csrf_token"`); c != 1 {
+		t.Fatalf("idempotency violated; got %d hidden inputs in %q", c, got.Content)
+	}
+}
+
+func TestLower_DynamicMethodIsSkipped(t *testing.T) {
+	src := []byte(`<form method={kind} action="?/x">
+  <input name="x">
+</form>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if got.Mutated {
+		t.Fatalf("dynamic method should not match POST; got=%q", got.Content)
+	}
+}
+
+func TestLower_MustacheActionTolerated(t *testing.T) {
+	src := []byte(`<form method="post" action={'?/' + slug}>
+  <input name="x">
+</form>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if !got.Mutated {
+		t.Fatalf("expected splice for POST form with mustache action; got=%q", got.Content)
+	}
+}
+
+func TestLower_RelativeImportsRewrittenToAbsolute(t *testing.T) {
+	src := []byte(`<script>
+  import Foo from './Foo.svelte';
+  import { bar } from "../shared/util";
+  import baz from "$lib/baz";
+</script>
+
+<Foo />
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/routes/login/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	out := string(got.Content)
+	if !strings.Contains(out, `from '/abs/routes/login/Foo.svelte'`) {
+		t.Fatalf("./Foo.svelte not rewritten to absolute; got=%q", out)
+	}
+	if !strings.Contains(out, `from "/abs/routes/shared/util"`) {
+		t.Fatalf("../shared/util not rewritten to absolute; got=%q", out)
+	}
+	if !strings.Contains(out, `from "$lib/baz"`) {
+		t.Fatalf("$lib alias incorrectly rewritten; got=%q", out)
+	}
+}
+
+func TestLower_EmptyInputReturnsCleanResult(t *testing.T) {
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: nil})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	if got.Mutated {
+		t.Fatalf("empty input mutated; got=%q", got.Content)
+	}
+	if len(got.Content) != 0 {
+		t.Fatalf("empty input changed; got=%q", got.Content)
+	}
+}
+
+func TestLower_PreservesSurroundingContent(t *testing.T) {
+	src := []byte(`<h1>before</h1>
+<form method="post" action="?/login">
+  <input name="x">
+</form>
+<p>after</p>
+`)
+	got, err := Lower(LowerOptions{Source: "/abs/_page.svelte", SourceContent: src})
+	if err != nil {
+		t.Fatalf("Lower returned err: %v", err)
+	}
+	out := string(got.Content)
+	if !strings.HasPrefix(out, "<h1>before</h1>\n") {
+		t.Fatalf("prefix lost; got=%q", out)
+	}
+	if !strings.HasSuffix(out, "<p>after</p>\n") {
+		t.Fatalf("suffix lost; got=%q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the wrapper-vs-source vDOM mismatch reported in #540: form actions on `<!-- sveltego:ssr-fallback -->` routes returned **403** in real browsers because Svelte 5 `hydrate()` stripped the SSR-rendered hidden `_csrf_token` input — the user's `_page.svelte` source had no input element, so vDOM disagreed with the DOM that `csrfinject.Rewrite` had spliced.

This PR ships the **narrow bug-fix scope** from #540 (Strategy 3, scope-cut to client-side only — see [comment](https://github.com/binsarjr/sveltego/issues/540#issuecomment-4366754350)). The broad origin-based-CSRF design pivot stays in the issue for a separate RFC.

## What changed

- New `internal/codegen/csrffallback` package: a Svelte-aware text scanner that splices `<input type="hidden" name="_csrf_token" value={globalThis.__sveltego__?.csrfToken ?? ''}>` immediately after every `<form method="post">` open tag in the Svelte source bytes. Mirrors the rules already documented on `runtime/svelte/csrfinject` and `internal/codegen/svelte_js2go/lower_csrf.go`: case-insensitive method, `nocsrf` opt-out, `<script>`/`<style>` skipped, idempotent re-runs. Relative imports in the source's `<script>` are rewritten to absolute fs paths so the lowered file can live outside the user's route directory without breaking module resolution.
- `internal/codegen/build.go` (`emitClientEntry`): for ssr-fallback routes that opt into CSRF, write the lowered source to `.gen/csrf-fallback/<routeKey>/_page.svelte` and redirect the per-route `entry.ts` `import Page from` there. The sidecar continues reading the user's original `_page.svelte` (the post-hoc `csrfinject.Rewrite` keeps SSR HTML correct) — only the client compile sees the lowered file.

## Why this fix works

- **SSR HTML** still carries the real token from `csrfinject.Rewrite` (unchanged). Initial GET-without-JS form submit therefore still works.
- **Client vDOM** now contains the input element with a `value` mustache that resolves against `globalThis.__sveltego__?.csrfToken`. Svelte 5 hydrate sees the input in both DOM and vDOM → no strip.
- `cliententry.ts` seeds `(window as any).__sveltego__ = { ...payload, enhance }` BEFORE calling `hydrate()`, so the client-side mustache evaluates to the same token Svelte 5 reconciles into the live DOM input — value parity post-hydrate.

## No regressions

- Transpile-path SSR routes still get the hidden input via the build-time AST splice in `lower_csrf.go` — that path is untouched.
- SPA / Static routes still rely on `__sveltegoInjectCSRF` post-mount as before.
- Routes without POST forms in their `_page.svelte` skip the lowering entirely (no file emitted).

## Tests

- 12 unit tests in `csrffallback/lower_test.go` cover: post forms, GET forms, `nocsrf` opt-out, scripts/styles skipped, multiple forms, idempotency, dynamic-method skip, mustache action tolerated, relative-import rewrite, empty input, surrounding-content preservation.
- 2 build-level tests in `build_test.go`:
  - `TestBuild_CSRFFallbackLowersClientSource` verifies the lowered file is emitted and the entry imports from `.gen/csrf-fallback/`.
  - `TestBuild_CSRFFallbackSkipsLoweringWithoutPostForm` pins the no-op case.

## Verification

```text
gofumpt -l (changed files)         clean
goimports -l -local github.com/binsarjr/sveltego  clean
go vet ./packages/sveltego/...     clean
go test -race ./packages/sveltego/... 1648 passed in 28 packages
go build ./...                     clean
```

Browser-end Playwright is still absent from CI (same posture as #523/#529); the equivalent contract is enforced statically by the new build-level tests.

## Test plan

- [x] Unit tests for the splicer.
- [x] Build-level tests for the entry redirect.
- [x] Full local gate (gofumpt / goimports / go vet / go test -race / go build).
- [ ] CI green.
- [ ] **Team-lead ack on the scope-cut posted to #540** before merge (per `feedback_scope_cut_ack.md`).

Closes #540 (narrow scope).