### PR TITLE
fix(forms,sidecar): reactive form after enhance + $app/forms shim

### DIFF
--- a/packages/sveltego/internal/codegen/svelterender/sidecar/shims/app-forms.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/shims/app-forms.mjs
@@ -1,0 +1,12 @@
+// Server-side shim for `$app/forms` consumed by the runtime SSR
+// fallback sidecar (`--mode=ssr-serve`). The `enhance` action is a
+// client-only DOM Svelte action; on the server it must exist as an
+// importable symbol but never run. The exported function returns the
+// inert `{ destroy }` shape Svelte's action contract expects so any
+// SSR-safe call site receives a valid handle without touching the DOM.
+
+export function enhance(_form, _callback) {
+	return {
+		destroy() {},
+	};
+}

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/ssr_serve.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/ssr_serve.mjs
@@ -43,6 +43,8 @@ const appShimURLs = {
 	"$app/navigation": pathToFileURL(
 		joinPath(sidecarDir, "shims", "app-navigation.mjs"),
 	).href,
+	"$app/forms": pathToFileURL(joinPath(sidecarDir, "shims", "app-forms.mjs"))
+		.href,
 };
 
 // rewriteAppAliases substitutes `'$app/state'` and `'$app/navigation'`
@@ -55,7 +57,7 @@ const appShimURLs = {
 // silently substituting an unrelated module.
 export function rewriteAppAliases(code) {
 	return code.replace(
-		/(\bfrom\s*|\bimport\s*\(\s*)(['"])(\$app\/(?:state|navigation))\2/g,
+		/(\bfrom\s*|\bimport\s*\(\s*)(['"])(\$app\/(?:state|navigation|forms))\2/g,
 		(_match, prefix, quote, specifier) => {
 			const url = appShimURLs[specifier];
 			return `${prefix}${quote}${url}${quote}`;

--- a/packages/sveltego/internal/codegen/svelterender/sidecar/svelte_loader.mjs
+++ b/packages/sveltego/internal/codegen/svelterender/sidecar/svelte_loader.mjs
@@ -53,11 +53,12 @@ export function initialize(data) {
 	appShimURLs = {
 		"$app/state": pathToFileURL(joinPath(sidecarDir, "shims", "app-state.mjs")).href,
 		"$app/navigation": pathToFileURL(joinPath(sidecarDir, "shims", "app-navigation.mjs")).href,
+		"$app/forms": pathToFileURL(joinPath(sidecarDir, "shims", "app-forms.mjs")).href,
 	};
 }
 
 function resolveAlias(specifier) {
-	if (specifier === "$app/state" || specifier === "$app/navigation") {
+	if (specifier === "$app/state" || specifier === "$app/navigation" || specifier === "$app/forms") {
 		return appShimURLs[specifier];
 	}
 	if (specifier.startsWith("$lib/")) {
@@ -110,7 +111,7 @@ export async function resolve(specifier, context, nextResolve) {
 // any `.svelte` the loader compiles, not just the entry.
 function rewriteImports(code) {
 	return code.replace(
-		/(\bfrom\s*|\bimport\s*\(\s*)(['"])((?:\$app\/(?:state|navigation))|(?:\$lib\/[^'"]+))\2/g,
+		/(\bfrom\s*|\bimport\s*\(\s*)(['"])((?:\$app\/(?:state|navigation|forms))|(?:\$lib\/[^'"]+))\2/g,
 		(_match, prefix, quote, specifier) => {
 			const url = resolveAlias(specifier);
 			if (!url) return _match;

--- a/packages/sveltego/internal/vite/cliententry.go
+++ b/packages/sveltego/internal/vite/cliententry.go
@@ -160,6 +160,26 @@ func GenerateClientEntry(opts ClientEntryOptions) string {
 	b.WriteString("queueMicrotask(__sveltegoInjectCSRF);\n")
 	b.WriteString("afterNavigate(__sveltegoInjectCSRF);\n")
 	b.WriteString("(window as any).__sveltego_csrf__ = __sveltegoInjectCSRF;\n\n")
+	// Wire the enhance flow's reactivity refresh: forms.ts dispatches a
+	// `sveltego:form` window event with the new ActionData on success or
+	// failure. Re-seed pageState.form (so `page.form` from $app/state is
+	// reactive) and, on chained routes, the wrapper-state rune (so the
+	// page's `let { form } = $props()` re-renders when the rune flows
+	// through the wrapper). Without this listener the global
+	// __sveltego__.form updates but the rendered template never re-runs.
+	b.WriteString("addEventListener('sveltego:form', (ev) => {\n")
+	b.WriteString("  const w = (window as any).__sveltego__ ?? {};\n")
+	b.WriteString("  const form = (ev as CustomEvent).detail;\n")
+	b.WriteString("  _setPage({ ...w, form });\n")
+	if useWrapper {
+		b.WriteString("  _setWrapperState({\n")
+		b.WriteString("    Page,\n")
+		b.WriteString("    data: w.data,\n")
+		b.WriteString("    layoutData: w.layoutData ?? [],\n")
+		b.WriteString("    form,\n")
+		b.WriteString("  });\n")
+	}
+	b.WriteString("});\n\n")
 	b.WriteString("(window as any).__sveltego_hydrated = true;\n\n")
 	// Forward the layout chain identifier so the SPA router can swap
 	// page slots in place when a navigation lands on a route that

--- a/packages/sveltego/internal/vite/forms.go
+++ b/packages/sveltego/internal/vite/forms.go
@@ -56,6 +56,14 @@ function defaultApply(result: EnhanceEnvelope, form: HTMLFormElement) {
     case 'success':
     case 'failure':
       w.form = result.data ?? null;
+      // Notify per-route entries so they can re-seed their wrapper-state
+      // rune and pageState.form. cliententry.ts registers a window-level
+      // handler at mount that calls _setWrapperState / _setPage with the
+      // new form value, triggering a Svelte 5 reactive re-render of any
+      // {#if form?.ok} / {form?.error} blocks in the page template.
+      window.dispatchEvent(
+        new CustomEvent('sveltego:form', { detail: result.data ?? null }),
+      );
       break;
     case 'redirect':
       if (result.location) {


### PR DESCRIPTION
## Summary

Two follow-ups to #545 surfaced in browser testing:

### 1. ssr-fallback routes 500 on `$app/forms` import

Node ESM has no Vite alias. The sidecar's `svelte_loader.mjs` already shims `\$app/state` and `\$app/navigation`; this PR adds the parallel `\$app/forms` shim:

- `internal/codegen/svelterender/sidecar/shims/app-forms.mjs` — server-side `enhance` is a noop returning the action contract (`{ destroy(){} }`).
- `svelte_loader.mjs` + `ssr_serve.mjs` register the shim URL and extend the `\$app/(state|navigation)` import-rewrite regex to include `forms`.

Before: `Cannot find package '$app' imported from ...`. After: 200 + sidecar HTML.

### 2. `form` prop didn't reactively update after enhance

`window.__sveltego__.form` was set but the page template's `let { form } = $props()` stayed at its initial value — `{#if form?.ok}` never re-ran. Bridge:

- `forms.ts` `defaultApply` dispatches a `sveltego:form` window CustomEvent with the new ActionData on success/failure.
- `cliententry.go` registers a per-route listener that calls `_setPage({ ...w, form })` (so `\$app/state.page.form` reactively reflects the action) and, on chained routes, `_setWrapperState({ ...current, form })` (so the wrapper's rune slot flows the new value into the page's `\$props()`).

After: success/failure messages render inline, no full reload, `page.form` reactive — matches SvelteKit's enhance UX.

## Test plan

- [x] curl + Playwright headless: GET /login returns 200; submit returns JSON envelope; \`form\` prop and DOM both reflect the new state.
- [x] kitchen-sink \`/login\` rebuild: \`{✓ Welcome, admin}\` renders without nav.
- [x] \`go test -race ./packages/sveltego/internal/vite/\` green.
- [ ] CI green.